### PR TITLE
Add UMA conversion architecture pages

### DIFF
--- a/book-site/active-descriptors/index.html
+++ b/book-site/active-descriptors/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Active Descriptors in UMA | Universal Microservices Architecture</title>
+    <meta name="description" content="Learn how UMA uses active descriptors as runtime-evaluated constraints for contracts, schemas, latency expectations, compatibility, and execution evidence." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/active-descriptors/" />
+    <meta property="og:title" content="Active Descriptors in UMA" />
+    <meta property="og:description" content="A practical preview of active descriptors in Universal Microservices Architecture and where the book explains the full model." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/active-descriptors/" />
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Active Descriptors in UMA",
+  "description": "A practical preview of active descriptors in Universal Microservices Architecture.",
+  "author": { "@type": "Person", "name": "Enrico Piovesan" },
+  "publisher": { "@type": "Organization", "name": "Universal Microservices Architecture" },
+  "mainEntityOfPage": "https://www.universalmicroservices.com/active-descriptors/"
+}
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>Active descriptors</h1>
+          <p>In UMA, a descriptor is not just documentation beside a service. It is metadata the runtime can evaluate to understand the service boundary, validate inputs and outputs, check compatibility, and record why execution was allowed.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>The useful idea</h2>
+            <p>An active descriptor describes a capability in terms the runtime can use: schemas, emitted events, required inputs, allowed placements, version constraints, and the evidence expected from a run. It is active because it participates in execution decisions.</p>
+            <p>This does not mean the contract replaces service logic. The contract is an executable constraint model around the logic, while the service still owns the durable behavior.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Boundary</h3><p>Input and output schemas define the shape of the portable behavior.</p></article>
+            <article class="subpage-card"><h3>Compatibility</h3><p>Version and event declarations help the runtime decide whether services can interact.</p></article>
+            <article class="subpage-card"><h3>Expectations</h3><p>Latency, error, and evidence expectations make execution easier to inspect.</p></article>
+            <article class="subpage-card"><h3>Authority</h3><p>The runtime evaluates the descriptor before it treats a proposed path as approved.</p></article>
+          </section>
+          <section>
+            <h2>Concrete proof</h2>
+            <p>The early examples prove the idea in small pieces: Chapter 4 uses a contract around deterministic flag evaluation, Chapter 6 uses a contract to compare native and WASI execution, and Chapter 7 lets contracts and events shape orchestration.</p>
+          </section>
+          <section class="subpage-callout">
+            <strong>Covered in the book</strong>
+            <p>This page gives the preview. Chapters 4, 6, and 7 explain how descriptors become practical runtime inputs without turning the website into the full book.</p>
+            <div class="subpage-inline-links">
+              <a href="../examples/chapter-04-feature-flag-evaluator/">Chapter 4 example</a>
+              <a href="../examples/chapter-06-portability-lab/">Chapter 6 example</a>
+              <a href="../examples/chapter-07-metadata-orchestration/">Chapter 7 example</a>
+              <a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/ai-native-runtime-governance/index.html
+++ b/book-site/ai-native-runtime-governance/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI-Native Runtime Governance in UMA | Universal Microservices Architecture</title>
+    <meta name="description" content="Learn how UMA lets AI participate in workflow proposals while the runtime remains authoritative, explainable, and traceable." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/ai-native-runtime-governance/" />
+    <meta property="og:title" content="AI-Native Runtime Governance in UMA" />
+    <meta property="og:description" content="A practical preview of how UMA separates AI proposals from runtime authority." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/ai-native-runtime-governance/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"AI-Native Runtime Governance in UMA","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/ai-native-runtime-governance/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero"><h1>AI-native runtime governance</h1><p>UMA does not make the agent the authority. It lets AI propose, summarize, rank, or assist, while the runtime validates what is allowed and leaves an inspectable trail.</p></section>
+        <div class="subpage-body">
+          <section><h2>The boundary that matters</h2><p>AI-native systems become risky when proposals, validation, execution, and authority collapse into one opaque step. UMA keeps those stages visible: a planner can propose, but runtime policy still decides what can run.</p><p>That is the difference between an AI-assisted workflow and an AI-owned architecture.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>Proposal</h3><p>The agent can suggest a path or choose among candidates.</p></article><article class="subpage-card"><h3>Validation</h3><p>The runtime checks constraints, authority, placement, and capability compatibility.</p></article><article class="subpage-card"><h3>Execution</h3><p>Approved intent resolves into concrete runtime steps.</p></article><article class="subpage-card"><h3>Trace</h3><p>The final result should explain the path, not hide it.</p></article></section>
+          <section><h2>Why this supports book conversion</h2><p>This page gives enough to understand the distinction. The complete argument lives in Chapters 12 and 13, where discoverable decisions and the portable MCP runtime turn the boundary into runnable behavior.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 12 explains the proposal, validation, revision, execution, and trace ladder. Chapter 13 shows AI participation inside the portable MCP runtime.</p><div class="subpage-inline-links"><a href="../agent-vs-runtime/">Agent vs runtime</a><a href="../examples/chapter-12-discoverable-decisions/">Chapter 12 example</a><a href="../examples/chapter-13-portable-mcp-runtime/">Chapter 13 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/app.js
+++ b/book-site/app.js
@@ -90,6 +90,8 @@ const footerColumns = [
       links: [
         ["what problem does uma solve?", "what-problem-does-uma-solve/"],
         ["what is uma", "what-is-uma/"],
+        ["what is a universal microservice?", "what-is-a-universal-microservice/"],
+        ["why universal microservices exist", "why-universal-microservices-exist/"],
         ["from stack ownership to behavior ownership", "from-stack-ownership-to-behavior-ownership/"],
         ["uma vs traditional microservices", "uma-vs-traditional-microservices/"],
       ],
@@ -101,6 +103,8 @@ const footerColumns = [
         ["what is a workflow?", "what-is-a-workflow/"],
         ["what is a uma runtime?", "what-is-a-uma-runtime/"],
         ["what belongs in the runtime layer?", "what-belongs-in-the-runtime-layer/"],
+        ["active descriptors", "active-descriptors/"],
+        ["late-bound policy enforcement", "late-bound-policy-enforcement/"],
         ["what makes a decision discoverable?", "what-makes-a-decision-discoverable/"],
         ["what is wasm mcp?", "what-is-wasm-mcp/"],
         ["agent vs runtime", "agent-vs-runtime/"],
@@ -115,7 +119,11 @@ const footerColumns = [
         ["how to prove portability", "how-to-prove-portability/"],
         ["runtime-agnostic architecture", "runtime-agnostic-architecture/"],
         ["portable business logic", "portable-business-logic/"],
+        ["architecture drift and portable logic", "architecture-drift-and-portable-business-logic/"],
         ["webassembly architecture", "webassembly-architecture/"],
+        ["migrating to uma incrementally", "migrating-to-uma-incrementally/"],
+        ["incremental uma adoption", "incremental-uma-adoption/"],
+        ["uma production readiness", "uma-production-readiness/"],
       ],
     },
     {
@@ -126,6 +134,17 @@ const footerColumns = [
         ["how systems evolve without fragmentation", "how-systems-evolve-without-fragmentation/"],
         ["what makes a system coherent?", "what-makes-a-system-coherent/"],
         ["trust boundaries", "trust-boundaries/"],
+        ["runtime provenance and trust", "runtime-provenance-and-trust/"],
+        ["ai-native runtime governance", "ai-native-runtime-governance/"],
+      ],
+    },
+    {
+      title: "Comparisons and tradeoffs",
+      links: [
+        ["uma vs serverless", "uma-vs-serverless/"],
+        ["uma vs modular monolith", "uma-vs-modular-monolith/"],
+        ["common criticisms and tradeoffs", "common-criticisms-and-tradeoffs-of-uma/"],
+        ["benchmark and footprint", "benchmark-and-footprint/"],
       ],
     },
     {
@@ -133,8 +152,8 @@ const footerColumns = [
       links: [
         ["learning path", "learning-path/"],
         ["examples", "examples/"],
-        ["example tutorials", "examples/chapter-04-feature-flag-evaluator/"],
-        ["benchmark and footprint", "benchmark-and-footprint/"],
+        ["end-to-end feature flag example", "end-to-end-feature-flag-example/"],
+        ["example tutorials", "examples/"],
         ["diagrams", "diagrams/"],
         ["faq", "faq/"],
         ["book", "book/"],

--- a/book-site/architecture-drift-and-portable-business-logic/index.html
+++ b/book-site/architecture-drift-and-portable-business-logic/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Architecture Drift and Portable Business Logic | UMA</title>
+    <meta name="description" content="Learn how UMA reduces architecture drift by keeping business behavior portable, contract-shaped, and governed across browser, edge, backend, and AI-assisted runtime paths." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/" />
+    <meta property="og:title" content="Architecture Drift and Portable Business Logic" />
+    <meta property="og:description" content="A practical preview of how UMA addresses duplicated business behavior and architecture drift." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Architecture Drift and Portable Business Logic","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero"><h1>Architecture drift and portable business logic</h1><p>Architecture drift often begins when the same business behavior is copied into browser code, mobile code, backend code, edge functions, workflow glue, and AI-adjacent automation. UMA attacks that drift by making the durable behavior portable and governed.</p></section>
+        <div class="subpage-body">
+          <section><h2>The problem</h2><p>A duplicated rule can start as a harmless optimization. Over time, each copy adapts to local pressures. The web client handles one edge case, the backend handles another, the edge function adds a shortcut, and nobody can point to one authoritative behavior anymore.</p><p>UMA does not promise magic elimination of drift. It gives teams a model for reducing drift by keeping business behavior behind explicit contracts and visible runtime authority.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>Portable core</h3><p>Keep the durable behavior testable outside one host.</p></article><article class="subpage-card"><h3>Runtime wrapper</h3><p>Let validation, adapters, and policy live around the core.</p></article><article class="subpage-card"><h3>Observable parity</h3><p>Compare behavior from outputs and events, not wishful code similarity.</p></article><article class="subpage-card"><h3>Governed evolution</h3><p>Use contracts and runtime decisions to manage version growth.</p></article></section>
+          <section><h2>The conversion point</h2><p>This is the pressure that makes the book worth reading. The website can name the pattern, but the book walks through how a system moves from one portable behavior to runtime governance, trust, discoverability, and long-term evolution.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapters 4, 6, 10, and 11 show the drift problem from different angles: portable behavior, proof of parity, coherence tradeoffs, and evolution without fragmentation.</p><div class="subpage-inline-links"><a href="../portable-business-logic/">Portable business logic</a><a href="../examples/chapter-04-feature-flag-evaluator/">Chapter 4 example</a><a href="../examples/chapter-10-architectural-tradeoffs/">Chapter 10 example</a><a href="../examples/chapter-11-evolution-without-fragmentation/">Chapter 11 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/examples/chapter-04-feature-flag-evaluator/index.html
+++ b/book-site/examples/chapter-04-feature-flag-evaluator/index.html
@@ -46,8 +46,13 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Feature Flag Evaluator its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Keep the navigation close to the tutorial itself. Use the links below to move between the source folder, the examples index, and the next chapter without hunting through the footer.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-04-feature-flag-evaluator">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-05-post-fetcher-runtime/">Next: Post Fetcher Runtime</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-05-post-fetcher-runtime/index.html
+++ b/book-site/examples/chapter-05-post-fetcher-runtime/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Post Fetcher Runtime its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Use the links below to move through the tutorial sequence without dropping to the footer first.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-05-post-fetcher-runtime">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-04-feature-flag-evaluator/">Previous: Feature Flag Evaluator</a>
+              <a href="../chapter-06-portability-lab/">Next: UMA Portability Lab</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-06-portability-lab/index.html
+++ b/book-site/examples/chapter-06-portability-lab/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives UMA Portability Lab its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Use the links up front so the portability path feels like a guided sequence instead of a footer scavenger hunt.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-06-portability-lab">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-05-post-fetcher-runtime/">Previous: Post Fetcher Runtime</a>
+              <a href="../chapter-07-metadata-orchestration/">Next: Metadata Orchestration</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-07-metadata-orchestration/index.html
+++ b/book-site/examples/chapter-07-metadata-orchestration/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Metadata Orchestration its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Keep the primary navigation alongside the lesson so the contract and policy links are visible before you reach the footer.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-07-metadata-orchestration">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-06-portability-lab/">Previous: Portability Lab</a>
+              <a href="../chapter-08-service-graph/">Next: Service Graph Evolution</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-08-service-graph/index.html
+++ b/book-site/examples/chapter-08-service-graph/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Service Graph Evolution its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Use the in-page route block to move through the graph progression without relying on footer links for the main sequence.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-08-service-graph">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-07-metadata-orchestration/">Previous: Metadata Orchestration</a>
+              <a href="../chapter-09-trust-boundaries/">Next: Trust Boundaries</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-09-trust-boundaries/index.html
+++ b/book-site/examples/chapter-09-trust-boundaries/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Trust Boundaries its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Keep the path visible beside the tutorial so the trust rules, source folder, and neighboring chapters are easy to jump to.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-09-trust-boundaries">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-08-service-graph/">Previous: Service Graph Evolution</a>
+              <a href="../chapter-10-architectural-tradeoffs/">Next: Architectural Tradeoffs</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-10-architectural-tradeoffs/index.html
+++ b/book-site/examples/chapter-10-architectural-tradeoffs/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Architectural Tradeoffs its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Keep the chapter sequence in view so the comparison path stays obvious while you read the tradeoff scenarios.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-10-architectural-tradeoffs">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-09-trust-boundaries/">Previous: Trust Boundaries</a>
+              <a href="../chapter-11-evolution-without-fragmentation/">Next: Evolution Without Fragmentation</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-11-evolution-without-fragmentation/index.html
+++ b/book-site/examples/chapter-11-evolution-without-fragmentation/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Evolution Without Fragmentation its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Use the links here to move between the evolution chapters without burying the learning path in the footer.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-11-evolution-without-fragmentation">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-10-architectural-tradeoffs/">Previous: Architectural Tradeoffs</a>
+              <a href="../chapter-12-discoverable-decisions/">Next: Discoverable Decisions</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-12-discoverable-decisions/index.html
+++ b/book-site/examples/chapter-12-discoverable-decisions/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Discoverable Decisions its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Keep the decision path in front of the reader so the queryable proof is visible while the tutorial is still on screen.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-12-discoverable-decisions">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-11-evolution-without-fragmentation/">Previous: Evolution Without Fragmentation</a>
+              <a href="../chapter-13-portable-mcp-runtime/">Next: Portable MCP Runtime</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/chapter-13-portable-mcp-runtime/index.html
+++ b/book-site/examples/chapter-13-portable-mcp-runtime/index.html
@@ -46,8 +46,14 @@
         </section>
         <div class="subpage-body tutorial-body">
           <section class="subpage-callout">
-            <strong>SEO strategy for this example</strong>
-            <p>This page gives Portable MCP Runtime its own canonical URL, tutorial title, crawlable internal links, and HowTo structured data. That helps search engines index the repository as a set of runnable UMA tutorials instead of a single generic GitHub project.</p>
+            <strong>Tutorial route</strong>
+            <p>Keep the final chapter’s navigation close to the lesson so the source, the examples index, and the previous step remain visible up front.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-13-portable-mcp-runtime">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-12-discoverable-decisions/">Previous: Discoverable Decisions</a>
+              <a href="../../reference-application/">Live reference application</a>
+            </div>
           </section>
           <section>
             <h2>What you will learn</h2>

--- a/book-site/examples/index.html
+++ b/book-site/examples/index.html
@@ -81,6 +81,20 @@
         </section>
 
         <div class="subpage-body">
+          <section class="subpage-callout">
+            <strong>How to navigate the examples</strong>
+            <p>
+              Start with Chapter 4 and move forward in order if you want the cleanest learning path. Each tutorial page keeps the source
+              folder, the examples index, and the sibling chapter links near the top so the navigation is part of the page instead of
+              hidden in the footer.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="chapter-04-feature-flag-evaluator/">Start with Chapter 4</a>
+              <a href="chapter-07-metadata-orchestration/">Jump to orchestration</a>
+              <a href="chapter-12-discoverable-decisions/">See discoverable decisions</a>
+            </div>
+          </section>
+
           <section>
             <h2>Why the examples matter</h2>
             <p>
@@ -143,10 +157,14 @@
           <section>
             <h2>Runnable tutorials for every code example</h2>
             <p>
-              Each chapter example now has a dedicated tutorial page with its own canonical URL, metadata, source link, validation command,
-              and repository-level acceptance check. This gives readers a clean entry point and gives search engines crawlable pages for
-              the concrete problems the repo solves.
+              Each chapter example now has a dedicated tutorial page with its own canonical URL, metadata, source link, validation
+              command, and repository-level acceptance check. The pages are grouped below so the learning path is easier to scan and
+              easier to follow.
             </p>
+          </section>
+
+          <section>
+            <h2>Foundations</h2>
             <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
                 <h3><a href="chapter-04-feature-flag-evaluator/">Chapter 4: Feature Flag Evaluator</a></h3>
@@ -160,6 +178,12 @@
                 <h3><a href="chapter-06-portability-lab/">Chapter 6: Portability Lab</a></h3>
                 <p>Compare native and WASI execution through the same emitted image analysis payload.</p>
               </article>
+            </div>
+          </section>
+
+          <section>
+            <h2>Orchestration and trust</h2>
+            <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
                 <h3><a href="chapter-07-metadata-orchestration/">Chapter 7: Metadata Orchestration</a></h3>
                 <p>Run the contract-driven orchestration flow and inspect binding, policy, schema, and telemetry signals.</p>
@@ -172,6 +196,12 @@
                 <h3><a href="chapter-09-trust-boundaries/">Chapter 9: Trust Boundaries</a></h3>
                 <p>See trust metadata, permissions, dependency provenance, and communication policy produce runtime decisions.</p>
               </article>
+            </div>
+          </section>
+
+          <section>
+            <h2>Evolution and discoverability</h2>
+            <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
                 <h3><a href="chapter-10-architectural-tradeoffs/">Chapter 10: Architectural Tradeoffs</a></h3>
                 <p>Compare coherent and degraded designs using runtime-visible warnings and architectural decision axes.</p>
@@ -189,6 +219,15 @@
                 <p>Build WASI AI capabilities, run the UMA workflow, inspect JSON reports, and smoke the MCP server.</p>
               </article>
             </div>
+          </section>
+
+          <section>
+            <h2>What each tutorial page includes</h2>
+            <p>
+              Every tutorial page now keeps the navigation close to the content: an in-page route block, the validation commands, the
+              source folder link, and the next step in the sequence. That makes the structure easier to scan without sending readers to
+              the footer first.
+            </p>
           </section>
 
           <section>

--- a/book-site/incremental-uma-adoption/index.html
+++ b/book-site/incremental-uma-adoption/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Incremental UMA Adoption | Universal Microservices Architecture</title>
+    <meta name="description" content="Learn how UMA can begin with one portable capability and coexist with legacy systems through adapters, governed boundaries, and gradual runtime adoption." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/incremental-uma-adoption/" />
+    <meta property="og:title" content="Incremental UMA Adoption" />
+    <meta property="og:description" content="A practical preview of adopting UMA without a full rewrite." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/incremental-uma-adoption/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Incremental UMA Adoption","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/incremental-uma-adoption/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero"><h1>Incremental UMA adoption</h1><p>UMA does not require a rewrite. It can start with one portable behavior, one contract, or one runtime-governed boundary inside a system that still has legacy services and ordinary deployment infrastructure.</p></section>
+        <div class="subpage-body">
+          <section><h2>Start with the boundary</h2><p>The practical first step is not replacing your platform. It is finding a duplicated behavior or fragile runtime decision and moving that behavior behind an explicit contract and runtime-evaluated boundary.</p><p>Adapters let existing hosts participate while the portable core stays visible.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>One behavior</h3><p>Choose a rule or normalization path that is repeated across environments.</p></article><article class="subpage-card"><h3>One contract</h3><p>Define what the behavior accepts, returns, emits, and depends on.</p></article><article class="subpage-card"><h3>One runtime wrapper</h3><p>Add validation, adapter binding, and lifecycle evidence around it.</p></article><article class="subpage-card"><h3>One migration path</h3><p>Keep legacy internals where needed while governing the boundary.</p></article></section>
+          <section><h2>Where the book goes further</h2><p>The full adoption story is not only about starting. It is about avoiding fragmentation as more versions, consumers, and runtime surfaces appear. That is why Chapter 11 matters so much.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapters 5 and 6 show the first runtime and portability steps. Chapter 11 explains hybrid adoption without forcing a rewrite.</p><div class="subpage-inline-links"><a href="../examples/chapter-05-post-fetcher-runtime/">Chapter 5 example</a><a href="../examples/chapter-06-portability-lab/">Chapter 6 example</a><a href="../examples/chapter-11-evolution-without-fragmentation/">Chapter 11 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/late-bound-policy-enforcement/index.html
+++ b/book-site/late-bound-policy-enforcement/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Late-Bound Policy Enforcement in UMA | Universal Microservices Architecture</title>
+    <meta name="description" content="A conversion-focused preview of late-bound policy enforcement in UMA: how runtimes apply policy, placement, trust, and compliance rules around portable services." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/late-bound-policy-enforcement/" />
+    <meta property="og:title" content="Late-Bound Policy Enforcement in UMA" />
+    <meta property="og:description" content="How UMA keeps policy close to execution while preserving portable service behavior." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/late-bound-policy-enforcement/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Late-Bound Policy Enforcement in UMA","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/late-bound-policy-enforcement/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero"><h1>Late-bound policy enforcement</h1><p>UMA treats policy as something evaluated near execution, not as a static diagram note. The runtime can apply placement, trust, compliance, and fail-fast rules without rewriting the portable service.</p></section>
+        <div class="subpage-body">
+          <section><h2>Why late-bound policy matters</h2><p>Distributed systems often hardwire policy into deployment scripts, gateway configuration, or application code. That makes the policy hard to audit and hard to move with the behavior it governs.</p><p>UMA keeps the portable behavior separate while letting runtime authority decide whether a specific execution path is allowed under current conditions.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>Local decision</h3><p>The runtime evaluates the metadata it has, instead of relying on hidden centralized coordination for every choice.</p></article><article class="subpage-card"><h3>Fail fast</h3><p>Invalid or disallowed runs should stop before adapter execution and side effects begin.</p></article><article class="subpage-card"><h3>Policy evidence</h3><p>The run should show which policy shaped the outcome.</p></article><article class="subpage-card"><h3>Portable core</h3><p>The service logic remains stable while execution conditions change around it.</p></article></section>
+          <section><h2>What this page does not replace</h2><p>The full book goes deeper into how validation, adapter binding, policy, and lifecycle evidence fit together. This page is the orientation layer: it tells you why the idea matters and where to inspect it in code.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 5 introduces the runtime layer, Chapter 7 applies policy in orchestration, and Chapter 9 turns trust into explicit enforcement.</p><div class="subpage-inline-links"><a href="../examples/chapter-05-post-fetcher-runtime/">Chapter 5 example</a><a href="../examples/chapter-07-metadata-orchestration/">Chapter 7 example</a><a href="../examples/chapter-09-trust-boundaries/">Chapter 9 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/robots.txt
+++ b/book-site/robots.txt
@@ -1,4 +1,12 @@
 User-agent: *
 Allow: /
+Allow: /active-descriptors/
+Allow: /late-bound-policy-enforcement/
+Allow: /runtime-provenance-and-trust/
+Allow: /ai-native-runtime-governance/
+Allow: /incremental-uma-adoption/
+Allow: /architecture-drift-and-portable-business-logic/
+Allow: /examples/
+Allow: /assets/
 
 Sitemap: https://www.universalmicroservices.com/sitemap.xml

--- a/book-site/runtime-provenance-and-trust/index.html
+++ b/book-site/runtime-provenance-and-trust/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Runtime Provenance and Trust in UMA | Universal Microservices Architecture</title>
+    <meta name="description" content="Learn how UMA makes provenance, permissions, dependencies, and trust boundaries explicit in runtime decisions instead of hiding them in perimeter infrastructure." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/runtime-provenance-and-trust/" />
+    <meta property="og:title" content="Runtime Provenance and Trust in UMA" />
+    <meta property="og:description" content="A practical preview of UMA trust boundaries and provenance-aware runtime enforcement." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/runtime-provenance-and-trust/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Runtime Provenance and Trust in UMA","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/runtime-provenance-and-trust/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero"><h1>Runtime provenance and trust</h1><p>Portable behavior does not automatically become trusted behavior. UMA makes publisher identity, declared permissions, dependency provenance, placement, and communication rules visible to the runtime.</p></section>
+        <div class="subpage-body">
+          <section><h2>The architectural shift</h2><p>Traditional systems often inherit trust from location: inside the network, inside the cluster, inside the gateway. UMA asks a different question: what does this module declare, who published it, what does it depend on, and what is it allowed to communicate with?</p><p>That makes trust part of the system model instead of a perimeter assumption.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>Publisher</h3><p>Who produced the service matters to runtime approval.</p></article><article class="subpage-card"><h3>Permissions</h3><p>Requested capability access must match declared permissions.</p></article><article class="subpage-card"><h3>Dependencies</h3><p>Provenance and checksums can affect whether a service is trusted.</p></article><article class="subpage-card"><h3>Communication</h3><p>Event compatibility is not enough if trust policy rejects the path.</p></article></section>
+          <section><h2>What readers should inspect</h2><p>The Chapter 9 example is the proof layer: trusted services are allowed, undeclared permissions are denied, untrusted dependencies fail, forbidden communication is blocked, and restored compliance brings the system back to allow.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 9 expands this into a full trust-boundary sequence. The site gives the map; the book explains why this model changes how portable systems should be governed.</p><div class="subpage-inline-links"><a href="../trust-boundaries/">Trust boundaries</a><a href="../examples/chapter-09-trust-boundaries/">Chapter 9 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/sitemap.xml
+++ b/book-site/sitemap.xml
@@ -4,22 +4,37 @@
     <loc>https://www.universalmicroservices.com/</loc>
   </url>
   <url>
+    <loc>https://www.universalmicroservices.com/about-enrico/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/active-descriptors/</loc>
+  </url>
+  <url>
     <loc>https://www.universalmicroservices.com/agent-vs-runtime/</loc>
   </url>
   <url>
-    <loc>https://www.universalmicroservices.com/about-enrico/</loc>
+    <loc>https://www.universalmicroservices.com/ai-native-runtime-governance/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/benchmark-and-footprint/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/book/</loc>
   </url>
   <url>
-    <loc>https://www.universalmicroservices.com/benchmark-and-footprint/</loc>
+    <loc>https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/contract-driven-orchestration/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/diagrams/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/end-to-end-feature-flag-example/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/examples/</loc>
@@ -61,22 +76,31 @@
     <loc>https://www.universalmicroservices.com/from-stack-ownership-to-behavior-ownership/</loc>
   </url>
   <url>
+    <loc>https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/</loc>
+  </url>
+  <url>
     <loc>https://www.universalmicroservices.com/how-to-prove-portability/</loc>
   </url>
   <url>
-    <loc>https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/</loc>
+    <loc>https://www.universalmicroservices.com/incremental-uma-adoption/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/late-bound-policy-enforcement/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/learning-path/</loc>
   </url>
   <url>
+    <loc>https://www.universalmicroservices.com/migrating-to-uma-incrementally/</loc>
+  </url>
+  <url>
     <loc>https://www.universalmicroservices.com/portable-business-logic/</loc>
   </url>
   <url>
-    <loc>https://www.universalmicroservices.com/reference-application/</loc>
+    <loc>https://www.universalmicroservices.com/runtime-agnostic-architecture/</loc>
   </url>
   <url>
-    <loc>https://www.universalmicroservices.com/runtime-agnostic-architecture/</loc>
+    <loc>https://www.universalmicroservices.com/runtime-provenance-and-trust/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/service-graph-evolution/</loc>
@@ -85,19 +109,43 @@
     <loc>https://www.universalmicroservices.com/trust-boundaries/</loc>
   </url>
   <url>
+    <loc>https://www.universalmicroservices.com/uma-production-readiness/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/uma-vs-modular-monolith/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/uma-vs-serverless/</loc>
+  </url>
+  <url>
     <loc>https://www.universalmicroservices.com/uma-vs-traditional-microservices/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/webassembly-architecture/</loc>
   </url>
   <url>
-    <loc>https://www.universalmicroservices.com/what-is-uma/</loc>
-  </url>
-  <url>
-    <loc>https://www.universalmicroservices.com/what-problem-does-uma-solve/</loc>
+    <loc>https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/what-is-a-capability/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/what-is-a-uma-runtime/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/what-is-a-universal-microservice/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/what-is-a-workflow/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/what-is-uma/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/what-is-wasm-mcp/</loc>
+  </url>
+  <url>
+    <loc>https://www.universalmicroservices.com/what-makes-a-decision-discoverable/</loc>
   </url>
   <url>
     <loc>https://www.universalmicroservices.com/what-makes-a-service-portable/</loc>
@@ -106,18 +154,9 @@
     <loc>https://www.universalmicroservices.com/what-makes-a-system-coherent/</loc>
   </url>
   <url>
-    <loc>https://www.universalmicroservices.com/what-makes-a-decision-discoverable/</loc>
+    <loc>https://www.universalmicroservices.com/what-problem-does-uma-solve/</loc>
   </url>
   <url>
-    <loc>https://www.universalmicroservices.com/what-is-a-workflow/</loc>
-  </url>
-  <url>
-    <loc>https://www.universalmicroservices.com/what-is-a-uma-runtime/</loc>
-  </url>
-  <url>
-    <loc>https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/</loc>
-  </url>
-  <url>
-    <loc>https://www.universalmicroservices.com/what-is-wasm-mcp/</loc>
+    <loc>https://www.universalmicroservices.com/why-universal-microservices-exist/</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add conversion-oriented UMA architecture pages for active descriptors, policy enforcement, provenance, AI runtime governance, migration, and architecture drift
- link the new pages from the shared footer and expose them in sitemap/robots for search indexing
- improve example tutorial navigation so code-example pages point readers through the implementation path

## Validation
- ./scripts/smoke_reader_paths.sh