### PR TITLE
fix(ch10): remove JSON merge markers from new labs

### DIFF
--- a/chapter-10-architectural-tradeoffs/scenarios/lab7-versioned-capability/scenario.json
+++ b/chapter-10-architectural-tradeoffs/scenarios/lab7-versioned-capability/scenario.json
@@ -6,11 +6,7 @@
       "id": "incident-reporter",
       "capability": "incident.reporting",
       "summary": "Collects field reports and emits incident.reported.",
-<<<<<<< HEAD
       "placements": ["client"],
-=======
-      "placements": ["mobile"],
->>>>>>> origin/main
       "events": {
         "consumes": [],
         "emits": ["incident.reported"]
@@ -24,11 +20,7 @@
       "id": "triage-v1",
       "capability": "incident.triage",
       "summary": "Version 1.0 accepts location and condition and emits incident.triaged.",
-<<<<<<< HEAD
       "placements": ["client", "edge", "cloud"],
-=======
-      "placements": ["mobile", "edge", "cloud"],
->>>>>>> origin/main
       "events": {
         "consumes": ["incident.reported"],
         "emits": ["incident.triaged"]

--- a/chapter-10-architectural-tradeoffs/scenarios/lab8-backward-compatible-extension/scenario.json
+++ b/chapter-10-architectural-tradeoffs/scenarios/lab8-backward-compatible-extension/scenario.json
@@ -6,11 +6,7 @@
       "id": "incident-reporter",
       "capability": "incident.reporting",
       "summary": "Collects field reports and emits incident.reported.",
-<<<<<<< HEAD
       "placements": ["client"],
-=======
-      "placements": ["mobile"],
->>>>>>> origin/main
       "events": {
         "consumes": [],
         "emits": ["incident.reported"]

--- a/chapter-10-architectural-tradeoffs/scenarios/lab9-capability-coexistence/scenario.json
+++ b/chapter-10-architectural-tradeoffs/scenarios/lab9-capability-coexistence/scenario.json
@@ -6,11 +6,7 @@
       "id": "incident-reporter",
       "capability": "incident.reporting",
       "summary": "Collects field reports and emits incident.reported.",
-<<<<<<< HEAD
       "placements": ["client"],
-=======
-      "placements": ["mobile"],
->>>>>>> origin/main
       "events": {
         "consumes": [],
         "emits": ["incident.reported"]
@@ -24,11 +20,7 @@
       "id": "response-management-basic",
       "capability": "response.management",
       "summary": "Records response progress locally so older devices can continue operating in the field.",
-<<<<<<< HEAD
       "placements": ["client", "edge", "cloud"],
-=======
-      "placements": ["mobile", "edge", "cloud"],
->>>>>>> origin/main
       "events": {
         "consumes": ["incident.reported"],
         "emits": ["response.started"]


### PR DESCRIPTION
Removes stray merge markers from the Chapter 10 lab 7-9 scenario JSON files so the smoke gate parses the labs again.

Verification:
- lab7-versioned-capability validates with verdict=coherent
- lab8-backward-compatible-extension validates with verdict=coherent
- lab9-capability-coexistence validates with verdict=coherent
- ./scripts/smoke_arch_labs.sh passes