### PR TITLE
chore: add blog publication link to website

### DIFF
--- a/book-site/index.html
+++ b/book-site/index.html
@@ -619,6 +619,10 @@ Smoke-tested and documented</code></pre>
           <div class="content-section-title">
             <p class="content-section-kicker">UMA BLOG</p>
           </div>
+          <p>
+            Read the full publication on
+            <a class="inline-link" href="https://medium.com/the-rise-of-device-independent-architecture" rel="noreferrer" target="_blank">Medium</a>.
+          </p>
           <div class="labs-grid" id="blog-cards"></div>
         </section>
 


### PR DESCRIPTION
Adds a direct link to the UMA Medium publication from the website blog section so visitors can jump to the full article list.