### PR TITLE
chore: add blog link to website header

### DIFF
--- a/book-site/app.js
+++ b/book-site/app.js
@@ -80,6 +80,7 @@ const mobileMenu = document.querySelector(".mobile-menu");
 const mobileMenuClose = document.querySelector(".mobile-menu-close");
 const sharedFooter = document.querySelector("[data-shared-footer]");
 const faviconHref = new URL("favicon.svg", import.meta.url).href;
+const blogHref = "https://medium.com/the-rise-of-device-independent-architecture";
 
 const siteRoot = new URL(".", import.meta.url);
 const footerColumns = [
@@ -207,6 +208,25 @@ function ensureFavicon() {
   document.head.appendChild(link);
 }
 
+function ensureHeaderBlogLink() {
+  const desktopNav = document.querySelector(".topnav");
+  const mobileNav = document.querySelector(".mobile-menu-nav");
+  const insertLink = (nav) => {
+    if (!nav || nav.querySelector(`a[href="${blogHref}"]`)) return;
+
+    const link = document.createElement("a");
+    link.href = blogHref;
+    link.textContent = "Blog";
+    link.target = "_blank";
+    link.rel = "noreferrer noopener";
+    link.className = "topnav-github";
+    nav.appendChild(link);
+  };
+
+  insertLink(desktopNav);
+  insertLink(mobileNav);
+}
+
 if (chapterCards) {
   for (const chapter of chapters) {
     const article = document.createElement("article");
@@ -324,6 +344,7 @@ if (coverFrame) {
 }
 
 ensureFavicon();
+ensureHeaderBlogLink();
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);

--- a/book-site/index.html
+++ b/book-site/index.html
@@ -48,6 +48,7 @@
           <a href="#contacts">Contacts</a>
           <a class="topnav-github" href="https://www.universalmicroservices.com/reference-application/">Ref App</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a class="topnav-github" href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">Blog</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
@@ -63,6 +64,7 @@
             <a href="#contacts">Contacts</a>
             <a href="https://www.universalmicroservices.com/reference-application/">Ref App</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+            <a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">Blog</a>
           </nav>
         </div>
       </aside>


### PR DESCRIPTION
Adds a direct blog link beside GitHub in the UMA website header and mobile navigation, plus the homepage header markup.