### PR TITLE
Add remaining UMA SEO landing pages

### DIFF
--- a/book-site/common-criticisms-and-tradeoffs-of-uma/index.html
+++ b/book-site/common-criticisms-and-tradeoffs-of-uma/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Common Criticisms and Tradeoffs of UMA | Universal Microservices Architecture</title>
+    <meta name="description" content="A credible look at UMA tradeoffs, including learning curve, runtime complexity, governance needs, and organizational readiness." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/" />
+    <meta property="og:title" content="Common Criticisms and Tradeoffs of UMA | Universal Microservices Architecture" />
+    <meta property="og:description" content="A practical discussion of UMA criticisms and tradeoffs for teams evaluating the model." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Common criticisms and tradeoffs of UMA","description":"A credible look at UMA tradeoffs, including learning curve, runtime complexity, governance needs, and organizational readiness.","url":"https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>Common criticisms and tradeoffs of UMA</h1>
+          <p>UMA is not a free upgrade to every architecture. It introduces a stronger model for portable behavior, but that model brings learning curve, runtime design work, governance responsibility, and organizational questions. Those tradeoffs are real and should be evaluated directly.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>The learning curve is real</h2>
+            <p>UMA asks teams to separate behavior, contract, runtime, adapter, trust, and workflow concerns more deliberately than many stack-first systems do. That can feel heavier at first.</p>
+            <p>The tradeoff is clarity. A team pays some design cost upfront to reduce hidden duplication later.</p>
+          </section>
+
+          <section>
+            <h2>Runtime complexity does not disappear</h2>
+            <p>A portable service still needs a runtime. Validation, transport, placement, events, observability, and policy all have to live somewhere.</p>
+            <p>UMA does not remove runtime complexity. It makes that complexity explicit so teams can reason about it.</p>
+          </section>
+
+          <section>
+            <h2>Governance becomes part of the architecture</h2>
+            <p>Portability without governance can make risk travel faster. A service that runs in more contexts needs clearer trust boundaries, versioning, and authority checks.</p>
+            <p>This is one reason the book treats governance as core methodology rather than as a late production appendix.</p>
+          </section>
+
+          <section>
+            <h2>Organizational readiness matters</h2>
+            <p>UMA works best when teams can agree on capability ownership and runtime responsibility. If every team optimizes only for its local stack, the model will be hard to sustain.</p>
+            <p>That does not mean the organization must transform all at once. It means adoption should begin where the ownership problem is visible.</p>
+          </section>
+
+          <section>
+            <h2>When UMA may be too much</h2>
+            <p>If a service has one stable deployment surface, little duplicated behavior, and no meaningful runtime diversity, UMA may not repay the design cost. The point is to apply it where portability and governance are actually needed.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Criticism</h3><p>It can feel more complex than a local service implementation.</p></article>
+            <article class="subpage-card"><h3>Response</h3><p>The complexity already exists when behavior crosses runtimes. UMA makes it visible.</p></article>
+            <article class="subpage-card"><h3>Criticism</h3><p>It requires governance discipline.</p></article>
+            <article class="subpage-card"><h3>Response</h3><p>That discipline is necessary when portable behavior becomes operationally important.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page is intentionally candid. The book expands the tradeoff analysis into decision criteria, governance patterns, and implementation guidance. The repository includes examples that expose both coherent and degraded designs.</p>
+            <div class="subpage-inline-links">
+              <a href="../uma-vs-traditional-microservices/">UMA vs traditional microservices</a>
+              <a href="../what-makes-a-system-coherent/">What makes a system coherent?</a>
+              <a href="../trust-boundaries/">Trust boundaries</a>
+              <a href="../examples/chapter-10-architectural-tradeoffs/">Architectural tradeoffs example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/end-to-end-feature-flag-example/index.html
+++ b/book-site/end-to-end-feature-flag-example/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>End-to-End UMA Example: Feature Flag Service | Universal Microservices Architecture</title>
+    <meta name="description" content="Follow an end-to-end UMA feature flag service from requirement to capability, contract, build, browser execution, cloud execution, and AI-assisted execution." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/end-to-end-feature-flag-example/" />
+    <meta property="og:title" content="End-to-End UMA Example: Feature Flag Service | Universal Microservices Architecture" />
+    <meta property="og:description" content="A complete conceptual walkthrough of a UMA feature flag service from requirement to runtime execution." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/end-to-end-feature-flag-example/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"End-to-end UMA example: feature flag service","description":"Follow an end-to-end UMA feature flag service from requirement to capability, contract, build, browser execution, cloud execution, and AI-assisted execution.","url":"https://www.universalmicroservices.com/end-to-end-feature-flag-example/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/end-to-end-feature-flag-example/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>End-to-end UMA example: feature flag service</h1>
+          <p>A feature flag service is a useful end-to-end UMA example because the business behavior is small, testable, and easy to duplicate badly. The same decision often appears in frontend checks, backend authority, edge routing, and workflow logic. UMA turns that repeated rule into one governed capability.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>1. Requirement</h2>
+            <p>The product needs to decide whether a feature is enabled for a user. The decision may depend on country, account, rollout percentage, or a fallback rule. The important part is that every runtime should agree on the same outcome.</p>
+          </section>
+
+          <section>
+            <h2>2. Capability</h2>
+            <p>The capability is feature flag evaluation. It is narrow enough to test and important enough to keep coherent. That makes it a good first Universal Microservice candidate.</p>
+          </section>
+
+          <section>
+            <h2>3. Contract</h2>
+            <p>The contract defines the input context, flag rules, and decision output. A reader should be able to inspect the contract without needing to understand a specific UI framework or cloud provider.</p>
+            <p>The contract is where the service becomes understandable before it becomes deployable.</p>
+          </section>
+
+          <section>
+            <h2>4. Build</h2>
+            <p>The portable core implements deterministic evaluation. In the repository, the Rust-first path is the authoritative implementation, with TypeScript parity where present to make comparison visible.</p>
+          </section>
+
+          <section>
+            <h2>5. Browser execution</h2>
+            <p>A browser can use the capability when low-latency local decisions are appropriate. The runtime still has to decide which data is safe and which decisions require backend authority.</p>
+          </section>
+
+          <section>
+            <h2>6. Cloud execution</h2>
+            <p>Cloud execution can provide authority, auditability, and integration with backend systems. UMA does not force the choice. It makes the runtime decision explicit.</p>
+          </section>
+
+          <section>
+            <h2>7. AI-assisted execution</h2>
+            <p>An AI-assisted flow may propose a flag change, request an evaluation, or summarize rollout behavior. The runtime remains authoritative over validation and execution. The agent participates, but it does not become the system of record.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Website</h3><p>Conceptual walkthrough of the end-to-end model.</p></article>
+            <article class="subpage-card"><h3>GitHub</h3><p>Runnable examples and validation scripts.</p></article>
+            <article class="subpage-card"><h3>Book</h3><p>Methodology, tradeoffs, governance, and production guidance.</p></article>
+            <article class="subpage-card"><h3>Runtime</h3><p>The authority that decides where execution belongs.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This walkthrough tells the complete story at a high level. The Chapter 4 example lets you run the evaluator, and the book connects the same pattern to contracts, runtime governance, and later production concerns.</p>
+            <div class="subpage-inline-links">
+              <a href="../examples/chapter-04-feature-flag-evaluator/">Feature flag tutorial</a>
+              <a href="../what-is-a-universal-microservice/">What is a Universal Microservice?</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/migrating-to-uma-incrementally/index.html
+++ b/book-site/migrating-to-uma-incrementally/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Migrating to UMA Incrementally | Universal Microservices Migration</title>
+    <meta name="description" content="A practical conceptual guide to incremental UMA migration for greenfield and brownfield systems without requiring a full rewrite." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/migrating-to-uma-incrementally/" />
+    <meta property="og:title" content="Migrating to UMA Incrementally | Universal Microservices Migration" />
+    <meta property="og:description" content="How to adopt UMA incrementally through capability extraction, strangler paths, and runtime-governed rollout." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/migrating-to-uma-incrementally/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Migrating to UMA incrementally","description":"A practical conceptual guide to incremental UMA migration for greenfield and brownfield systems without requiring a full rewrite.","url":"https://www.universalmicroservices.com/migrating-to-uma-incrementally/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/migrating-to-uma-incrementally/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>Migrating to UMA incrementally</h1>
+          <p>UMA does not require a full-platform rewrite. A practical migration begins with one behavior that is duplicated, hard to govern, or forced to run in more than one place. From there, the team extracts a capability, defines its contract, proves portability, and expands only when the result is useful.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>Start with one capability</h2>
+            <p>The best first candidate is a rule or decision that already appears in multiple places. Feature flags, eligibility checks, routing decisions, and policy evaluations are common starting points.</p>
+            <p>The goal is not to universalize everything. The goal is to find one behavior where portability reduces drift.</p>
+          </section>
+
+          <section>
+            <h2>Greenfield adoption</h2>
+            <p>In a greenfield system, UMA can start as a design discipline. Define the capability, contract, runtime expectations, and validation path before choosing all host-specific details.</p>
+            <p>That keeps the first service small enough to understand while still teaching the team the model.</p>
+          </section>
+
+          <section>
+            <h2>Brownfield adoption</h2>
+            <p>In an existing system, begin beside the current implementation. Keep the old path alive, extract the behavior into a portable service, and compare outputs before moving traffic or workflow authority.</p>
+            <p>This makes migration observable rather than ideological.</p>
+          </section>
+
+          <section>
+            <h2>Use a strangler path</h2>
+            <p>A strangler path works well when one capability can be routed gradually to the UMA implementation. The surrounding system keeps operating while the runtime earns authority through tests, telemetry, and controlled rollout.</p>
+            <p>This approach also helps teams avoid creating a second architecture that nobody trusts.</p>
+          </section>
+
+          <section>
+            <h2>Incremental rollout</h2>
+            <p>Roll out by capability, not by layer. A team can adopt one portable service, one runtime wrapper, one validation flow, and one chapter-aligned proof point before expanding the approach to other parts of the system.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Find drift</h3><p>Look for behavior copied across client, edge, backend, and workflow paths.</p></article>
+            <article class="subpage-card"><h3>Extract capability</h3><p>Name the durable behavior before choosing the new runtime shape.</p></article>
+            <article class="subpage-card"><h3>Prove parity</h3><p>Compare outputs across the old path and the portable implementation.</p></article>
+            <article class="subpage-card"><h3>Expand carefully</h3><p>Move the next behavior only after the runtime path is understandable and governed.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page keeps migration at a conceptual level. The migration material in the book goes deeper into sequencing, risk, governance, and production patterns. The repository gives concrete labs for proving one step at a time.</p>
+            <div class="subpage-inline-links">
+              <a href="../how-to-prove-portability/">How to prove portability</a>
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../trust-boundaries/">Trust boundaries</a>
+              <a href="../examples/chapter-06-portability-lab/">Portability lab example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/robots.txt
+++ b/book-site/robots.txt
@@ -6,6 +6,14 @@ Allow: /runtime-provenance-and-trust/
 Allow: /ai-native-runtime-governance/
 Allow: /incremental-uma-adoption/
 Allow: /architecture-drift-and-portable-business-logic/
+Allow: /what-is-a-universal-microservice/
+Allow: /why-universal-microservices-exist/
+Allow: /migrating-to-uma-incrementally/
+Allow: /uma-production-readiness/
+Allow: /uma-vs-serverless/
+Allow: /uma-vs-modular-monolith/
+Allow: /common-criticisms-and-tradeoffs-of-uma/
+Allow: /end-to-end-feature-flag-example/
 Allow: /examples/
 Allow: /assets/
 

--- a/book-site/uma-production-readiness/index.html
+++ b/book-site/uma-production-readiness/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UMA Production Readiness | Universal Microservices Architecture</title>
+    <meta name="description" content="Understand what production readiness means in UMA across security, versioning, governance, observability, deployment, and runtime authority." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/uma-production-readiness/" />
+    <meta property="og:title" content="UMA Production Readiness | Universal Microservices Architecture" />
+    <meta property="og:description" content="A conceptual production readiness checklist for Universal Microservices Architecture." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/uma-production-readiness/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"UMA production readiness","description":"Understand what production readiness means in UMA across security, versioning, governance, observability, deployment, and runtime authority.","url":"https://www.universalmicroservices.com/uma-production-readiness/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/uma-production-readiness/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>UMA production readiness</h1>
+          <p>Production readiness in UMA is not just the question of whether portable code can run. The stronger question is whether the runtime can govern that code under real trust, versioning, observability, and deployment constraints.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>Security and trust</h2>
+            <p>A portable service can create new security pressure because the same behavior may run in different contexts. UMA treats trust boundaries, permissions, provenance, and authority as part of the runtime model.</p>
+            <p>The runtime must know what is allowed before it executes.</p>
+          </section>
+
+          <section>
+            <h2>Versioning and compatibility</h2>
+            <p>A production UMA system needs clear contracts, compatibility checks, and versioned evolution. Without that discipline, portability can turn into version sprawl.</p>
+            <p>The service graph should make change visible rather than leaving teams to discover drift through incidents.</p>
+          </section>
+
+          <section>
+            <h2>Governance</h2>
+            <p>Governance means deciding who can expose a capability, who can call it, what evidence is required, and which runtime path is authoritative. UMA makes those questions architecture questions, not only operations questions.</p>
+            <p>This is especially important when AI-assisted workflows participate in discovery or proposal.</p>
+          </section>
+
+          <section>
+            <h2>Observability</h2>
+            <p>Observability should show more than whether a process is alive. A UMA runtime should expose capability selection, validation decisions, approvals, rejections, execution paths, and relevant traces.</p>
+            <p>That evidence is what makes runtime decisions explainable.</p>
+          </section>
+
+          <section>
+            <h2>Deployment</h2>
+            <p>Deployment readiness depends on the hosts involved. Browser, edge, cloud, WASI, and workflow execution each introduce different constraints. UMA does not erase those differences. It gives teams a model for deciding where a capability should run and why.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Security</h3><p>Trust, permissions, and provenance must travel with the runtime decision.</p></article>
+            <article class="subpage-card"><h3>Versioning</h3><p>Contracts and compatibility need to be visible as the system evolves.</p></article>
+            <article class="subpage-card"><h3>Governance</h3><p>Capability exposure and execution authority need explicit ownership.</p></article>
+            <article class="subpage-card"><h3>Observability</h3><p>The runtime should explain decisions, not only report activity.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page answers the production question at a conceptual level. The book goes further into governance, deployment patterns, runtime controls, and implementation guidance. The repository shows the proof artifacts that make those discussions concrete.</p>
+            <div class="subpage-inline-links">
+              <a href="../trust-boundaries/">Trust boundaries</a>
+              <a href="../what-makes-a-system-coherent/">What makes a system coherent?</a>
+              <a href="../what-makes-a-decision-discoverable/">What makes a decision discoverable?</a>
+              <a href="../examples/chapter-09-trust-boundaries/">Trust boundaries example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/uma-vs-modular-monolith/index.html
+++ b/book-site/uma-vs-modular-monolith/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UMA vs Modular Monolith | Universal Microservices Architecture</title>
+    <meta name="description" content="Compare UMA and modular monoliths across modularity, deployment boundaries, runtime boundaries, and system evolution paths." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/uma-vs-modular-monolith/" />
+    <meta property="og:title" content="UMA vs Modular Monolith | Universal Microservices Architecture" />
+    <meta property="og:description" content="A practical comparison of UMA and modular monolith architecture." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/uma-vs-modular-monolith/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"UMA vs modular monolith","description":"Compare UMA and modular monoliths across modularity, deployment boundaries, runtime boundaries, and system evolution paths.","url":"https://www.universalmicroservices.com/uma-vs-modular-monolith/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/uma-vs-modular-monolith/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>UMA vs modular monolith</h1>
+          <p>A modular monolith can be a strong architecture when one deployment unit is acceptable and internal boundaries are clear. UMA addresses a different pressure: how to preserve one behavior when execution needs to cross runtime boundaries.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>A modular monolith organizes code inside one deployable system. UMA organizes portable behavior so it can remain coherent across multiple execution contexts.</p>
+            <p>The two ideas can coexist. A modular monolith may host UMA-style capabilities, and UMA can help identify which behaviors should leave the monolith first.</p>
+          </section>
+
+          <section>
+            <h2>Modularity</h2>
+            <p>Modular monoliths improve internal structure by making module boundaries explicit. That is valuable. UMA adds a stronger question about whether a behavior can survive outside the original host without being rewritten.</p>
+            <p>Internal modularity is not the same as runtime portability.</p>
+          </section>
+
+          <section>
+            <h2>Deployment boundaries</h2>
+            <p>The modular monolith usually keeps deployment simple by shipping one unit. UMA accepts that some behavior may need to execute in different places and makes the surrounding runtime decisions explicit.</p>
+            <p>This is not a claim that distributed deployment is always better. It is a claim that runtime diversity needs a model when it appears.</p>
+          </section>
+
+          <section>
+            <h2>Runtime boundaries</h2>
+            <p>A module inside a monolith often assumes the host process, shared memory, local libraries, and a common framework. A Universal Microservice has to make more of its boundary explicit so the behavior can be governed elsewhere.</p>
+            <p>That extra discipline is useful only when the behavior needs that freedom.</p>
+          </section>
+
+          <section>
+            <h2>Evolution paths</h2>
+            <p>A modular monolith can evolve into services when pressure justifies it. UMA gives teams a way to extract behavior by capability and prove that the extracted unit remains coherent before wider rollout.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Modular monolith</h3><p>Best when deployment simplicity and internal modularity solve the main problem.</p></article>
+            <article class="subpage-card"><h3>UMA</h3><p>Best when behavior must cross browser, edge, cloud, workflow, or AI-assisted paths.</p></article>
+            <article class="subpage-card"><h3>Shared strength</h3><p>Both models value explicit boundaries over accidental coupling.</p></article>
+            <article class="subpage-card"><h3>Key difference</h3><p>UMA treats runtime movement as a first-class architectural concern.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page compares the architectural lenses. The book expands the decision model for when to keep behavior inside one system and when to extract it into a portable capability.</p>
+            <div class="subpage-inline-links">
+              <a href="../from-stack-ownership-to-behavior-ownership/">From stack ownership to behavior ownership</a>
+              <a href="../what-is-a-universal-microservice/">What is a Universal Microservice?</a>
+              <a href="../service-graph-evolution/">Service graph evolution</a>
+              <a href="../examples/chapter-08-service-graph/">Service graph example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/uma-vs-serverless/index.html
+++ b/book-site/uma-vs-serverless/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UMA vs Serverless | Universal Microservices Architecture</title>
+    <meta name="description" content="Compare UMA and serverless across runtime model, deployment model, portability, governance, and cost considerations." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/uma-vs-serverless/" />
+    <meta property="og:title" content="UMA vs Serverless | Universal Microservices Architecture" />
+    <meta property="og:description" content="A clear comparison of Universal Microservices Architecture and serverless architecture." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/uma-vs-serverless/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"UMA vs serverless","description":"Compare UMA and serverless across runtime model, deployment model, portability, governance, and cost considerations.","url":"https://www.universalmicroservices.com/uma-vs-serverless/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/uma-vs-serverless/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>UMA vs serverless</h1>
+          <p>UMA and serverless solve different problems. Serverless is primarily a deployment and operations model. UMA is an architectural model for keeping behavior portable, governed, and coherent as execution crosses runtime boundaries.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>Serverless asks who manages the servers and how functions are invoked. UMA asks how one business capability keeps its meaning when it can execute across browser, edge, cloud, workflow, and AI-assisted paths.</p>
+            <p>A UMA service could run through a serverless platform, but serverless alone does not define the portable service boundary.</p>
+          </section>
+
+          <section>
+            <h2>Runtime model</h2>
+            <p>Serverless runtimes are provider-shaped. They define invocation, scaling, permissions, event bindings, and operational constraints. UMA treats runtime concerns as explicit architecture, but does not assume one provider runtime is the durable model.</p>
+            <p>The runtime in UMA governs where and how a portable capability executes.</p>
+          </section>
+
+          <section>
+            <h2>Deployment model</h2>
+            <p>Serverless focuses on deploying small units without managing servers. UMA focuses on preserving business behavior across deployment shapes. The deployment target is important, but it is not the center of the model.</p>
+            <p>That distinction matters when the same behavior must live in more than one environment.</p>
+          </section>
+
+          <section>
+            <h2>Portability</h2>
+            <p>A serverless function may be easy to deploy but still deeply tied to provider APIs, event models, and operational assumptions. A UMA service is designed so the core behavior can remain stable while adapters and runtimes vary.</p>
+            <p>Portability is not automatic. It has to be designed and proven.</p>
+          </section>
+
+          <section>
+            <h2>Cost considerations</h2>
+            <p>Serverless can reduce operational burden and align cost to usage, but provider-specific coupling and cold-start behavior can influence architecture. UMA does not prescribe a cost model. It helps teams make runtime placement decisions explicit so cost is one visible input among others.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Serverless</h3><p>A deployment and operations model for running code without managing servers.</p></article>
+            <article class="subpage-card"><h3>UMA</h3><p>An architectural model for portable behavior and governed runtime decisions.</p></article>
+            <article class="subpage-card"><h3>Serverless risk</h3><p>Provider-specific events and APIs can become hidden architecture.</p></article>
+            <article class="subpage-card"><h3>UMA risk</h3><p>The runtime and governance model must be designed deliberately.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This comparison stays at the concept level. The book goes deeper into runtime placement, operational tradeoffs, and production patterns, while the repository lets you inspect how portable services are validated outside one platform assumption.</p>
+            <div class="subpage-inline-links">
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../what-belongs-in-the-runtime-layer/">What belongs in the runtime layer?</a>
+              <a href="../how-to-prove-portability/">How to prove portability</a>
+              <a href="../examples/chapter-05-post-fetcher-runtime/">Post fetcher runtime example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/what-is-a-universal-microservice/index.html
+++ b/book-site/what-is-a-universal-microservice/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>What Is a Universal Microservice? | Universal Microservices Architecture</title>
+    <meta name="description" content="Define a Universal Microservice, what makes it portable, how its lifecycle works, and how it differs from a traditional service." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/what-is-a-universal-microservice/" />
+    <meta property="og:title" content="What Is a Universal Microservice? | Universal Microservices Architecture" />
+    <meta property="og:description" content="A clear definition of a Universal Microservice and the portable service boundary at the center of UMA." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/what-is-a-universal-microservice/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What is a Universal Microservice?","description":"Define a Universal Microservice, what makes it portable, how its lifecycle works, and how it differs from a traditional service.","url":"https://www.universalmicroservices.com/what-is-a-universal-microservice/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/what-is-a-universal-microservice/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>What is a Universal Microservice?</h1>
+          <p>A Universal Microservice is a small unit of business behavior that can remain recognizable across runtime contexts. It is not just a service that has been packaged differently. It is a capability with an explicit contract, portable core logic, and a runtime boundary that makes validation, placement, trust, and execution visible.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>The short definition</h2>
+            <p>A Universal Microservice is the primary object in UMA. It owns a specific behavior, exposes a clear contract, and can be executed through more than one runtime path without changing what the behavior means.</p>
+            <p>The portable summary is write once, run where it makes sense. That matters because the runtime may change while the service meaning should not.</p>
+          </section>
+
+          <section>
+            <h2>Properties that define it</h2>
+            <p>A Universal Microservice has a narrow responsibility, deterministic inputs and outputs where possible, explicit capability expectations, and a boundary that does not depend on one host framework. It can be wrapped by different adapters, but the adapters do not become the service.</p>
+            <p>The core question is simple: can the behavior be understood, tested, and governed without assuming one permanent deployment surface?</p>
+          </section>
+
+          <section>
+            <h2>How it differs from a traditional service</h2>
+            <p>A traditional microservice is usually defined by deployment, ownership, and network boundaries. A Universal Microservice is defined first by portable behavior and then by the runtime decisions that surround it.</p>
+            <p>This does not make conventional services obsolete. It makes the durable behavioral unit more explicit when the same capability needs to appear in browser, edge, cloud, workflow, or AI-assisted execution paths.</p>
+          </section>
+
+          <section>
+            <h2>What makes it portable</h2>
+            <p>Portability comes from separating core behavior from host concerns. Contracts describe what the service accepts and returns. The runtime handles validation, transport, policy, and placement. That separation lets the same behavior move without dragging a whole application stack behind it.</p>
+            <p>WebAssembly can provide a strong execution boundary, but UMA is the architectural model that keeps the boundary meaningful.</p>
+          </section>
+
+          <section>
+            <h2>Lifecycle of a Universal Microservice</h2>
+            <p>The lifecycle begins with a capability, then a contract, then a portable implementation, then runtime exposure, validation, observation, and versioned evolution. The service is not complete just because it compiles. It is complete when the runtime can govern how and where it is used.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Capability</h3><p>The service exists because the system needs one specific behavior to remain coherent.</p></article>
+            <article class="subpage-card"><h3>Contract</h3><p>Inputs, outputs, events, and expectations are explicit enough for humans and tools to inspect.</p></article>
+            <article class="subpage-card"><h3>Portable core</h3><p>The behavior is not hidden inside framework glue or a single host process.</p></article>
+            <article class="subpage-card"><h3>Runtime governance</h3><p>Placement, policy, trust, and validation stay visible as the service moves.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page defines the object at a conceptual level. Chapters 2 through 4 of the book build the complete design model, and the first runnable proof lives in the feature flag evaluator example.</p>
+            <div class="subpage-inline-links">
+              <a href="../what-is-uma/">What is UMA?</a>
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../examples/chapter-04-feature-flag-evaluator/">Feature flag example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/book-site/why-universal-microservices-exist/index.html
+++ b/book-site/why-universal-microservices-exist/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Why Universal Microservices Exist | Portable Architecture and UMA</title>
+    <meta name="description" content="Learn why Universal Microservices exist, including infrastructure coupling, runtime dependence, portability pressure, and AI-driven architecture change." />
+    <link rel="canonical" href="https://www.universalmicroservices.com/why-universal-microservices-exist/" />
+    <meta property="og:title" content="Why Universal Microservices Exist | Portable Architecture and UMA" />
+    <meta property="og:description" content="The strategic motivation for Universal Microservices and portable architecture." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.universalmicroservices.com/why-universal-microservices-exist/" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Why Universal Microservices exist","description":"Learn why Universal Microservices exist, including infrastructure coupling, runtime dependence, portability pressure, and AI-driven architecture change.","url":"https://www.universalmicroservices.com/why-universal-microservices-exist/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/why-universal-microservices-exist/"}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../subpages.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+      <main class="subpage-main">
+        <section class="subpage-hero">
+          <h1>Why Universal Microservices exist</h1>
+          <p>Universal Microservices exist because modern systems no longer execute in one stable place. Business behavior now crosses browsers, edge runtimes, cloud services, workflows, and AI-assisted paths. Without an architectural model for that movement, systems duplicate behavior and lose coherence.</p>
+        </section>
+        <div class="subpage-body">
+          <section>
+            <h2>The pressure underneath the model</h2>
+            <p>Teams already know how to deploy services. The harder problem is preserving service meaning when execution spreads across many runtimes. UMA starts from that pressure rather than from a new packaging technique.</p>
+            <p>The model exists to make runtime diversity manageable without pretending every runtime is equivalent.</p>
+          </section>
+
+          <section>
+            <h2>Infrastructure coupling</h2>
+            <p>Many systems look modular from the outside but keep business behavior bound to a specific framework, queue, database adapter, or hosting assumption. That coupling limits where the behavior can run and makes change expensive.</p>
+            <p>UMA separates the portable service boundary from the infrastructure concerns that surround it.</p>
+          </section>
+
+          <section>
+            <h2>Runtime dependence</h2>
+            <p>Runtime dependence becomes a problem when local choices quietly redefine the service. A browser rule, an edge optimization, and a backend authority check may all claim to implement the same behavior while drifting apart over time.</p>
+            <p>Universal Microservices make the runtime layer explicit so placement, validation, and policy are governed decisions.</p>
+          </section>
+
+          <section>
+            <h2>AI-driven architectural pressure</h2>
+            <p>AI-assisted flows increase the need for visible authority. Agents can propose paths, rank options, or assemble workflows, but the runtime still needs to validate what is allowed and what actually executes.</p>
+            <p>That is why UMA draws a firm distinction between proposal and authority.</p>
+          </section>
+
+          <section>
+            <h2>Why this matters now</h2>
+            <p>Portable architecture is no longer a niche concern. It is a response to systems that must keep one behavior consistent across many execution surfaces while still respecting trust, latency, cost, and operational context.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Less duplication</h3><p>One behavior can remain the durable center instead of being reimplemented surface by surface.</p></article>
+            <article class="subpage-card"><h3>Clearer authority</h3><p>The runtime becomes responsible for validation and policy rather than leaving those decisions implicit.</p></article>
+            <article class="subpage-card"><h3>Better evolution</h3><p>Versioning and compatibility become visible system concerns.</p></article>
+            <article class="subpage-card"><h3>More credible AI use</h3><p>Agents can participate without becoming the source of operational authority.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This topic maps to the strategic argument in Chapter 1. The website explains why UMA exists, the repository shows runnable proof, and the book develops the methodology for applying it responsibly.</p>
+            <div class="subpage-inline-links">
+              <a href="../what-problem-does-uma-solve/">What problem does UMA solve?</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="../examples/">Examples</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>
+      </main>
+    </div>
+    <script src="../app.js" type="module"></script>
+  </body>
+</html>

--- a/chapter-07-metadata-orchestration/scripts/compare_impls.sh
+++ b/chapter-07-metadata-orchestration/scripts/compare_impls.sh
@@ -14,7 +14,7 @@ trap 'rm -f "$rust_output" "$ts_output"' EXIT
 ./scripts/run_cloud.sh >"$rust_output" 2>&1
 ./scripts/run_cloud_ts.sh >"$ts_output" 2>&1
 
-node - "$rust_output" "$ts_output" <<'EOF'
+node --input-type=module - "$rust_output" "$ts_output" <<'EOF'
 import fs from "node:fs";
 import { summarizeRunnerOutput } from "./runtime/lib.mjs";
 


### PR DESCRIPTION
## Summary
- add the remaining UMA SEO landing pages for definitions, migration, production readiness, comparisons, criticisms, and the end-to-end feature flag walkthrough
- expose the new article routes in robots.txt for indexing alongside the already-linked footer and sitemap entries
- keep the Chapter 7 reader smoke fix present on this validated branch so the full smoke gate passes

## Validation
- ./scripts/smoke_reader_paths.sh