### PR TITLE
chore: add semantic subpage navigation

### DIFF
--- a/.github/workflows/book-site-pages.yml
+++ b/.github/workflows/book-site-pages.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
     paths:
+      - "content/**"
+      - "docs/site/**"
+      - "docs/seo/**"
+      - "book-site/scripts/build_from_content.mjs"
       - "book-site/**"
       - "chapter-13-portable-mcp-runtime/app/**"
       - ".github/workflows/book-site-pages.yml"
@@ -39,6 +43,9 @@ jobs:
 
       - name: Build reference app
         run: npm --prefix chapter-13-portable-mcp-runtime/app run build
+
+      - name: Build UMA subpages from Markdown
+        run: node book-site/scripts/build_from_content.mjs
 
       - name: Stage reference app for Pages
         shell: bash

--- a/book-site/README.md
+++ b/book-site/README.md
@@ -4,7 +4,15 @@ This folder contains the single-page GitHub Pages site for the *Universal Micros
 
 ## Local Preview
 
-Because the site is plain static HTML, CSS, and JavaScript, you can preview it with any static file server.
+The homepage is still a static HTML page, but the non-home pages are generated from the Markdown source in `content/pages/` at build time.
+
+To regenerate the generated subpages locally:
+
+```bash
+node book-site/scripts/build_from_content.mjs
+```
+
+Because the site is still plain static HTML, CSS, and JavaScript after generation, you can preview it with any static file server.
 
 Example:
 
@@ -14,6 +22,12 @@ python3 -m http.server 4173
 ```
 
 Then open `http://localhost:4173`.
+
+## Markdown Source of Truth
+
+- `content/site-map.md` defines the canonical page order and macro areas.
+- `content/pages/**.md` holds the page content and metadata.
+- `book-site/scripts/build_from_content.mjs` turns the Markdown source into the published subpages.
 
 ## Sync Blog Posts
 
@@ -36,7 +50,7 @@ The script tries the Medium publication feed first and falls back to scraping th
 ## Deployment
 
 GitHub Pages deployment is handled by [`.github/workflows/book-site-pages.yml`](../.github/workflows/book-site-pages.yml).
-The workflow publishes the contents of `book-site/` directly.
+The workflow builds the Markdown-backed subpages, stages the reference application, and then publishes the contents of `book-site/`.
 
 ## Page Outline
 

--- a/book-site/about-enrico/index.html
+++ b/book-site/about-enrico/index.html
@@ -3,38 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>About Enrico Piovesan</title>
-    <meta
-      name="description"
-      content="About Enrico Piovesan, platform software architect, writer, and author of Universal Microservices Architecture."
-    />
+    <title>About Enrico Piovesan | Universal Microservices Architecture</title>
+    <meta name="description" content="About Enrico Piovesan, platform software architect, writer, and author of Universal Microservices Architecture." />
     <link rel="canonical" href="https://www.universalmicroservices.com/about-enrico/" />
     <meta property="og:title" content="About Enrico Piovesan" />
-    <meta
-      property="og:description"
-      content="Learn about Enrico Piovesan, his background in modular and distributed systems, and the perspective behind Universal Microservices Architecture."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:description" content="About Enrico Piovesan, platform software architect, writer, and author of Universal Microservices Architecture." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/about-enrico/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"About Enrico Piovesan","item":"https://www.universalmicroservices.com/about-enrico/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"About Enrico Piovesan","description":"About Enrico Piovesan, platform software architect, writer, and author of Universal Microservices Architecture.","url":"https://www.universalmicroservices.com/about-enrico/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#architectural-perspective">Architectural perspective</a></li><li><a href="#professional-background">Professional background</a>
+    <ul class="page-rail-links">
+      <li><a href="#platform-experience">Platform experience</a></li><li><a href="#product-reality">Product reality</a></li><li><a href="#system-thinking">System thinking</a></li><li><a href="#long-term-durability">Long-term durability</a></li>
+    </ul></li><li><a href="#why-this-site-exists">Why this site exists</a></li><li><a href="#what-readers-can-expect-here">What readers can expect here</a></li><li><a href="#frequently-asked-question">Frequently asked question</a>
+    <ul class="page-rail-links">
+      <li><a href="#why-separate-the-site-from-medium">Why separate the site from Medium?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">About Enrico Piovesan</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>About Enrico Piovesan</h1>
           <p>
             Enrico Piovesan is a platform software architect with more than two decades of experience building modular, cloud-native, and
@@ -79,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>Architectural perspective</h2>
+            <h2 id="architectural-perspective">Architectural perspective</h2>
             <p>
               Universal Microservices Architecture comes from a practical concern: modern systems keep spreading across runtimes faster than
               their architecture evolves. The result is often duplication, hidden dependencies, and governance that arrives too late. Enrico
@@ -91,7 +112,7 @@
           </section>
 
           <section>
-            <h2>Professional background</h2>
+            <h2 id="professional-background">Professional background</h2>
             <p>
               Enrico’s work spans modular systems, event-driven architecture, platform design, and developer experience. That mix matters
               because Universal Microservices Architecture is not just a theory about service boundaries. It is also a response to the
@@ -101,25 +122,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Platform experience</h3>
+              <h3 id="platform-experience">Platform experience</h3>
               <p>Long experience with distributed systems, modular design, and developer workflows informs the model behind UMA.</p>
             </article>
             <article class="subpage-card">
-              <h3>Product reality</h3>
+              <h3 id="product-reality">Product reality</h3>
               <p>The architectural ideas are grounded in systems that must survive scaling pressure, delivery pressure, and team boundaries.</p>
             </article>
             <article class="subpage-card">
-              <h3>System thinking</h3>
+              <h3 id="system-thinking">System thinking</h3>
               <p>The work is driven by the idea that software architecture should remain understandable as systems become more distributed.</p>
             </article>
             <article class="subpage-card">
-              <h3>Long-term durability</h3>
+              <h3 id="long-term-durability">Long-term durability</h3>
               <p>The aim is not novelty for its own sake, but an architecture that lasts longer under change.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why this site exists</h2>
+            <h2 id="why-this-site-exists">Why this site exists</h2>
             <p>
               This site is the public hub for the book, the learning path, the examples, and the related writing. Medium remains the main
               publication channel for long-form posts, while this site acts as the authority and navigation layer around the book and the
@@ -132,7 +153,7 @@
           </section>
 
           <section>
-            <h2>What readers can expect here</h2>
+            <h2 id="what-readers-can-expect-here">What readers can expect here</h2>
             <p>
               Readers who arrive through the book or Medium should be able to understand what UMA is, why it exists, how the examples map to
               the ideas, and where to go next. The site is meant to reduce friction, not add another layer of explanation without structure.
@@ -140,8 +161,8 @@
           </section>
 
           <section>
-            <h2>Frequently asked question</h2>
-            <h3>Why separate the site from Medium?</h3>
+            <h2 id="frequently-asked-question">Frequently asked question</h2>
+            <h3 id="why-separate-the-site-from-medium">Why separate the site from Medium?</h3>
             <p>
               Medium is the ongoing publication channel. The site is the stable authority hub for the book, the learning path, and the
               examples. Keeping both allows discovery and conversion to support each other instead of competing.
@@ -165,7 +186,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/active-descriptors/index.html
+++ b/book-site/active-descriptors/index.html
@@ -7,56 +7,106 @@
     <meta name="description" content="Learn how UMA uses active descriptors as runtime-evaluated constraints for contracts, schemas, latency expectations, compatibility, and execution evidence." />
     <link rel="canonical" href="https://www.universalmicroservices.com/active-descriptors/" />
     <meta property="og:title" content="Active Descriptors in UMA" />
-    <meta property="og:description" content="A practical preview of active descriptors in Universal Microservices Architecture and where the book explains the full model." />
+    <meta property="og:description" content="Learn how UMA uses active descriptors as runtime-evaluated constraints for contracts, schemas, latency expectations, compatibility, and execution evidence." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/active-descriptors/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "Active Descriptors in UMA",
-  "description": "A practical preview of active descriptors in Universal Microservices Architecture.",
-  "author": { "@type": "Person", "name": "Enrico Piovesan" },
-  "publisher": { "@type": "Organization", "name": "Universal Microservices Architecture" },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/active-descriptors/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Active Descriptors in UMA","item":"https://www.universalmicroservices.com/active-descriptors/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Active Descriptors in UMA","description":"Learn how UMA uses active descriptors as runtime-evaluated constraints for contracts, schemas, latency expectations, compatibility, and execution evidence.","url":"https://www.universalmicroservices.com/active-descriptors/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-useful-idea">The useful idea</a>
+    <ul class="page-rail-links">
+      <li><a href="#boundary">Boundary</a></li><li><a href="#compatibility">Compatibility</a></li><li><a href="#expectations">Expectations</a></li><li><a href="#authority">Authority</a></li>
+    </ul></li><li><a href="#concrete-proof">Concrete proof</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Active Descriptors in UMA</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Active descriptors</h1>
           <p>In UMA, a descriptor is not just documentation beside a service. It is metadata the runtime can evaluate to understand the service boundary, validate inputs and outputs, check compatibility, and record why execution was allowed.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>The useful idea</h2>
+            <h2 id="the-useful-idea">The useful idea</h2>
             <p>An active descriptor describes a capability in terms the runtime can use: schemas, emitted events, required inputs, allowed placements, version constraints, and the evidence expected from a run. It is active because it participates in execution decisions.</p>
             <p>This does not mean the contract replaces service logic. The contract is an executable constraint model around the logic, while the service still owns the durable behavior.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Boundary</h3><p>Input and output schemas define the shape of the portable behavior.</p></article>
-            <article class="subpage-card"><h3>Compatibility</h3><p>Version and event declarations help the runtime decide whether services can interact.</p></article>
-            <article class="subpage-card"><h3>Expectations</h3><p>Latency, error, and evidence expectations make execution easier to inspect.</p></article>
-            <article class="subpage-card"><h3>Authority</h3><p>The runtime evaluates the descriptor before it treats a proposed path as approved.</p></article>
+            <article class="subpage-card"><h3 id="boundary">Boundary</h3><p>Input and output schemas define the shape of the portable behavior.</p></article>
+            <article class="subpage-card"><h3 id="compatibility">Compatibility</h3><p>Version and event declarations help the runtime decide whether services can interact.</p></article>
+            <article class="subpage-card"><h3 id="expectations">Expectations</h3><p>Latency, error, and evidence expectations make execution easier to inspect.</p></article>
+            <article class="subpage-card"><h3 id="authority">Authority</h3><p>The runtime evaluates the descriptor before it treats a proposed path as approved.</p></article>
           </section>
           <section>
-            <h2>Concrete proof</h2>
+            <h2 id="concrete-proof">Concrete proof</h2>
             <p>The early examples prove the idea in small pieces: Chapter 4 uses a contract around deterministic flag evaluation, Chapter 6 uses a contract to compare native and WASI execution, and Chapter 7 lets contracts and events shape orchestration.</p>
           </section>
           <section class="subpage-callout">

--- a/book-site/agent-vs-runtime/index.html
+++ b/book-site/agent-vs-runtime/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agent vs Runtime in UMA | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Understand the difference between agents and the runtime in Universal Microservices Architecture: agents propose, the runtime validates, and the system stays governed."
-    />
+    <meta name="description" content="Understand the difference between agents and the runtime in Universal Microservices Architecture: agents propose, the runtime validates, and the system stays governed." />
     <link rel="canonical" href="https://www.universalmicroservices.com/agent-vs-runtime/" />
-    <meta property="og:title" content="Agent vs Runtime in UMA | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to one of the most important UMA ideas: agents can help compose work, but the runtime must remain authoritative."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Agent vs Runtime in UMA" />
+    <meta property="og:description" content="Understand the difference between agents and the runtime in Universal Microservices Architecture: agents propose, the runtime validates, and the system stays governed." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/agent-vs-runtime/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "Agent vs Runtime in UMA",
-  "description": "An original explanation of why agents can propose capability paths in UMA while the runtime remains authoritative over validation and execution.",
-  "url": "https://www.universalmicroservices.com/agent-vs-runtime/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/agent-vs-runtime/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Agent vs Runtime in UMA","item":"https://www.universalmicroservices.com/agent-vs-runtime/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Agent vs Runtime in UMA","description":"Understand the difference between agents and the runtime in Universal Microservices Architecture: agents propose, the runtime validates, and the system stays governed.","url":"https://www.universalmicroservices.com/agent-vs-runtime/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#what-an-agent-is-for">What an agent is for</a></li><li><a href="#what-the-runtime-is-for">What the runtime is for</a>
+    <ul class="page-rail-links">
+      <li><a href="#agent-responsibility">Agent responsibility</a></li><li><a href="#runtime-responsibility">Runtime responsibility</a></li><li><a href="#agent-strength">Agent strength</a></li><li><a href="#runtime-strength">Runtime strength</a></li>
+    </ul></li><li><a href="#if-you-remember-one-rule">If you remember one rule</a></li><li><a href="#why-this-distinction-matters-more-with-ai">Why this distinction matters more with AI</a></li><li><a href="#what-goes-wrong-when-the-distinction-disappears">What goes wrong when the distinction disappears</a></li><li><a href="#how-chapter-13-makes-this-visible">How Chapter 13 makes this visible</a></li><li><a href="#a-useful-design-test">A useful design test</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#does-uma-require-an-agent">Does UMA require an agent?</a></li><li><a href="#can-an-agent-ever-be-authoritative">Can an agent ever be authoritative?</a></li><li><a href="#why-not-let-the-agent-decide-everything-if-it-performs-well">Why not let the agent decide everything if it performs well?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Agent vs Runtime in UMA</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Agent vs runtime in UMA</h1>
           <p>
             One of the easiest ways to misunderstand Universal Microservices Architecture is to assume that once agents enter the picture,
@@ -97,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               In UMA, an agent is a reasoning component. It interprets a goal, looks at available capabilities, and proposes a path. The
               runtime is the execution authority. It validates contracts, checks constraints, enforces trust and placement rules, and
@@ -118,7 +121,7 @@
           </section>
 
           <section>
-            <h2>What an agent is for</h2>
+            <h2 id="what-an-agent-is-for">What an agent is for</h2>
             <p>
               Agents are useful when a system has many capabilities and no single fixed workflow fits every situation. They can help
               interpret goals, identify candidate capabilities, rank plausible options, and suggest a sequence that might satisfy the
@@ -132,7 +135,7 @@
           </section>
 
           <section>
-            <h2>What the runtime is for</h2>
+            <h2 id="what-the-runtime-is-for">What the runtime is for</h2>
             <p>
               The runtime exists to turn a capability model into governed execution. It knows what is available, what is compatible, what
               is allowed in the current environment, and what must be rejected even if a proposal looks plausible. It can also explain what
@@ -147,25 +150,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Agent responsibility</h3>
+              <h3 id="agent-responsibility">Agent responsibility</h3>
               <p>Interpret the goal, explore available capabilities, and propose a plausible path.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime responsibility</h3>
+              <h3 id="runtime-responsibility">Runtime responsibility</h3>
               <p>Validate contracts, enforce constraints, and decide whether the proposal can actually run.</p>
             </article>
             <article class="subpage-card">
-              <h3>Agent strength</h3>
+              <h3 id="agent-strength">Agent strength</h3>
               <p>Adaptability, ranking, and dynamic composition when the exact path cannot be fully hardwired in advance.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime strength</h3>
+              <h3 id="runtime-strength">Runtime strength</h3>
               <p>Authority, repeatability, evidence, and governance across environments and capability boundaries.</p>
             </article>
           </section>
 
           <section>
-            <h2>If you remember one rule</h2>
+            <h2 id="if-you-remember-one-rule">If you remember one rule</h2>
             <p>
               A good UMA system can benefit from an agent without becoming agent-governed. That is the practical test. If the planner goes
               away, the runtime should still be coherent. If the runtime goes away, the planner should not be trusted to define the system
@@ -179,7 +182,7 @@
           </section>
 
           <section>
-            <h2>Why this distinction matters more with AI</h2>
+            <h2 id="why-this-distinction-matters-more-with-ai">Why this distinction matters more with AI</h2>
             <p>
               AI systems make the agent side more powerful, but they also make the boundary more important. As soon as the planning layer is
               model-driven, it becomes even more dangerous to let the proposal layer silently become the control layer. A strong answer is
@@ -193,7 +196,7 @@
           </section>
 
           <section>
-            <h2>What goes wrong when the distinction disappears</h2>
+            <h2 id="what-goes-wrong-when-the-distinction-disappears">What goes wrong when the distinction disappears</h2>
             <p>
               When teams blur the line between agent and runtime, failures start to look intelligent instead of architectural. A proposal is
               accepted because it seems reasonable, not because it was validated. A capability is invoked because it looked relevant, not
@@ -211,7 +214,7 @@
           </section>
 
           <section>
-            <h2>How Chapter 13 makes this visible</h2>
+            <h2 id="how-chapter-13-makes-this-visible">How Chapter 13 makes this visible</h2>
             <p>
               The Chapter 13 reference experience is useful because it shows this boundary directly instead of leaving it implicit. The
               planner can rank capabilities. The runtime still validates the choice. If a proposed path violates the active rules, the
@@ -229,7 +232,7 @@
           </section>
 
           <section>
-            <h2>A useful design test</h2>
+            <h2 id="a-useful-design-test">A useful design test</h2>
             <p>
               If you want to know whether your system is treating agents and runtimes clearly, ask a simple question: if the planner proposes
               a valid-looking but disallowed path, what enforces the rejection? If the answer is unclear, the architecture probably needs a
@@ -243,18 +246,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Does UMA require an agent?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="does-uma-require-an-agent">Does UMA require an agent?</h3>
             <p>
               No. UMA does not require an agent in order to be coherent. A system can still use explicit workflows, fixed capability
               selection, and strong runtime governance. Agents become useful when the system needs dynamic selection or proposal behavior.
             </p>
-            <h3>Can an agent ever be authoritative?</h3>
+            <h3 id="can-an-agent-ever-be-authoritative">Can an agent ever be authoritative?</h3>
             <p>
               It can feel authoritative at the product layer, but in a governed UMA system it should still pass through runtime approval.
               Otherwise the system loses the architectural distinction that keeps dynamic planning from turning into hidden control.
             </p>
-            <h3>Why not let the agent decide everything if it performs well?</h3>
+            <h3 id="why-not-let-the-agent-decide-everything-if-it-performs-well">Why not let the agent decide everything if it performs well?</h3>
             <p>
               Because performance and authority are different concerns. A planner may often suggest a good path, but a governed system still
               needs explicit validation, trust enforcement, and reproducible approval. Those are runtime responsibilities, not prompt
@@ -284,7 +287,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/ai-native-runtime-governance/index.html
+++ b/book-site/ai-native-runtime-governance/index.html
@@ -7,28 +7,93 @@
     <meta name="description" content="Learn how UMA lets AI participate in workflow proposals while the runtime remains authoritative, explainable, and traceable." />
     <link rel="canonical" href="https://www.universalmicroservices.com/ai-native-runtime-governance/" />
     <meta property="og:title" content="AI-Native Runtime Governance in UMA" />
-    <meta property="og:description" content="A practical preview of how UMA separates AI proposals from runtime authority." />
+    <meta property="og:description" content="Learn how UMA lets AI participate in workflow proposals while the runtime remains authoritative, explainable, and traceable." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/ai-native-runtime-governance/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"AI-Native Runtime Governance in UMA","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/ai-native-runtime-governance/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"AI-Native Runtime Governance in UMA","item":"https://www.universalmicroservices.com/ai-native-runtime-governance/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"AI-Native Runtime Governance in UMA","description":"Learn how UMA lets AI participate in workflow proposals while the runtime remains authoritative, explainable, and traceable.","url":"https://www.universalmicroservices.com/ai-native-runtime-governance/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
   </head>
   <body>
-    <div class="page-shell">
-      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+    <div class="page-shell has-page-rail">
+      <header class="topbar">
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-boundary-that-matters">The boundary that matters</a>
+    <ul class="page-rail-links">
+      <li><a href="#proposal">Proposal</a></li><li><a href="#validation">Validation</a></li><li><a href="#execution">Execution</a></li><li><a href="#trace">Trace</a></li>
+    </ul></li><li><a href="#why-this-supports-book-conversion">Why this supports book conversion</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero"><h1>AI-native runtime governance</h1><p>UMA does not make the agent the authority. It lets AI propose, summarize, rank, or assist, while the runtime validates what is allowed and leaves an inspectable trail.</p></section>
-        <div class="subpage-body">
-          <section><h2>The boundary that matters</h2><p>AI-native systems become risky when proposals, validation, execution, and authority collapse into one opaque step. UMA keeps those stages visible: a planner can propose, but runtime policy still decides what can run.</p><p>That is the difference between an AI-assisted workflow and an AI-owned architecture.</p></section>
-          <section class="subpage-grid"><article class="subpage-card"><h3>Proposal</h3><p>The agent can suggest a path or choose among candidates.</p></article><article class="subpage-card"><h3>Validation</h3><p>The runtime checks constraints, authority, placement, and capability compatibility.</p></article><article class="subpage-card"><h3>Execution</h3><p>Approved intent resolves into concrete runtime steps.</p></article><article class="subpage-card"><h3>Trace</h3><p>The final result should explain the path, not hide it.</p></article></section>
-          <section><h2>Why this supports book conversion</h2><p>This page gives enough to understand the distinction. The complete argument lives in Chapters 12 and 13, where discoverable decisions and the portable MCP runtime turn the boundary into runnable behavior.</p></section>
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">AI-Native Runtime Governance in UMA</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero"><h1>AI-native runtime governance</h1><p>UMA does not make the agent the authority. It lets AI propose, summarize, rank, or assist, while the runtime validates what is allowed and leaves an inspectable trail.</p></section>
+
+<div class="subpage-body">
+          <section><h2 id="the-boundary-that-matters">The boundary that matters</h2><p>AI-native systems become risky when proposals, validation, execution, and authority collapse into one opaque step. UMA keeps those stages visible: a planner can propose, but runtime policy still decides what can run.</p><p>That is the difference between an AI-assisted workflow and an AI-owned architecture.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3 id="proposal">Proposal</h3><p>The agent can suggest a path or choose among candidates.</p></article><article class="subpage-card"><h3 id="validation">Validation</h3><p>The runtime checks constraints, authority, placement, and capability compatibility.</p></article><article class="subpage-card"><h3 id="execution">Execution</h3><p>Approved intent resolves into concrete runtime steps.</p></article><article class="subpage-card"><h3 id="trace">Trace</h3><p>The final result should explain the path, not hide it.</p></article></section>
+          <section><h2 id="why-this-supports-book-conversion">Why this supports book conversion</h2><p>This page gives enough to understand the distinction. The complete argument lives in Chapters 12 and 13, where discoverable decisions and the portable MCP runtime turn the boundary into runnable behavior.</p></section>
           <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 12 explains the proposal, validation, revision, execution, and trace ladder. Chapter 13 shows AI participation inside the portable MCP runtime.</p><div class="subpage-inline-links"><a href="../agent-vs-runtime/">Agent vs runtime</a><a href="../examples/chapter-12-discoverable-decisions/">Chapter 12 example</a><a href="../examples/chapter-13-portable-mcp-runtime/">Chapter 13 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
         </div>
         <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/book-site/app.js
+++ b/book-site/app.js
@@ -79,85 +79,113 @@ const menuToggle = document.querySelector(".menu-toggle");
 const mobileMenu = document.querySelector(".mobile-menu");
 const mobileMenuClose = document.querySelector(".mobile-menu-close");
 const sharedFooter = document.querySelector("[data-shared-footer]");
+const subpageMain = document.querySelector("main.subpage-main");
 const faviconHref = new URL("favicon.png", import.meta.url).href;
 const blogHref = "https://medium.com/the-rise-of-device-independent-architecture";
+const githubHref = "https://github.com/enricopiovesan/UMA-code-examples";
+const whitePaperHref = "https://drive.google.com/file/d/1e8rvpXZ7Y89R5VxmAa1nihUDkKrG1TIj/view?pli=1";
 
 const siteRoot = new URL(".", import.meta.url);
+const currentPath = window.location.pathname.replace(/index\.html$/, "").replace(/\/+$/, "/");
+
+function internalHref(path) {
+  return new URL(path, siteRoot).href;
+}
+
+function externalLink(label, href) {
+  return [label, href, true];
+}
+
+function internalLink(label, path) {
+  return [label, path, false];
+}
+
+function normalizePath(path) {
+  return path.replace(/index\.html$/, "").replace(/\/+$/, "/");
+}
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const chapterEntries = chapters.map((chapter) => ({
+  ...chapter,
+  path: normalizePath(chapter.href),
+}));
+const chapterByPath = new Map(chapterEntries.map((chapter) => [chapter.path, chapter]));
 const footerColumns = [
   [
     {
-      title: "Foundations",
+      title: "Start here",
       links: [
-        ["what problem does uma solve?", "what-problem-does-uma-solve/"],
-        ["what is uma", "what-is-uma/"],
-        ["what is a universal microservice?", "what-is-a-universal-microservice/"],
-        ["why universal microservices exist", "why-universal-microservices-exist/"],
-        ["from stack ownership to behavior ownership", "from-stack-ownership-to-behavior-ownership/"],
-        ["uma vs traditional microservices", "uma-vs-traditional-microservices/"],
+        internalLink("what problem does uma solve?", "what-problem-does-uma-solve/"),
+        internalLink("what is uma?", "what-is-uma/"),
+        internalLink("what is a universal microservice?", "what-is-a-universal-microservice/"),
+        internalLink("why universal microservices exist", "why-universal-microservices-exist/"),
+        internalLink("from stack ownership to behavior ownership", "from-stack-ownership-to-behavior-ownership/"),
+        internalLink("learning path", "learning-path/"),
+        internalLink("book", "book/"),
       ],
     },
     {
-      title: "Runtime model",
+      title: "Core concepts",
       links: [
-        ["what is a capability?", "what-is-a-capability/"],
-        ["what is a workflow?", "what-is-a-workflow/"],
-        ["what is a uma runtime?", "what-is-a-uma-runtime/"],
-        ["what belongs in the runtime layer?", "what-belongs-in-the-runtime-layer/"],
-        ["active descriptors", "active-descriptors/"],
-        ["late-bound policy enforcement", "late-bound-policy-enforcement/"],
-        ["what makes a decision discoverable?", "what-makes-a-decision-discoverable/"],
-        ["what is wasm mcp?", "what-is-wasm-mcp/"],
-        ["agent vs runtime", "agent-vs-runtime/"],
+        internalLink("what is a capability?", "what-is-a-capability/"),
+        internalLink("what is a workflow?", "what-is-a-workflow/"),
+        internalLink("what is a uma runtime?", "what-is-a-uma-runtime/"),
+        internalLink("what belongs in the runtime layer?", "what-belongs-in-the-runtime-layer/"),
+        internalLink("active descriptors", "active-descriptors/"),
+        internalLink("late-bound policy enforcement", "late-bound-policy-enforcement/"),
+        internalLink("what makes a decision discoverable?", "what-makes-a-decision-discoverable/"),
+        internalLink("what is wasm mcp?", "what-is-wasm-mcp/"),
+        internalLink("agent vs runtime", "agent-vs-runtime/"),
       ],
     },
   ],
   [
     {
-      title: "Architecture paths",
+      title: "Build and prove",
       links: [
-        ["what makes a service portable?", "what-makes-a-service-portable/"],
-        ["how to prove portability", "how-to-prove-portability/"],
-        ["runtime-agnostic architecture", "runtime-agnostic-architecture/"],
-        ["portable business logic", "portable-business-logic/"],
-        ["architecture drift and portable logic", "architecture-drift-and-portable-business-logic/"],
-        ["webassembly architecture", "webassembly-architecture/"],
-        ["migrating to uma incrementally", "migrating-to-uma-incrementally/"],
-        ["incremental uma adoption", "incremental-uma-adoption/"],
-        ["uma production readiness", "uma-production-readiness/"],
+        internalLink("what makes a service portable?", "what-makes-a-service-portable/"),
+        internalLink("how to prove portability", "how-to-prove-portability/"),
+        internalLink("runtime-agnostic architecture", "runtime-agnostic-architecture/"),
+        internalLink("portable business logic", "portable-business-logic/"),
+        internalLink("architecture drift and portable business logic", "architecture-drift-and-portable-business-logic/"),
+        internalLink("webassembly architecture", "webassembly-architecture/"),
+        internalLink("migrating to uma incrementally", "migrating-to-uma-incrementally/"),
+        internalLink("incremental uma adoption", "incremental-uma-adoption/"),
+        internalLink("uma production readiness", "uma-production-readiness/"),
+        internalLink("benchmark and footprint", "benchmark-and-footprint/"),
       ],
     },
     {
       title: "System evolution",
       links: [
-        ["contract-driven orchestration", "contract-driven-orchestration/"],
-        ["service graph evolution", "service-graph-evolution/"],
-        ["how systems evolve without fragmentation", "how-systems-evolve-without-fragmentation/"],
-        ["what makes a system coherent?", "what-makes-a-system-coherent/"],
-        ["trust boundaries", "trust-boundaries/"],
-        ["runtime provenance and trust", "runtime-provenance-and-trust/"],
-        ["ai-native runtime governance", "ai-native-runtime-governance/"],
+        internalLink("contract-driven orchestration", "contract-driven-orchestration/"),
+        internalLink("service graph evolution", "service-graph-evolution/"),
+        internalLink("how systems evolve without fragmentation", "how-systems-evolve-without-fragmentation/"),
+        internalLink("what makes a system coherent?", "what-makes-a-system-coherent/"),
+        internalLink("trust boundaries", "trust-boundaries/"),
+        internalLink("runtime provenance and trust", "runtime-provenance-and-trust/"),
+        internalLink("ai-native runtime governance", "ai-native-runtime-governance/"),
       ],
     },
     {
-      title: "Comparisons and tradeoffs",
+      title: "Examples and resources",
       links: [
-        ["uma vs serverless", "uma-vs-serverless/"],
-        ["uma vs modular monolith", "uma-vs-modular-monolith/"],
-        ["common criticisms and tradeoffs", "common-criticisms-and-tradeoffs-of-uma/"],
-        ["benchmark and footprint", "benchmark-and-footprint/"],
-      ],
-    },
-    {
-      title: "Explore",
-      links: [
-        ["learning path", "learning-path/"],
-        ["examples", "examples/"],
-        ["end-to-end feature flag example", "end-to-end-feature-flag-example/"],
-        ["example tutorials", "examples/"],
-        ["diagrams", "diagrams/"],
-        ["faq", "faq/"],
-        ["book", "book/"],
-        ["about enrico", "about-enrico/"],
+        internalLink("examples", "examples/"),
+        internalLink("end-to-end feature flag example", "end-to-end-feature-flag-example/"),
+        internalLink("diagrams", "diagrams/"),
+        internalLink("faq", "faq/"),
+        internalLink("about enrico", "about-enrico/"),
+        externalLink("blog", blogHref),
+        externalLink("github", githubHref),
+        externalLink("reference application", "https://www.universalmicroservices.com/reference-application/"),
+        externalLink("read the white paper", whitePaperHref),
       ],
     },
   ],
@@ -175,7 +203,11 @@ if (sharedFooter) {
                   <h3>${cluster.title}</h3>
                   <nav class="footer-links">
                     ${cluster.links
-                      .map(([label, path]) => `<a href="${new URL(path, siteRoot)}">${label}</a>`)
+                      .map(([label, path, external = false]) => {
+                        const href = external ? path : new URL(path, siteRoot).href;
+                        const attrs = external ? ' target="_blank" rel="noreferrer noopener"' : "";
+                        return `<a href="${href}"${attrs}>${label}</a>`;
+                      })
                       .join("")}
                   </nav>
                 </div>
@@ -209,13 +241,210 @@ if (sharedFooter) {
           </a>
           <div class="footer-book-copy">
             <p>Go deeper into UMA with the full book, examples, and architecture model.</p>
-            <a class="inline-link" href="https://drive.google.com/file/d/1e8rvpXZ7Y89R5VxmAa1nihUDkKrG1TIj/view?pli=1" target="_blank" rel="noreferrer noopener">Read the white paper</a>
+            <a class="inline-link" href="${whitePaperHref}" target="_blank" rel="noreferrer noopener">Read the white paper</a>
             <a class="button button-dark footer-book-button" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
           </div>
         </div>
       </section>
     </div>
   `;
+}
+
+function createLinkList(items, ordered = false, className = "") {
+  const list = document.createElement(ordered ? "ol" : "ul");
+  list.className = className;
+
+  for (const [label, path, external = false] of items) {
+    const item = document.createElement("li");
+    const link = document.createElement("a");
+    link.href = external ? path : internalHref(path);
+    link.textContent = label;
+    if (external) {
+      link.target = "_blank";
+      link.rel = "noreferrer noopener";
+    }
+    item.appendChild(link);
+    list.appendChild(item);
+  }
+
+  return list;
+}
+
+function getCurrentChapter() {
+  const normalizedPath = normalizePath(currentPath);
+  const chapter = chapterEntries.find((entry) => normalizedPath.endsWith(entry.path));
+  if (chapter) {
+    return chapter;
+  }
+
+  const examplesMatch = normalizedPath.match(/\/examples\/(chapter-[^/]+)\//);
+  if (examplesMatch) {
+    return chapterByPath.get(normalizePath(`examples/${examplesMatch[1]}/`)) || null;
+  }
+
+  return null;
+}
+
+function getPageLabel() {
+  const heading = document.querySelector("main.subpage-main h1");
+  if (heading) {
+    return heading.textContent.replace(/\s+/g, " ").trim();
+  }
+
+  return document.title.split("|")[0].trim();
+}
+
+function buildBreadcrumbs() {
+  const breadcrumbs = document.createElement("nav");
+  breadcrumbs.className = "page-breadcrumbs";
+  breadcrumbs.setAttribute("aria-label", "Breadcrumb");
+
+  const list = document.createElement("ol");
+  const items = [{ label: "Home", href: internalHref("/") }];
+  const chapter = getCurrentChapter();
+
+  if (currentPath.includes("/examples/")) {
+    items.push({ label: "Examples", href: internalHref("examples/") });
+    if (chapter) {
+      items.push({ label: `${chapter.number}: ${chapter.title}`, href: internalHref(chapter.href) });
+    } else if (!currentPath.endsWith("/examples/")) {
+      items.push({ label: getPageLabel() });
+    }
+  } else if (currentPath !== "/") {
+    items.push({ label: getPageLabel() });
+  }
+
+  for (const [index, item] of items.entries()) {
+    const li = document.createElement("li");
+    if (index === items.length - 1 || !item.href) {
+      const current = document.createElement("span");
+      current.textContent = item.label;
+      current.setAttribute("aria-current", "page");
+      li.appendChild(current);
+    } else {
+      const link = document.createElement("a");
+      link.href = item.href;
+      link.textContent = item.label;
+      li.appendChild(link);
+    }
+    list.appendChild(li);
+  }
+
+  breadcrumbs.appendChild(list);
+  return breadcrumbs;
+}
+
+function buildHeadingOutline(main) {
+  const headings = [...main.querySelectorAll("h2, h3")].filter((heading) => !heading.closest(".contacts-band"));
+  const outline = [];
+  const ids = new Set([...document.querySelectorAll("[id]")].map((element) => element.id));
+  let currentSection = null;
+
+  for (const heading of headings) {
+    if (!heading.id) {
+      let base = slugify(heading.textContent);
+      let suffix = 2;
+      while (ids.has(base)) {
+        base = `${base}-${suffix++}`;
+      }
+      heading.id = base;
+      ids.add(base);
+    }
+
+    if (heading.tagName === "H2") {
+      currentSection = { label: heading.textContent.trim(), href: `#${heading.id}`, children: [] };
+      outline.push(currentSection);
+      continue;
+    }
+
+    if (currentSection) {
+      currentSection.children.push({ label: heading.textContent.trim(), href: `#${heading.id}` });
+    }
+  }
+
+  return outline;
+}
+
+function renderOutlineList(items, ordered = true) {
+  const list = document.createElement(ordered ? "ol" : "ul");
+  list.className = ordered ? "page-rail-outline" : "page-rail-links";
+
+  for (const item of items) {
+    const li = document.createElement("li");
+    const link = document.createElement("a");
+    link.href = item.href;
+    link.textContent = item.label;
+    li.appendChild(link);
+
+    if (item.children?.length) {
+      li.appendChild(renderOutlineList(item.children, false));
+    }
+
+    list.appendChild(li);
+  }
+
+  return list;
+}
+
+function buildPageRail(main) {
+  const rail = document.createElement("aside");
+  rail.className = "page-rail";
+  rail.setAttribute("aria-label", "Page navigation");
+
+  const chapter = getCurrentChapter();
+  const outline = buildHeadingOutline(main);
+  const exploreLinks = [
+    ["home", "/"],
+    ["book", "book/"],
+    ["examples", "examples/"],
+    ["learning path", "learning-path/"],
+    ["faq", "faq/"],
+    ["blog", blogHref, true],
+    ["reference application", "https://www.universalmicroservices.com/reference-application/", true],
+    ["github", githubHref, true],
+  ];
+
+  rail.innerHTML = `
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+    </nav>
+  `;
+
+  const [outlineBlock, exploreBlock] = rail.querySelectorAll(".page-rail-block");
+  outlineBlock.appendChild(renderOutlineList(outline, true));
+  exploreBlock.appendChild(createLinkList(exploreLinks, false, "page-rail-links"));
+
+  if (chapter) {
+    const currentIndex = chapterEntries.findIndex((entry) => entry.path === chapter.path);
+    const chapterLinks = [
+      ["examples hub", "examples/"],
+      currentIndex > 0 ? [`previous: ${chapterEntries[currentIndex - 1].number}`, chapterEntries[currentIndex - 1].href] : null,
+      currentIndex < chapterEntries.length - 1 ? [`next: ${chapterEntries[currentIndex + 1].number}`, chapterEntries[currentIndex + 1].href] : null,
+      ["source folder", `https://github.com/enricopiovesan/UMA-code-examples/tree/main/${chapter.href}`, true],
+    ].filter(Boolean);
+
+    const chapterBlock = document.createElement("nav");
+    chapterBlock.className = "page-rail-block";
+    chapterBlock.innerHTML = "<h2>In the examples path</h2>";
+    chapterBlock.appendChild(createLinkList(chapterLinks, false, "page-rail-links"));
+    rail.appendChild(chapterBlock);
+  }
+
+  return rail;
+}
+
+function enhanceSubpageLayout() {
+  if (!subpageMain) return;
+
+  const pageShell = document.querySelector(".page-shell");
+  if (!pageShell || pageShell.classList.contains("has-page-rail")) return;
+
+  pageShell.classList.add("has-page-rail");
+  subpageMain.prepend(buildBreadcrumbs());
+  pageShell.insertBefore(buildPageRail(subpageMain), subpageMain);
 }
 
 function ensureFavicon() {
@@ -295,7 +524,7 @@ if (blogCards) {
     });
 }
 
-document.querySelectorAll('a[href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4reference-application/"], a[href="https://github.com/enricopiovesan/UMA-code-examples"]').forEach((link) => {
+document.querySelectorAll(`a[href="${githubHref}"], a[href="${blogHref}"]`).forEach((link) => {
   link.setAttribute("target", "_blank");
   link.setAttribute("rel", "noreferrer noopener");
 });
@@ -363,6 +592,7 @@ if (coverFrame) {
   window.addEventListener("pointermove", updateCoverShadow, { passive: true });
 }
 
+enhanceSubpageLayout();
 ensureFavicon();
 ensureHeaderBlogLink();
 

--- a/book-site/app.js
+++ b/book-site/app.js
@@ -163,6 +163,19 @@ const footerColumns = [
       ],
     },
     {
+      title: "Hands-on",
+      links: [
+        internalLink("examples", "examples/"),
+        internalLink("end-to-end feature flag example", "end-to-end-feature-flag-example/"),
+        internalLink("learning path", "learning-path/"),
+        internalLink("chapter 4-6 tutorials", "examples/#foundations"),
+        internalLink("chapter 7-9 tutorials", "examples/#orchestration-and-trust"),
+        internalLink("chapter 10-13 tutorials", "examples/#evolution-and-discoverability"),
+      ],
+    },
+  ],
+  [
+    {
       title: "System evolution",
       links: [
         internalLink("contract-driven orchestration", "contract-driven-orchestration/"),
@@ -175,12 +188,11 @@ const footerColumns = [
       ],
     },
     {
-      title: "Examples and resources",
+      title: "Explore UMA",
       links: [
-        internalLink("examples", "examples/"),
-        internalLink("end-to-end feature flag example", "end-to-end-feature-flag-example/"),
         internalLink("diagrams", "diagrams/"),
         internalLink("faq", "faq/"),
+        internalLink("book", "book/"),
         internalLink("about enrico", "about-enrico/"),
         externalLink("blog", blogHref),
         externalLink("github", githubHref),

--- a/book-site/architecture-drift-and-portable-business-logic/index.html
+++ b/book-site/architecture-drift-and-portable-business-logic/index.html
@@ -3,32 +3,97 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Architecture Drift and Portable Business Logic | UMA</title>
+    <title>Architecture Drift and Portable Business Logic | Universal Microservices Architecture</title>
     <meta name="description" content="Learn how UMA reduces architecture drift by keeping business behavior portable, contract-shaped, and governed across browser, edge, backend, and AI-assisted runtime paths." />
     <link rel="canonical" href="https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/" />
     <meta property="og:title" content="Architecture Drift and Portable Business Logic" />
-    <meta property="og:description" content="A practical preview of how UMA addresses duplicated business behavior and architecture drift." />
+    <meta property="og:description" content="Learn how UMA reduces architecture drift by keeping business behavior portable, contract-shaped, and governed across browser, edge, backend, and AI-assisted runtime paths." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Architecture Drift and Portable Business Logic","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Architecture Drift and Portable Business Logic","item":"https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Architecture Drift and Portable Business Logic","description":"Learn how UMA reduces architecture drift by keeping business behavior portable, contract-shaped, and governed across browser, edge, backend, and AI-assisted runtime paths.","url":"https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
   </head>
   <body>
-    <div class="page-shell">
-      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+    <div class="page-shell has-page-rail">
+      <header class="topbar">
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-problem">The problem</a>
+    <ul class="page-rail-links">
+      <li><a href="#portable-core">Portable core</a></li><li><a href="#runtime-wrapper">Runtime wrapper</a></li><li><a href="#observable-parity">Observable parity</a></li><li><a href="#governed-evolution">Governed evolution</a></li>
+    </ul></li><li><a href="#the-conversion-point">The conversion point</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero"><h1>Architecture drift and portable business logic</h1><p>Architecture drift often begins when the same business behavior is copied into browser code, mobile code, backend code, edge functions, workflow glue, and AI-adjacent automation. UMA attacks that drift by making the durable behavior portable and governed.</p></section>
-        <div class="subpage-body">
-          <section><h2>The problem</h2><p>A duplicated rule can start as a harmless optimization. Over time, each copy adapts to local pressures. The web client handles one edge case, the backend handles another, the edge function adds a shortcut, and nobody can point to one authoritative behavior anymore.</p><p>UMA does not promise magic elimination of drift. It gives teams a model for reducing drift by keeping business behavior behind explicit contracts and visible runtime authority.</p></section>
-          <section class="subpage-grid"><article class="subpage-card"><h3>Portable core</h3><p>Keep the durable behavior testable outside one host.</p></article><article class="subpage-card"><h3>Runtime wrapper</h3><p>Let validation, adapters, and policy live around the core.</p></article><article class="subpage-card"><h3>Observable parity</h3><p>Compare behavior from outputs and events, not wishful code similarity.</p></article><article class="subpage-card"><h3>Governed evolution</h3><p>Use contracts and runtime decisions to manage version growth.</p></article></section>
-          <section><h2>The conversion point</h2><p>This is the pressure that makes the book worth reading. The website can name the pattern, but the book walks through how a system moves from one portable behavior to runtime governance, trust, discoverability, and long-term evolution.</p></section>
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Architecture Drift and Portable Business Logic</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero"><h1>Architecture drift and portable business logic</h1><p>Architecture drift often begins when the same business behavior is copied into browser code, mobile code, backend code, edge functions, workflow glue, and AI-adjacent automation. UMA attacks that drift by making the durable behavior portable and governed.</p></section>
+
+<div class="subpage-body">
+          <section><h2 id="the-problem">The problem</h2><p>A duplicated rule can start as a harmless optimization. Over time, each copy adapts to local pressures. The web client handles one edge case, the backend handles another, the edge function adds a shortcut, and nobody can point to one authoritative behavior anymore.</p><p>UMA does not promise magic elimination of drift. It gives teams a model for reducing drift by keeping business behavior behind explicit contracts and visible runtime authority.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3 id="portable-core">Portable core</h3><p>Keep the durable behavior testable outside one host.</p></article><article class="subpage-card"><h3 id="runtime-wrapper">Runtime wrapper</h3><p>Let validation, adapters, and policy live around the core.</p></article><article class="subpage-card"><h3 id="observable-parity">Observable parity</h3><p>Compare behavior from outputs and events, not wishful code similarity.</p></article><article class="subpage-card"><h3 id="governed-evolution">Governed evolution</h3><p>Use contracts and runtime decisions to manage version growth.</p></article></section>
+          <section><h2 id="the-conversion-point">The conversion point</h2><p>This is the pressure that makes the book worth reading. The website can name the pattern, but the book walks through how a system moves from one portable behavior to runtime governance, trust, discoverability, and long-term evolution.</p></section>
           <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapters 4, 6, 10, and 11 show the drift problem from different angles: portable behavior, proof of parity, coherence tradeoffs, and evolution without fragmentation.</p><div class="subpage-inline-links"><a href="../portable-business-logic/">Portable business logic</a><a href="../examples/chapter-04-feature-flag-evaluator/">Chapter 4 example</a><a href="../examples/chapter-10-architectural-tradeoffs/">Chapter 10 example</a><a href="../examples/chapter-11-evolution-without-fragmentation/">Chapter 11 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
         </div>
         <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/book-site/benchmark-and-footprint/index.html
+++ b/book-site/benchmark-and-footprint/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UMA Benchmark And Footprint Notes | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Initial UMA benchmark and footprint notes: reproducible local measurements for portable services, WASI runners, and runtime tradeoffs."
-    />
+    <meta name="description" content="Initial UMA benchmark and footprint notes: reproducible local measurements for portable services, WASI runners, and runtime tradeoffs." />
     <link rel="canonical" href="https://www.universalmicroservices.com/benchmark-and-footprint/" />
-    <meta property="og:title" content="UMA Benchmark And Footprint Notes | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="Reproducible local benchmark and footprint notes for the UMA examples, focused on artifact size, repeated execution timing, and honest tradeoff interpretation."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="UMA Benchmark And Footprint Notes" />
+    <meta property="og:description" content="Initial UMA benchmark and footprint notes: reproducible local measurements for portable services, WASI runners, and runtime tradeoffs." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/benchmark-and-footprint/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "UMA Benchmark And Footprint Notes",
-  "description": "Initial reproducible local benchmark and footprint notes for the UMA examples.",
-  "url": "https://www.universalmicroservices.com/benchmark-and-footprint/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/benchmark-and-footprint/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA Benchmark And Footprint Notes","item":"https://www.universalmicroservices.com/benchmark-and-footprint/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA Benchmark And Footprint Notes","description":"Initial UMA benchmark and footprint notes: reproducible local measurements for portable services, WASI runners, and runtime tradeoffs.","url":"https://www.universalmicroservices.com/benchmark-and-footprint/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#how-to-read-this-page">How to read this page</a>
+    <ul class="page-rail-links">
+      <li><a href="#environment">Environment</a></li><li><a href="#method">Method</a></li><li><a href="#scope">Scope</a></li><li><a href="#what-not-to-infer">What not to infer</a></li>
+    </ul></li><li><a href="#at-a-glance">At a glance</a>
+    <ul class="page-rail-links">
+      <li><a href="#chapter-4-repeated-execution">Chapter 4 repeated execution</a></li><li><a href="#chapter-4-first-run-and-memory">Chapter 4 first run and memory</a></li><li><a href="#chapter-6-artifact-footprint">Chapter 6 artifact footprint</a></li><li><a href="#chapter-6-repeated-execution">Chapter 6 repeated execution</a></li><li><a href="#chapter-6-first-run-and-memory">Chapter 6 first run and memory</a></li><li><a href="#chapter-13-reference-runtime">Chapter 13 reference runtime</a></li>
+    </ul></li><li><a href="#chapter-4-minimal-portable-evaluator">Chapter 4: minimal portable evaluator</a></li><li><a href="#chapter-6-portability-proof-under-two-runtime-targets">Chapter 6: portability proof under two runtime targets</a></li><li><a href="#chapter-13-reference-runtime-cli">Chapter 13: reference runtime CLI</a></li><li><a href="#what-these-numbers-actually-prove">What these numbers actually prove</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA Benchmark And Footprint Notes</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>UMA benchmark and footprint notes</h1>
           <p>
             These numbers are intended as honest proof points, not universal claims. They show that the UMA examples can publish measurable
@@ -97,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>How to read this page</h2>
+            <h2 id="how-to-read-this-page">How to read this page</h2>
             <p>
               The measurements here come from reproducible local runs against fixed inputs. They are useful because they expose tradeoffs
               clearly. They are not meant to imply that one runtime always wins in every deployment environment.
@@ -117,32 +120,32 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Environment</h3>
+              <h3 id="environment">Environment</h3>
               <p>macOS 26.3 on arm64, Rust 1.94.0, Node v23.11.0, local pinned Wasmtime v39.0.0.</p>
             </article>
             <article class="subpage-card">
-              <h3>Method</h3>
+              <h3 id="method">Method</h3>
               <p>Release builds, fixed inputs, warmup runs, then repeated local measurements with mean, median, min, and max timing.</p>
             </article>
             <article class="subpage-card">
-              <h3>Scope</h3>
+              <h3 id="scope">Scope</h3>
               <p>Chapter 4 for a minimal portable evaluator, and Chapter 6 for native-versus-WASI portability under one contract.</p>
             </article>
             <article class="subpage-card">
-              <h3>What not to infer</h3>
+              <h3 id="what-not-to-infer">What not to infer</h3>
               <p>These are not cloud benchmarks, distributed throughput tests, or cost comparisons across production-scale environments.</p>
             </article>
           </section>
 
           <section>
-            <h2>At a glance</h2>
+            <h2 id="at-a-glance">At a glance</h2>
             <p>
               These comparisons are normalized inside each row so the slower or larger path sets the full scale. They are not trying to
               imply global winners across workloads. They are here to make the local tradeoff legible quickly.
             </p>
             <div class="benchmark-compare">
               <article class="benchmark-panel">
-                <h3>Chapter 4 repeated execution</h3>
+                <h3 id="chapter-4-repeated-execution">Chapter 4 repeated execution</h3>
                 <div class="benchmark-row">
                   <div class="benchmark-label"><strong>Rust WASI via Wasmtime</strong><span>33.42 ms mean</span></div>
                   <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 12.32%"></span></div>
@@ -153,7 +156,7 @@
                 </div>
               </article>
               <article class="benchmark-panel">
-                <h3>Chapter 4 first run and memory</h3>
+                <h3 id="chapter-4-first-run-and-memory">Chapter 4 first run and memory</h3>
                 <div class="benchmark-row">
                   <div class="benchmark-label"><strong>Rust WASI cold start</strong><span>51.63 ms</span></div>
                   <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 53.53%"></span></div>
@@ -172,7 +175,7 @@
                 </div>
               </article>
               <article class="benchmark-panel">
-                <h3>Chapter 6 artifact footprint</h3>
+                <h3 id="chapter-6-artifact-footprint">Chapter 6 artifact footprint</h3>
                 <div class="benchmark-row">
                   <div class="benchmark-label"><strong>Native runner</strong><span>5.31 MiB</span></div>
                   <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
@@ -183,7 +186,7 @@
                 </div>
               </article>
               <article class="benchmark-panel">
-                <h3>Chapter 6 repeated execution</h3>
+                <h3 id="chapter-6-repeated-execution">Chapter 6 repeated execution</h3>
                 <div class="benchmark-row">
                   <div class="benchmark-label"><strong>Native runner</strong><span>56.73 ms mean</span></div>
                   <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 14.94%"></span></div>
@@ -194,7 +197,7 @@
                 </div>
               </article>
               <article class="benchmark-panel">
-                <h3>Chapter 6 first run and memory</h3>
+                <h3 id="chapter-6-first-run-and-memory">Chapter 6 first run and memory</h3>
                 <div class="benchmark-row">
                   <div class="benchmark-label"><strong>Native cold start</strong><span>336.64 ms</span></div>
                   <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
@@ -213,7 +216,7 @@
                 </div>
               </article>
               <article class="benchmark-panel">
-                <h3>Chapter 13 reference runtime</h3>
+                <h3 id="chapter-13-reference-runtime">Chapter 13 reference runtime</h3>
                 <div class="benchmark-row">
                   <div class="benchmark-label"><strong>Release CLI binary</strong><span>947.95 KiB</span></div>
                   <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 100%"></span></div>
@@ -235,7 +238,7 @@
           </section>
 
           <section>
-            <h2>Chapter 4: minimal portable evaluator</h2>
+            <h2 id="chapter-4-minimal-portable-evaluator">Chapter 4: minimal portable evaluator</h2>
             <p>
               Chapter 4 is the right first footprint proof because it shows the smallest portable unit in the repo: one contract, one
               deterministic evaluator, and one WASI boundary.
@@ -286,7 +289,7 @@
           </section>
 
           <section>
-            <h2>Chapter 6: portability proof under two runtime targets</h2>
+            <h2 id="chapter-6-portability-proof-under-two-runtime-targets">Chapter 6: portability proof under two runtime targets</h2>
             <p>
               Chapter 6 is the more interesting benchmark because it keeps one contract and one shared service behavior while running it
               through both a native path and a WASI path.
@@ -337,7 +340,7 @@
           </section>
 
           <section>
-            <h2>Chapter 13: reference runtime CLI</h2>
+            <h2 id="chapter-13-reference-runtime-cli">Chapter 13: reference runtime CLI</h2>
             <p>
               The earlier chapters prove compact portability. Chapter 13 adds a different kind of evidence: the reference runtime can
               still expose a deterministic local path without dragging the benchmark through the model-backed AI setup. The measured slice
@@ -380,7 +383,7 @@
           </section>
 
           <section>
-            <h2>What these numbers actually prove</h2>
+            <h2 id="what-these-numbers-actually-prove">What these numbers actually prove</h2>
             <p>
               The important result is not that every portable path is the fastest. The important result is that the portable path remains
               compact, measurable, and behaviorally comparable. That gives teams a much cleaner basis for deciding where logic should run
@@ -417,7 +420,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/book/index.html
+++ b/book-site/book/index.html
@@ -3,38 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Universal Microservices Architecture Book</title>
-    <meta
-      name="description"
-      content="A practical overview of the Universal Microservices Architecture book, including what it teaches, who it helps, and how it connects to the runnable examples."
-    />
+    <title>Universal Microservices Architecture Book | Universal Microservices Architecture</title>
+    <meta name="description" content="A practical overview of the Universal Microservices Architecture book, including what it teaches, who it helps, and how it connects to the runnable examples." />
     <link rel="canonical" href="https://www.universalmicroservices.com/book/" />
     <meta property="og:title" content="Universal Microservices Architecture Book" />
-    <meta
-      property="og:description"
-      content="Discover what the Universal Microservices Architecture book covers, why it matters, and how it connects architecture concepts to runnable examples."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:description" content="A practical overview of the Universal Microservices Architecture book, including what it teaches, who it helps, and how it connects to the runnable examples." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/book/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Universal Microservices Architecture Book","item":"https://www.universalmicroservices.com/book/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Universal Microservices Architecture Book","description":"A practical overview of the Universal Microservices Architecture book, including what it teaches, who it helps, and how it connects to the runnable examples.","url":"https://www.universalmicroservices.com/book/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,63 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-readers-should-expect">What readers should expect</a>
+    <ul class="page-rail-links">
+      <li><a href="#what-problem-it-tackles">What problem it tackles</a></li><li><a href="#what-the-reader-gets">What the reader gets</a></li><li><a href="#what-keeps-it-honest">What keeps it honest</a></li><li><a href="#who-it-is-for">Who it is for</a></li>
+    </ul></li><li><a href="#how-the-book-is-organized">How the book is organized</a>
+    <ul class="page-rail-links">
+      <li><a href="#portable-service-design">Portable service design</a></li><li><a href="#runtime-architecture">Runtime architecture</a></li><li><a href="#system-composition">System composition</a></li><li><a href="#evolution-over-time">Evolution over time</a></li>
+    </ul></li><li><a href="#why-the-book-matters-now">Why the book matters now</a></li><li><a href="#who-should-read-it">Who should read it</a></li><li><a href="#what-makes-it-different">What makes it different</a></li><li><a href="#how-it-connects-to-the-site-and-examples">How it connects to the site and examples</a></li><li><a href="#frequently-asked-question">Frequently asked question</a>
+    <ul class="page-rail-links">
+      <li><a href="#do-i-need-to-adopt-uma-all-at-once">Do I need to adopt UMA all at once?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Universal Microservices Architecture Book</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>The Universal Microservices Architecture book</h1>
           <p>
             This book is for architects and senior engineers who can already ship distributed systems, but are no longer satisfied with how
@@ -79,9 +103,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>What readers should expect</h2>
+            <h2 id="what-readers-should-expect">What readers should expect</h2>
             <p>
               The book is not a vague argument that portability is good. It works from the smallest portable service boundary outward into
               runtime design, contracts, orchestration, service graph evolution, trust boundaries, discoverable decisions, and long-term
@@ -91,25 +115,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>What problem it tackles</h3>
+              <h3 id="what-problem-it-tackles">What problem it tackles</h3>
               <p>Why systems keep duplicating business behavior across runtimes even when the team already has good deployment tooling.</p>
             </article>
             <article class="subpage-card">
-              <h3>What the reader gets</h3>
+              <h3 id="what-the-reader-gets">What the reader gets</h3>
               <p>A structured architectural model for portable services, governed runtime decisions, and explainable workflow execution.</p>
             </article>
             <article class="subpage-card">
-              <h3>What keeps it honest</h3>
+              <h3 id="what-keeps-it-honest">What keeps it honest</h3>
               <p>A companion repository and live reference app that let readers inspect the model instead of taking the claims on faith.</p>
             </article>
             <article class="subpage-card">
-              <h3>Who it is for</h3>
+              <h3 id="who-it-is-for">Who it is for</h3>
               <p>Architects, senior engineers, and platform teams trying to keep behavior coherent across client, edge, cloud, and AI surfaces.</p>
             </article>
           </section>
 
           <section>
-            <h2>How the book is organized</h2>
+            <h2 id="how-the-book-is-organized">How the book is organized</h2>
             <p>
               The book is structured as a progression rather than as an encyclopedia. It begins with one portable service boundary and then
               deliberately adds the runtime concerns that real systems accumulate: contracts, orchestration, metadata, compatibility,
@@ -125,25 +149,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Portable service design</h3>
+              <h3 id="portable-service-design">Portable service design</h3>
               <p>Learn how to preserve business behavior without letting any one framework or host environment own the logic.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime architecture</h3>
+              <h3 id="runtime-architecture">Runtime architecture</h3>
               <p>See how validation, transport, adapters, policy, and trust become explicit parts of the system model.</p>
             </article>
             <article class="subpage-card">
-              <h3>System composition</h3>
+              <h3 id="system-composition">System composition</h3>
               <p>Follow the path from a single service to event-driven orchestration, service graphs, and runtime-governed systems.</p>
             </article>
             <article class="subpage-card">
-              <h3>Evolution over time</h3>
+              <h3 id="evolution-over-time">Evolution over time</h3>
               <p>Understand how portability, governance, and compatibility interact as a system grows more complex.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why the book matters now</h2>
+            <h2 id="why-the-book-matters-now">Why the book matters now</h2>
             <p>
               Modern delivery models already assume software will move between many execution contexts. The real architectural challenge is
               not simply shipping code to multiple runtimes. It is keeping the meaning of the system stable while those runtimes continue to
@@ -157,7 +181,7 @@
           </section>
 
           <section>
-            <h2>Who should read it</h2>
+            <h2 id="who-should-read-it">Who should read it</h2>
             <p>
               This book is written for people who are responsible for architectural clarity over time. That includes software architects,
               senior engineers, platform teams, and technical leads who need a better way to think about service behavior, runtime
@@ -166,7 +190,7 @@
           </section>
 
           <section>
-            <h2>What makes it different</h2>
+            <h2 id="what-makes-it-different">What makes it different</h2>
             <p>
               Many architecture books stay abstract. Many implementation books stay tied to one stack. This book sits between those two
               worlds. It introduces a concrete architectural model, but keeps the discussion close to runtime behavior, operational
@@ -176,7 +200,7 @@
           </section>
 
           <section>
-            <h2>How it connects to the site and examples</h2>
+            <h2 id="how-it-connects-to-the-site-and-examples">How it connects to the site and examples</h2>
             <p>
               The site acts as the authority hub for the book, while the repository acts as the practical companion. Together they turn the
               material into a connected experience: understand the idea, follow the learning path, inspect the code, and validate the
@@ -192,8 +216,8 @@
           </section>
 
           <section>
-            <h2>Frequently asked question</h2>
-            <h3>Do I need to adopt UMA all at once?</h3>
+            <h2 id="frequently-asked-question">Frequently asked question</h2>
+            <h3 id="do-i-need-to-adopt-uma-all-at-once">Do I need to adopt UMA all at once?</h3>
             <p>
               No. One of the practical strengths of the model is that it can begin with a single portable service and then expand as runtime
               and governance complexity increase. The book is sequenced that way intentionally.
@@ -219,7 +243,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/common-criticisms-and-tradeoffs-of-uma/index.html
+++ b/book-site/common-criticisms-and-tradeoffs-of-uma/index.html
@@ -6,16 +6,20 @@
     <title>Common Criticisms and Tradeoffs of UMA | Universal Microservices Architecture</title>
     <meta name="description" content="A credible look at UMA tradeoffs, including learning curve, runtime complexity, governance needs, and organizational readiness." />
     <link rel="canonical" href="https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/" />
-    <meta property="og:title" content="Common Criticisms and Tradeoffs of UMA | Universal Microservices Architecture" />
-    <meta property="og:description" content="A practical discussion of UMA criticisms and tradeoffs for teams evaluating the model." />
+    <meta property="og:title" content="Common Criticisms and Tradeoffs of UMA" />
+    <meta property="og:description" content="A credible look at UMA tradeoffs, including learning curve, runtime complexity, governance needs, and organizational readiness." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Common criticisms and tradeoffs of UMA","description":"A credible look at UMA tradeoffs, including learning curve, runtime complexity, governance needs, and organizational readiness.","url":"https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Common Criticisms and Tradeoffs of UMA","item":"https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Common Criticisms and Tradeoffs of UMA","description":"A credible look at UMA tradeoffs, including learning curve, runtime complexity, governance needs, and organizational readiness.","url":"https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -26,53 +30,103 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-learning-curve-is-real">The learning curve is real</a></li><li><a href="#runtime-complexity-does-not-disappear">Runtime complexity does not disappear</a></li><li><a href="#governance-becomes-part-of-the-architecture">Governance becomes part of the architecture</a></li><li><a href="#organizational-readiness-matters">Organizational readiness matters</a></li><li><a href="#when-uma-may-be-too-much">When UMA may be too much</a>
+    <ul class="page-rail-links">
+      <li><a href="#criticism">Criticism</a></li><li><a href="#response">Response</a></li><li><a href="#criticism-2">Criticism</a></li><li><a href="#response-2">Response</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Common Criticisms and Tradeoffs of UMA</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Common criticisms and tradeoffs of UMA</h1>
           <p>UMA is not a free upgrade to every architecture. It introduces a stronger model for portable behavior, but that model brings learning curve, runtime design work, governance responsibility, and organizational questions. Those tradeoffs are real and should be evaluated directly.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>The learning curve is real</h2>
+            <h2 id="the-learning-curve-is-real">The learning curve is real</h2>
             <p>UMA asks teams to separate behavior, contract, runtime, adapter, trust, and workflow concerns more deliberately than many stack-first systems do. That can feel heavier at first.</p>
             <p>The tradeoff is clarity. A team pays some design cost upfront to reduce hidden duplication later.</p>
           </section>
 
           <section>
-            <h2>Runtime complexity does not disappear</h2>
+            <h2 id="runtime-complexity-does-not-disappear">Runtime complexity does not disappear</h2>
             <p>A portable service still needs a runtime. Validation, transport, placement, events, observability, and policy all have to live somewhere.</p>
             <p>UMA does not remove runtime complexity. It makes that complexity explicit so teams can reason about it.</p>
           </section>
 
           <section>
-            <h2>Governance becomes part of the architecture</h2>
+            <h2 id="governance-becomes-part-of-the-architecture">Governance becomes part of the architecture</h2>
             <p>Portability without governance can make risk travel faster. A service that runs in more contexts needs clearer trust boundaries, versioning, and authority checks.</p>
             <p>This is one reason the book treats governance as core methodology rather than as a late production appendix.</p>
           </section>
 
           <section>
-            <h2>Organizational readiness matters</h2>
+            <h2 id="organizational-readiness-matters">Organizational readiness matters</h2>
             <p>UMA works best when teams can agree on capability ownership and runtime responsibility. If every team optimizes only for its local stack, the model will be hard to sustain.</p>
             <p>That does not mean the organization must transform all at once. It means adoption should begin where the ownership problem is visible.</p>
           </section>
 
           <section>
-            <h2>When UMA may be too much</h2>
+            <h2 id="when-uma-may-be-too-much">When UMA may be too much</h2>
             <p>If a service has one stable deployment surface, little duplicated behavior, and no meaningful runtime diversity, UMA may not repay the design cost. The point is to apply it where portability and governance are actually needed.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Criticism</h3><p>It can feel more complex than a local service implementation.</p></article>
-            <article class="subpage-card"><h3>Response</h3><p>The complexity already exists when behavior crosses runtimes. UMA makes it visible.</p></article>
-            <article class="subpage-card"><h3>Criticism</h3><p>It requires governance discipline.</p></article>
-            <article class="subpage-card"><h3>Response</h3><p>That discipline is necessary when portable behavior becomes operationally important.</p></article>
+            <article class="subpage-card"><h3 id="criticism">Criticism</h3><p>It can feel more complex than a local service implementation.</p></article>
+            <article class="subpage-card"><h3 id="response">Response</h3><p>The complexity already exists when behavior crosses runtimes. UMA makes it visible.</p></article>
+            <article class="subpage-card"><h3 id="criticism-2">Criticism</h3><p>It requires governance discipline.</p></article>
+            <article class="subpage-card"><h3 id="response-2">Response</h3><p>That discipline is necessary when portable behavior becomes operationally important.</p></article>
           </section>
           <section class="subpage-callout">
             <strong>Want to go deeper?</strong>

--- a/book-site/contract-driven-orchestration/index.html
+++ b/book-site/contract-driven-orchestration/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Contract-Driven Orchestration | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn how contract-driven orchestration works in UMA, where events, policies, and metadata shape execution without hardcoded workflow glue."
-    />
+    <meta name="description" content="Learn how contract-driven orchestration works in UMA, where events, policies, and metadata shape execution without hardcoded workflow glue." />
     <link rel="canonical" href="https://www.universalmicroservices.com/contract-driven-orchestration/" />
-    <meta property="og:title" content="Contract-Driven Orchestration | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to contract-driven orchestration in UMA: events create governed bindings, policies shape execution, and telemetry keeps the flow auditable."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Contract-Driven Orchestration" />
+    <meta property="og:description" content="Learn how contract-driven orchestration works in UMA, where events, policies, and metadata shape execution without hardcoded workflow glue." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/contract-driven-orchestration/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "Contract-Driven Orchestration",
-  "description": "An original explanation of contract-driven orchestration in Universal Microservices Architecture and why governed bindings, policy-aware execution, and telemetry make orchestration more visible than hardcoded process glue.",
-  "url": "https://www.universalmicroservices.com/contract-driven-orchestration/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/contract-driven-orchestration/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Contract-Driven Orchestration","item":"https://www.universalmicroservices.com/contract-driven-orchestration/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Contract-Driven Orchestration","description":"Learn how contract-driven orchestration works in UMA, where events, policies, and metadata shape execution without hardcoded workflow glue.","url":"https://www.universalmicroservices.com/contract-driven-orchestration/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-contracts-matter-more-than-glue-code">Why contracts matter more than glue code</a></li><li><a href="#how-events-and-subscriptions-create-the-path">How events and subscriptions create the path</a>
+    <ul class="page-rail-links">
+      <li><a href="#contracts-define-possibilities">Contracts define possibilities</a></li><li><a href="#policies-shape-execution">Policies shape execution</a></li><li><a href="#telemetry-proves-behavior">Telemetry proves behavior</a></li><li><a href="#determinism-still-matters">Determinism still matters</a></li>
+    </ul></li><li><a href="#why-policy-belongs-inside-the-orchestration-path">Why policy belongs inside the orchestration path</a></li><li><a href="#why-telemetry-matters-here">Why telemetry matters here</a></li><li><a href="#what-this-is-not">What this is not</a></li><li><a href="#a-practical-design-test">A practical design test</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-contract-driven-orchestration-the-same-as-event-driven-architecture">Is contract-driven orchestration the same as event-driven architecture?</a></li><li><a href="#does-this-remove-the-need-for-a-workflow-model">Does this remove the need for a workflow model?</a></li><li><a href="#why-is-telemetry-part-of-the-concept-instead-of-a-later-operational-topic">Why is telemetry part of the concept instead of a later operational topic?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Contract-Driven Orchestration</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Contract-driven orchestration</h1>
           <p>
             In UMA, orchestration becomes more durable when it emerges from contracts, events, metadata, and policy instead of being
@@ -96,9 +99,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               Contract-driven orchestration means the runtime uses declared event and capability relationships to create the execution path,
               rather than relying on a hand-wired chain of process calls. The contracts describe what can emit, what can subscribe, and
@@ -112,7 +115,7 @@
           </section>
 
           <section>
-            <h2>Why contracts matter more than glue code</h2>
+            <h2 id="why-contracts-matter-more-than-glue-code">Why contracts matter more than glue code</h2>
             <p>
               A hardcoded workflow can still work, but it tends to make orchestration fragile and stack-bound. The orchestration logic
               becomes a private implementation detail rather than a visible architectural fact. Contracts change that. They make the
@@ -125,7 +128,7 @@
           </section>
 
           <section>
-            <h2>How events and subscriptions create the path</h2>
+            <h2 id="how-events-and-subscriptions-create-the-path">How events and subscriptions create the path</h2>
             <p>
               In a contract-driven model, emitted events are not just messages flying around the system. They are declared architectural
               signals that other capabilities can subscribe to under known conditions. That makes orchestration feel less like a hidden
@@ -139,25 +142,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Contracts define possibilities</h3>
+              <h3 id="contracts-define-possibilities">Contracts define possibilities</h3>
               <p>The system can see what may emit, what may subscribe, and what compatibility rules shape the flow.</p>
             </article>
             <article class="subpage-card">
-              <h3>Policies shape execution</h3>
+              <h3 id="policies-shape-execution">Policies shape execution</h3>
               <p>Execution mode can change without rewriting the services themselves because policy stays in the runtime path.</p>
             </article>
             <article class="subpage-card">
-              <h3>Telemetry proves behavior</h3>
+              <h3 id="telemetry-proves-behavior">Telemetry proves behavior</h3>
               <p>Evidence about bindings, validation, and subscriber execution keeps orchestration auditable.</p>
             </article>
             <article class="subpage-card">
-              <h3>Determinism still matters</h3>
+              <h3 id="determinism-still-matters">Determinism still matters</h3>
               <p>A governed orchestration path should remain repeatable enough to inspect and verify under the same conditions.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why policy belongs inside the orchestration path</h2>
+            <h2 id="why-policy-belongs-inside-the-orchestration-path">Why policy belongs inside the orchestration path</h2>
             <p>
               Policy is most useful when it shapes execution at the moment orchestration becomes real. If policy is only an external
               review step, the system can still drift toward undocumented local behavior. When policy stays in the path, the runtime can
@@ -170,7 +173,7 @@
           </section>
 
           <section>
-            <h2>Why telemetry matters here</h2>
+            <h2 id="why-telemetry-matters-here">Why telemetry matters here</h2>
             <p>
               Telemetry is often treated as a later operational concern. In contract-driven orchestration, it becomes architectural
               evidence. If the runtime creates a binding, validates an event, dispatches a subscriber, or changes behavior because of
@@ -183,7 +186,7 @@
           </section>
 
           <section>
-            <h2>What this is not</h2>
+            <h2 id="what-this-is-not">What this is not</h2>
             <ul>
               <li>It is not a claim that every workflow should be fully dynamic.</li>
               <li>It is not an argument against simple deterministic flows.</li>
@@ -194,7 +197,7 @@
           </section>
 
           <section>
-            <h2>A practical design test</h2>
+            <h2 id="a-practical-design-test">A practical design test</h2>
             <p>
               Ask whether your system can explain why a particular binding existed. Was it declared through contracts and metadata? Was it
               allowed by policy? Can the runtime show evidence that it validated and dispatched the path intentionally? If not, the system
@@ -207,18 +210,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is contract-driven orchestration the same as event-driven architecture?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-contract-driven-orchestration-the-same-as-event-driven-architecture">Is contract-driven orchestration the same as event-driven architecture?</h3>
             <p>
               Not exactly. Events are part of it, but the important UMA distinction is that contracts, policies, and runtime validation
               keep the event relationships governed instead of implicit.
             </p>
-            <h3>Does this remove the need for a workflow model?</h3>
+            <h3 id="does-this-remove-the-need-for-a-workflow-model">Does this remove the need for a workflow model?</h3>
             <p>
               No. It changes how the workflow becomes real. The path is no longer just a handwritten chain; it is something the runtime can
               justify from the declared relationships.
             </p>
-            <h3>Why is telemetry part of the concept instead of a later operational topic?</h3>
+            <h3 id="why-is-telemetry-part-of-the-concept-instead-of-a-later-operational-topic">Why is telemetry part of the concept instead of a later operational topic?</h3>
             <p>
               Because telemetry is what turns orchestration into evidence. Without it, teams are left trusting the flow rather than being
               able to inspect it.
@@ -245,7 +248,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/diagrams/index.html
+++ b/book-site/diagrams/index.html
@@ -3,38 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>UMA Diagrams</title>
-    <meta
-      name="description"
-      content="Structured UMA diagrams for service boundaries, runtime flow, trust decisions, service graph evolution, governed evolution without fragmentation, and discoverable decision lifecycles."
-    />
+    <title>UMA Diagrams | Universal Microservices Architecture</title>
+    <meta name="description" content="Structured UMA diagrams for service boundaries, runtime flow, trust decisions, service graph evolution, governed evolution without fragmentation, and discoverable decision lifecycles." />
     <link rel="canonical" href="https://www.universalmicroservices.com/diagrams/" />
     <meta property="og:title" content="UMA Diagrams" />
-    <meta
-      property="og:description"
-      content="UMA diagrams showing portable service boundaries, runtime flow, trust decisions, service graph evolution, governed evolution without fragmentation, and discoverable decision lifecycles."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:description" content="Structured UMA diagrams for service boundaries, runtime flow, trust decisions, service graph evolution, governed evolution without fragmentation, and discoverable decision lifecycles." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/diagrams/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA Diagrams","item":"https://www.universalmicroservices.com/diagrams/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA Diagrams","description":"Structured UMA diagrams for service boundaries, runtime flow, trust decisions, service graph evolution, governed evolution without fragmentation, and discoverable decision lifecycles.","url":"https://www.universalmicroservices.com/diagrams/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,54 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#why-diagram-curation-matters">Why diagram curation matters</a></li><li><a href="#diagram-conventions">Diagram conventions</a></li><li><a href="#diagram-1-portable-service-boundary">Diagram 1: Portable service boundary</a></li><li><a href="#diagram-2-runtime-execution-flow">Diagram 2: Runtime execution flow</a></li><li><a href="#diagram-3-trust-boundary-decision">Diagram 3: Trust boundary decision</a></li><li><a href="#diagram-4-service-graph-evolution">Diagram 4: Service graph evolution</a></li><li><a href="#diagram-5-evolution-without-fragmentation">Diagram 5: Evolution without fragmentation</a></li><li><a href="#diagram-6-discoverable-decision-lifecycle">Diagram 6: Discoverable decision lifecycle</a></li><li><a href="#how-to-choose-the-right-diagram">How to choose the right diagram</a></li><li><a href="#download-the-current-diagram-set">Download the current diagram set</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA Diagrams</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>UMA diagrams</h1>
           <p>
             This page collects reusable diagrams for Universal Microservices Architecture. Each section explains what the diagram is trying
@@ -79,9 +94,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>Why diagram curation matters</h2>
+            <h2 id="why-diagram-curation-matters">Why diagram curation matters</h2>
             <p>
               UMA depends on architectural visibility. The more clearly a team can show service boundaries, runtime transitions, trust
               decisions, and compatibility relationships, the easier the model is to teach, review, and evolve. These diagrams are designed
@@ -95,7 +110,7 @@
           </section>
 
           <section>
-            <h2>Diagram conventions</h2>
+            <h2 id="diagram-conventions">Diagram conventions</h2>
             <p>
               The diagrams on this page reuse the same conventions so readers do not need to learn a new visual language each time. Portable
               service behavior is highlighted as the part that must remain stable. Runtime-owned elements are shown separately so transport,
@@ -111,7 +126,7 @@
           </section>
 
           <section>
-            <h2>Diagram 1: Portable service boundary</h2>
+            <h2 id="diagram-1-portable-service-boundary">Diagram 1: Portable service boundary</h2>
             <p>
               This diagram shows the core UMA split between pure service behavior and the runtime shell that validates input, binds adapters,
               and decides where execution happens. The point is to make the portable unit of behavior explicit instead of burying it inside a
@@ -160,7 +175,7 @@
           </section>
 
           <section>
-            <h2>Diagram 2: Runtime execution flow</h2>
+            <h2 id="diagram-2-runtime-execution-flow">Diagram 2: Runtime execution flow</h2>
             <p>
               UMA is not only about where behavior lives. It is also about how the runtime executes that behavior predictably. This sequence
               shows the flow from request to validation, service execution, adapter access, and final response without hiding the runtime
@@ -209,7 +224,7 @@
           </section>
 
           <section>
-            <h2>Diagram 3: Trust boundary decision</h2>
+            <h2 id="diagram-3-trust-boundary-decision">Diagram 3: Trust boundary decision</h2>
             <p>
               Trust decisions in UMA should not be implicit. This diagram shows a simplified runtime trust flow where identity, policy, and
               capability intent are evaluated before the runtime allows a protected service to execute. It is a useful pattern for pages that
@@ -256,7 +271,7 @@
           </section>
 
           <section>
-            <h2>Diagram 4: Service graph evolution</h2>
+            <h2 id="diagram-4-service-graph-evolution">Diagram 4: Service graph evolution</h2>
             <p>
               Once systems grow beyond one portable service, teams need to visualize how compatible capabilities form a graph. This diagram
               shows a simple evolution path from a single service to a governed graph, where contracts and metadata keep relationships
@@ -311,7 +326,7 @@
           </section>
 
           <section>
-            <h2>Diagram 5: Evolution without fragmentation</h2>
+            <h2 id="diagram-5-evolution-without-fragmentation">Diagram 5: Evolution without fragmentation</h2>
             <p>
               This diagram captures a progression many teams recognize but rarely name clearly. One contract anchor stretches into
               behavioral drift, drift leads to duplication, duplication hardens into version sprawl, and then the architecture either
@@ -363,7 +378,7 @@
           </section>
 
           <section>
-            <h2>Diagram 6: Discoverable decision lifecycle</h2>
+            <h2 id="diagram-6-discoverable-decision-lifecycle">Diagram 6: Discoverable decision lifecycle</h2>
             <p>
               This diagram shows the decision ladder that becomes a first-class architectural topic in the later UMA examples.
               Discoverability is not only about surfacing which capabilities exist. It is about surfacing how a projected path became a
@@ -410,7 +425,7 @@
           </section>
 
           <section>
-            <h2>How to choose the right diagram</h2>
+            <h2 id="how-to-choose-the-right-diagram">How to choose the right diagram</h2>
             <p>
               Use the service boundary diagram when the question is about separation of concerns. Use the execution flow when the question is
               about what a runtime actually does. Use the trust diagram when readers need to see where permissions and policy are enforced.
@@ -427,7 +442,7 @@
           </section>
 
           <section>
-            <h2>Download the current diagram set</h2>
+            <h2 id="download-the-current-diagram-set">Download the current diagram set</h2>
             <p>
               Every diagram on this page has a downloadable source file so the same visual models can move into repository documentation,
               issue discussions, architecture notes, and future chapter pages. That keeps the diagrams reusable and versionable instead of
@@ -463,27 +478,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
-    <script type="module">
-      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
-
-      mermaid.initialize({
-        startOnLoad: true,
-        theme: "dark",
-        securityLevel: "loose",
-        themeVariables: {
-          background: "#0d0d0d",
-          primaryColor: "#151515",
-          primaryTextColor: "#ffffff",
-          primaryBorderColor: "#ffc501",
-          lineColor: "#bfb8a2",
-          tertiaryColor: "#111111",
-          fontFamily: "Space Grotesk, sans-serif",
-          clusterBkg: "#111111",
-          clusterBorder: "#4a4a4a"
-        }
-      });
-    </script>
   </body>
 </html>

--- a/book-site/end-to-end-feature-flag-example/index.html
+++ b/book-site/end-to-end-feature-flag-example/index.html
@@ -6,16 +6,20 @@
     <title>End-to-End UMA Example: Feature Flag Service | Universal Microservices Architecture</title>
     <meta name="description" content="Follow an end-to-end UMA feature flag service from requirement to capability, contract, build, browser execution, cloud execution, and AI-assisted execution." />
     <link rel="canonical" href="https://www.universalmicroservices.com/end-to-end-feature-flag-example/" />
-    <meta property="og:title" content="End-to-End UMA Example: Feature Flag Service | Universal Microservices Architecture" />
-    <meta property="og:description" content="A complete conceptual walkthrough of a UMA feature flag service from requirement to runtime execution." />
+    <meta property="og:title" content="End-to-End UMA Example: Feature Flag Service" />
+    <meta property="og:description" content="Follow an end-to-end UMA feature flag service from requirement to capability, contract, build, browser execution, cloud execution, and AI-assisted execution." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/end-to-end-feature-flag-example/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"End-to-end UMA example: feature flag service","description":"Follow an end-to-end UMA feature flag service from requirement to capability, contract, build, browser execution, cloud execution, and AI-assisted execution.","url":"https://www.universalmicroservices.com/end-to-end-feature-flag-example/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/end-to-end-feature-flag-example/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"End-to-End UMA Example: Feature Flag Service","item":"https://www.universalmicroservices.com/end-to-end-feature-flag-example/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"End-to-End UMA Example: Feature Flag Service","description":"Follow an end-to-end UMA feature flag service from requirement to capability, contract, build, browser execution, cloud execution, and AI-assisted execution.","url":"https://www.universalmicroservices.com/end-to-end-feature-flag-example/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -26,60 +30,110 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#1-requirement">1. Requirement</a></li><li><a href="#2-capability">2. Capability</a></li><li><a href="#3-contract">3. Contract</a></li><li><a href="#4-build">4. Build</a></li><li><a href="#5-browser-execution">5. Browser execution</a></li><li><a href="#6-cloud-execution">6. Cloud execution</a></li><li><a href="#7-ai-assisted-execution">7. AI-assisted execution</a>
+    <ul class="page-rail-links">
+      <li><a href="#website">Website</a></li><li><a href="#github">GitHub</a></li><li><a href="#book">Book</a></li><li><a href="#runtime">Runtime</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">End-to-End UMA Example: Feature Flag Service</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>End-to-end UMA example: feature flag service</h1>
           <p>A feature flag service is a useful end-to-end UMA example because the business behavior is small, testable, and easy to duplicate badly. The same decision often appears in frontend checks, backend authority, edge routing, and workflow logic. UMA turns that repeated rule into one governed capability.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>1. Requirement</h2>
+            <h2 id="1-requirement">1. Requirement</h2>
             <p>The product needs to decide whether a feature is enabled for a user. The decision may depend on country, account, rollout percentage, or a fallback rule. The important part is that every runtime should agree on the same outcome.</p>
           </section>
 
           <section>
-            <h2>2. Capability</h2>
+            <h2 id="2-capability">2. Capability</h2>
             <p>The capability is feature flag evaluation. It is narrow enough to test and important enough to keep coherent. That makes it a good first Universal Microservice candidate.</p>
           </section>
 
           <section>
-            <h2>3. Contract</h2>
+            <h2 id="3-contract">3. Contract</h2>
             <p>The contract defines the input context, flag rules, and decision output. A reader should be able to inspect the contract without needing to understand a specific UI framework or cloud provider.</p>
             <p>The contract is where the service becomes understandable before it becomes deployable.</p>
           </section>
 
           <section>
-            <h2>4. Build</h2>
+            <h2 id="4-build">4. Build</h2>
             <p>The portable core implements deterministic evaluation. In the repository, the Rust-first path is the authoritative implementation, with TypeScript parity where present to make comparison visible.</p>
           </section>
 
           <section>
-            <h2>5. Browser execution</h2>
+            <h2 id="5-browser-execution">5. Browser execution</h2>
             <p>A browser can use the capability when low-latency local decisions are appropriate. The runtime still has to decide which data is safe and which decisions require backend authority.</p>
           </section>
 
           <section>
-            <h2>6. Cloud execution</h2>
+            <h2 id="6-cloud-execution">6. Cloud execution</h2>
             <p>Cloud execution can provide authority, auditability, and integration with backend systems. UMA does not force the choice. It makes the runtime decision explicit.</p>
           </section>
 
           <section>
-            <h2>7. AI-assisted execution</h2>
+            <h2 id="7-ai-assisted-execution">7. AI-assisted execution</h2>
             <p>An AI-assisted flow may propose a flag change, request an evaluation, or summarize rollout behavior. The runtime remains authoritative over validation and execution. The agent participates, but it does not become the system of record.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Website</h3><p>Conceptual walkthrough of the end-to-end model.</p></article>
-            <article class="subpage-card"><h3>GitHub</h3><p>Runnable examples and validation scripts.</p></article>
-            <article class="subpage-card"><h3>Book</h3><p>Methodology, tradeoffs, governance, and production guidance.</p></article>
-            <article class="subpage-card"><h3>Runtime</h3><p>The authority that decides where execution belongs.</p></article>
+            <article class="subpage-card"><h3 id="website">Website</h3><p>Conceptual walkthrough of the end-to-end model.</p></article>
+            <article class="subpage-card"><h3 id="github">GitHub</h3><p>Runnable examples and validation scripts.</p></article>
+            <article class="subpage-card"><h3 id="book">Book</h3><p>Methodology, tradeoffs, governance, and production guidance.</p></article>
+            <article class="subpage-card"><h3 id="runtime">Runtime</h3><p>The authority that decides where execution belongs.</p></article>
           </section>
           <section class="subpage-callout">
             <strong>Want to go deeper?</strong>

--- a/book-site/examples/chapter-04-feature-flag-evaluator/index.html
+++ b/book-site/examples/chapter-04-feature-flag-evaluator/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 4 Feature Flag Evaluator Tutorial | UMA Examples</title>
+    <title>Chapter 4 Feature Flag Evaluator Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Run the Chapter 4 UMA feature flag evaluator tutorial and learn how one Rust-first portable service keeps deterministic rule behavior aligned with TypeScript parity." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-04-feature-flag-evaluator/" />
     <meta property="og:title" content="Chapter 4 Feature Flag Evaluator Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-04-feature-flag-evaluator/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 4 Feature Flag Evaluator Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-04-feature-flag-evaluator/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 4 Feature Flag Evaluator Tutorial","description":"Run the Chapter 4 UMA feature flag evaluator tutorial and learn how one Rust-first portable service keeps deterministic rule behavior aligned with TypeScript parity.","url":"https://www.universalmicroservices.com/examples/chapter-04-feature-flag-evaluator/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 4: Feature Flag Evaluator UMA tutorial","description":"Run the Chapter 4 UMA feature flag evaluator tutorial and learn how one Rust-first portable service keeps deterministic rule behavior aligned with TypeScript parity.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-04-feature-flag-evaluator"},{"@type":"HowToStep","position":2,"name":"List the guided labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Run the country match lab","text":"./scripts/run_lab.sh lab1-country-match"},{"@type":"HowToStep","position":4,"name":"Run the sticky rollout lab","text":"./scripts/run_lab.sh lab2-rollout-match"},{"@type":"HowToStep","position":5,"name":"Run the default fallback lab","text":"./scripts/run_lab.sh lab3-default-fallback"},{"@type":"HowToStep","position":6,"name":"Run the rule language lab","text":"./scripts/run_lab.sh lab4-rule-language"},{"@type":"HowToStep","position":7,"name":"Compare Rust and TypeScript behavior","text":"./scripts/compare_impls.sh"},{"@type":"HowToStep","position":8,"name":"Run the chapter smoke path","text":"./scripts/smoke_flag_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 4: Feature Flag Evaluator","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-04-feature-flag-evaluator","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Run the Chapter 4 UMA feature flag evaluator tutorial and learn how one Rust-first portable service keeps deterministic rule behavior aligned with TypeScript parity."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-05-post-fetcher-runtime/">next: Chapter 5</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-04-feature-flag-evaluator" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 4 Feature Flag Evaluator Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 4 UMA code example</p>
           <h1>Feature flag evaluator tutorial</h1>
           <p>This tutorial walks through the first hands-on UMA example: a deterministic feature flag evaluator with one contract, one portable Rust core, a WASI executable, and a TypeScript parity implementation.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Keep the navigation close to the tutorial itself. Use the links below to move between the source folder, the examples index, and the next chapter without hunting through the footer.</p>
@@ -55,25 +110,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>what belongs in the evaluator contract instead of the host adapter</li><li>how first-match rule evaluation and sticky rollout decisions stay deterministic</li><li>how Rust and TypeScript parity is proven from observable output</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust with the wasm32-wasip1 target</li><li>Wasmtime on your PATH</li><li>Node.js 20 or newer for parity checks</li><li>npm for TypeScript parity and optional adapters</li></ul>
             <p>Run this setup command before the lab if your machine does not already have the target installed.</p><pre class="tutorial-code"><code>rustup target add wasm32-wasip1</code></pre>
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-04-feature-flag-evaluator</code></pre></li><li><strong>List the guided labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Run the country match lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab1-country-match</code></pre></li><li><strong>Run the sticky rollout lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab2-rollout-match</code></pre></li><li><strong>Run the default fallback lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab3-default-fallback</code></pre></li><li><strong>Run the rule language lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab4-rule-language</code></pre></li><li><strong>Compare Rust and TypeScript behavior</strong><pre class="tutorial-code"><code>./scripts/compare_impls.sh</code></pre></li><li><strong>Run the chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_flag_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>enabled</li><li>matchedRule</li><li>the same lab returning the same decision in Rust and TypeScript</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_flag_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -81,12 +136,12 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 5 introduces the runtime layer around a pure service.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-04-feature-flag-evaluator">Open source folder</a>
               <a href="../">All UMA examples</a>
-              
+
               <a href="../chapter-05-post-fetcher-runtime/">Next: Post Fetcher Runtime</a>
             </div>
           </section>

--- a/book-site/examples/chapter-05-post-fetcher-runtime/index.html
+++ b/book-site/examples/chapter-05-post-fetcher-runtime/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 5 Post Fetcher Runtime Tutorial | UMA Examples</title>
+    <title>Chapter 5 Post Fetcher Runtime Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Follow the Chapter 5 UMA post fetcher runtime tutorial to see validation, adapter binding, event ordering, and lifecycle metadata around a pure Rust service." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-05-post-fetcher-runtime/" />
     <meta property="og:title" content="Chapter 5 Post Fetcher Runtime Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-05-post-fetcher-runtime/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 5 Post Fetcher Runtime Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-05-post-fetcher-runtime/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 5 Post Fetcher Runtime Tutorial","description":"Follow the Chapter 5 UMA post fetcher runtime tutorial to see validation, adapter binding, event ordering, and lifecycle metadata around a pure Rust service.","url":"https://www.universalmicroservices.com/examples/chapter-05-post-fetcher-runtime/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 5: Post Fetcher Runtime UMA tutorial","description":"Follow the Chapter 5 UMA post fetcher runtime tutorial to see validation, adapter binding, event ordering, and lifecycle metadata around a pure Rust service.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-05-post-fetcher-runtime"},{"@type":"HowToStep","position":2,"name":"List the guided labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Run the golden cloud host path","text":"./scripts/run_lab.sh lab1-cloud-golden-path"},{"@type":"HowToStep","position":4,"name":"Run fail-fast header validation","text":"./scripts/run_lab.sh lab2-header-validation-fail-fast"},{"@type":"HowToStep","position":5,"name":"Inspect adapter binding and wrappers","text":"./scripts/run_lab.sh lab3-adapter-binding-and-wrappers"},{"@type":"HowToStep","position":6,"name":"Verify Rust and TypeScript parity","text":"./scripts/run_lab.sh lab4-rust-ts-parity"},{"@type":"HowToStep","position":7,"name":"Run the chapter smoke path","text":"./scripts/smoke_runtime_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 5: Post Fetcher Runtime","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-05-post-fetcher-runtime","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Follow the Chapter 5 UMA post fetcher runtime tutorial to see validation, adapter binding, event ordering, and lifecycle metadata around a pure Rust service."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-04-feature-flag-evaluator/">previous: Chapter 4</a></li><li><a href="../chapter-06-portability-lab/">next: Chapter 6</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-05-post-fetcher-runtime" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 5 Post Fetcher Runtime Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 5 UMA code example</p>
           <h1>Post fetcher runtime tutorial</h1>
           <p>This tutorial shows what the UMA runtime layer owns around a pure service: validation, adapter selection, deterministic event ordering, and lifecycle evidence.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Use the links below to move through the tutorial sequence without dropping to the footer first.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>what belongs in service logic versus runtime logic</li><li>why validation should stop execution before side effects happen</li><li>how lifecycle metadata records the network.fetch adapter binding</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.77 or newer</li><li>cargo</li><li>jq</li><li>Node.js and npm for TypeScript parity</li></ul>
-            
+
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-05-post-fetcher-runtime</code></pre></li><li><strong>List the guided labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Run the golden cloud host path</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab1-cloud-golden-path</code></pre></li><li><strong>Run fail-fast header validation</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab2-header-validation-fail-fast</code></pre></li><li><strong>Inspect adapter binding and wrappers</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab3-adapter-binding-and-wrappers</code></pre></li><li><strong>Verify Rust and TypeScript parity</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab4-rust-ts-parity</code></pre></li><li><strong>Run the chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_runtime_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>output.events</li><li>lifecycle.bindings</li><li>final lifecycle.state</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_runtime_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 6 proves portability across native and WASI targets.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-05-post-fetcher-runtime">Open source folder</a>

--- a/book-site/examples/chapter-06-portability-lab/index.html
+++ b/book-site/examples/chapter-06-portability-lab/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 6 UMA Portability Lab Tutorial | UMA Examples</title>
+    <title>Chapter 6 UMA Portability Lab Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Run the Chapter 6 UMA portability tutorial and compare the same image analyzer behavior across native Rust and WASI with shared event payloads." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-06-portability-lab/" />
     <meta property="og:title" content="Chapter 6 UMA Portability Lab Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-06-portability-lab/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 6 UMA Portability Lab Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-06-portability-lab/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 6 UMA Portability Lab Tutorial","description":"Run the Chapter 6 UMA portability tutorial and compare the same image analyzer behavior across native Rust and WASI with shared event payloads.","url":"https://www.universalmicroservices.com/examples/chapter-06-portability-lab/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 6: UMA Portability Lab UMA tutorial","description":"Run the Chapter 6 UMA portability tutorial and compare the same image analyzer behavior across native Rust and WASI with shared event payloads.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-06-portability-lab"},{"@type":"HowToStep","position":2,"name":"List the guided labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Compare native and WASI events","text":"./scripts/run_lab.sh lab1-native-wasm-parity"},{"@type":"HowToStep","position":4,"name":"Compute shared payload digests","text":"./scripts/run_lab.sh lab2-shared-payload-digest"},{"@type":"HowToStep","position":5,"name":"Exercise failure paths and capability gates","text":"./scripts/run_lab.sh lab3-failure-paths-and-capability-gates"},{"@type":"HowToStep","position":6,"name":"Check Rust and TypeScript reference parity","text":"./scripts/run_lab.sh lab4-rust-ts-reference-parity"},{"@type":"HowToStep","position":7,"name":"Run the chapter smoke path","text":"./scripts/smoke_portability_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 6: UMA Portability Lab","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-06-portability-lab","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Run the Chapter 6 UMA portability tutorial and compare the same image analyzer behavior across native Rust and WASI with shared event payloads."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-05-post-fetcher-runtime/">previous: Chapter 5</a></li><li><a href="../chapter-07-metadata-orchestration/">next: Chapter 7</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-06-portability-lab" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 6 UMA Portability Lab Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 6 UMA code example</p>
           <h1>UMA portability lab tutorial</h1>
           <p>This tutorial proves portability through observable behavior. The native runner and WASI runner emit the same image.analyzed payload while target-specific telemetry remains explicit.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Use the links up front so the portability path feels like a guided sequence instead of a footer scavenger hunt.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>how one contract drives native and WASI execution</li><li>why parity should be checked through emitted events</li><li>how native-only capabilities stay outside the portable path</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.77 or newer</li><li>rustup target add wasm32-wasip1</li><li>Wasmtime 20 or newer</li><li>jq</li></ul>
             <p>Run this setup command before the lab if your machine does not already have the target installed.</p><pre class="tutorial-code"><code>rustup target add wasm32-wasip1</code></pre>
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-06-portability-lab</code></pre></li><li><strong>List the guided labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Compare native and WASI events</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab1-native-wasm-parity</code></pre></li><li><strong>Compute shared payload digests</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab2-shared-payload-digest</code></pre></li><li><strong>Exercise failure paths and capability gates</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab3-failure-paths-and-capability-gates</code></pre></li><li><strong>Check Rust and TypeScript reference parity</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab4-rust-ts-reference-parity</code></pre></li><li><strong>Run the chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_portability_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>identical image.analyzed payloads</li><li>matching shared payload digests</li><li>gpu.telemetry.reported only on the native path</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_portability_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 7 uses contracts and events to create orchestration.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-06-portability-lab">Open source folder</a>

--- a/book-site/examples/chapter-07-metadata-orchestration/index.html
+++ b/book-site/examples/chapter-07-metadata-orchestration/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 7 Metadata Orchestration Tutorial | UMA Examples</title>
+    <title>Chapter 7 Metadata Orchestration Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Use the Chapter 7 UMA metadata orchestration tutorial to run a contract-driven flow where bindings, policy, validation, and telemetry are visible." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-07-metadata-orchestration/" />
     <meta property="og:title" content="Chapter 7 Metadata Orchestration Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-07-metadata-orchestration/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 7 Metadata Orchestration Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-07-metadata-orchestration/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 7 Metadata Orchestration Tutorial","description":"Use the Chapter 7 UMA metadata orchestration tutorial to run a contract-driven flow where bindings, policy, validation, and telemetry are visible.","url":"https://www.universalmicroservices.com/examples/chapter-07-metadata-orchestration/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 7: Metadata Orchestration UMA tutorial","description":"Use the Chapter 7 UMA metadata orchestration tutorial to run a contract-driven flow where bindings, policy, validation, and telemetry are visible.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-07-metadata-orchestration"},{"@type":"HowToStep","position":2,"name":"List the guided labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Run the baseline cloud flow","text":"./scripts/run_lab.sh lab1-baseline-cloud-flow"},{"@type":"HowToStep","position":4,"name":"Verify Rust and TypeScript parity","text":"./scripts/run_lab.sh lab2-rust-ts-parity"},{"@type":"HowToStep","position":5,"name":"Run the fail-closed policy lab","text":"./scripts/run_lab.sh lab3-policy-fail-closed"},{"@type":"HowToStep","position":6,"name":"Run the telemetry audit lab","text":"./scripts/run_lab.sh lab4-telemetry-audit"},{"@type":"HowToStep","position":7,"name":"Run the chapter smoke path","text":"./scripts/smoke_orchestration_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 7: Metadata Orchestration","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-07-metadata-orchestration","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Use the Chapter 7 UMA metadata orchestration tutorial to run a contract-driven flow where bindings, policy, validation, and telemetry are visible."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-06-portability-lab/">previous: Chapter 6</a></li><li><a href="../chapter-08-service-graph/">next: Chapter 8</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-07-metadata-orchestration" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 7 Metadata Orchestration Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 7 UMA code example</p>
           <h1>Metadata orchestration tutorial</h1>
           <p>This tutorial shows orchestration emerging from contracts and events instead of hardcoded workflow steps. The Rust cloud runner is the validated path, with TypeScript kept in parity.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Keep the primary navigation alongside the lesson so the contract and policy links are visible before you reach the footer.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>how emits and subscribes create runtime bindings</li><li>how policy fail-open and fail-closed modes affect execution</li><li>how CloudEvents and telemetry prove orchestration behavior</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.76 or newer</li><li>Wasmtime 20 or newer</li><li>Node.js 20 or newer</li><li>jq and yq are optional</li></ul>
-            
+
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-07-metadata-orchestration</code></pre></li><li><strong>List the guided labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Run the baseline cloud flow</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab1-baseline-cloud-flow</code></pre></li><li><strong>Verify Rust and TypeScript parity</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab2-rust-ts-parity</code></pre></li><li><strong>Run the fail-closed policy lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab3-policy-fail-closed</code></pre></li><li><strong>Run the telemetry audit lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab4-telemetry-audit</code></pre></li><li><strong>Run the chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_orchestration_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>binding.created</li><li>policy.violation</li><li>validation.passed</li><li>telemetry.ok</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_orchestration_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 8 makes service graph evolution inspectable.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-07-metadata-orchestration">Open source folder</a>

--- a/book-site/examples/chapter-08-service-graph/index.html
+++ b/book-site/examples/chapter-08-service-graph/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 8 Service Graph Evolution Tutorial | UMA Examples</title>
+    <title>Chapter 8 Service Graph Evolution Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Follow the Chapter 8 UMA service graph tutorial to inspect graph growth, compatibility breaks, and recovery using Rust-first scenario snapshots and diffs." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-08-service-graph/" />
     <meta property="og:title" content="Chapter 8 Service Graph Evolution Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-08-service-graph/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 8 Service Graph Evolution Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-08-service-graph/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 8 Service Graph Evolution Tutorial","description":"Follow the Chapter 8 UMA service graph tutorial to inspect graph growth, compatibility breaks, and recovery using Rust-first scenario snapshots and diffs.","url":"https://www.universalmicroservices.com/examples/chapter-08-service-graph/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 8: Service Graph Evolution UMA tutorial","description":"Follow the Chapter 8 UMA service graph tutorial to inspect graph growth, compatibility breaks, and recovery using Rust-first scenario snapshots and diffs.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-08-service-graph"},{"@type":"HowToStep","position":2,"name":"List the graph labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Validate the first scenario contracts","text":"./scripts/validate_graph_contracts.sh lab1-upload-only"},{"@type":"HowToStep","position":4,"name":"Run the upload-only graph","text":"./scripts/run_graph_demo.sh lab1-upload-only"},{"@type":"HowToStep","position":5,"name":"Inspect the contract change to image tagging","text":"./scripts/contract_diff.sh lab1-upload-only lab2-image-tagger"},{"@type":"HowToStep","position":6,"name":"Run the indexer graph","text":"./scripts/run_graph_demo.sh lab3-indexer"},{"@type":"HowToStep","position":7,"name":"Compare a compatibility break","text":"./scripts/graph_diff.sh lab3-indexer lab4-broken-compat"},{"@type":"HowToStep","position":8,"name":"Run the full smoke path","text":"./scripts/smoke_graph_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 8: Service Graph Evolution","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-08-service-graph","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Follow the Chapter 8 UMA service graph tutorial to inspect graph growth, compatibility breaks, and recovery using Rust-first scenario snapshots and diffs."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-07-metadata-orchestration/">previous: Chapter 7</a></li><li><a href="../chapter-09-trust-boundaries/">next: Chapter 9</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-08-service-graph" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 8 Service Graph Evolution Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 8 UMA code example</p>
           <h1>Service graph evolution tutorial</h1>
           <p>This tutorial turns system growth into something inspectable. You will run graph scenarios, compare contract changes, and see how compatible services join the graph without upstream rewrites.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Use the in-page route block to move through the graph progression without relying on footer links for the main sequence.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>how service graphs emerge from contracts and event compatibility</li><li>how Git-style diffs expose architecture changes</li><li>how broken compatibility fails visibly and recovers predictably</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
-            
+
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-08-service-graph</code></pre></li><li><strong>List the graph labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the first scenario contracts</strong><pre class="tutorial-code"><code>./scripts/validate_graph_contracts.sh lab1-upload-only</code></pre></li><li><strong>Run the upload-only graph</strong><pre class="tutorial-code"><code>./scripts/run_graph_demo.sh lab1-upload-only</code></pre></li><li><strong>Inspect the contract change to image tagging</strong><pre class="tutorial-code"><code>./scripts/contract_diff.sh lab1-upload-only lab2-image-tagger</code></pre></li><li><strong>Run the indexer graph</strong><pre class="tutorial-code"><code>./scripts/run_graph_demo.sh lab3-indexer</code></pre></li><li><strong>Compare a compatibility break</strong><pre class="tutorial-code"><code>./scripts/graph_diff.sh lab3-indexer lab4-broken-compat</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_graph_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>capability lines</li><li>consumes and emits lines</li><li>Edges</li><li>Waiting Consumers</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_graph_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 9 adds explicit trust and runtime enforcement.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-08-service-graph">Open source folder</a>

--- a/book-site/examples/chapter-09-trust-boundaries/index.html
+++ b/book-site/examples/chapter-09-trust-boundaries/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 9 Trust Boundaries Tutorial | UMA Examples</title>
+    <title>Chapter 9 Trust Boundaries Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Run the Chapter 9 UMA trust boundaries tutorial to see publisher trust, permissions, provenance, and communication policy produce allow and deny decisions." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-09-trust-boundaries/" />
     <meta property="og:title" content="Chapter 9 Trust Boundaries Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-09-trust-boundaries/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 9 Trust Boundaries Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-09-trust-boundaries/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 9 Trust Boundaries Tutorial","description":"Run the Chapter 9 UMA trust boundaries tutorial to see publisher trust, permissions, provenance, and communication policy produce allow and deny decisions.","url":"https://www.universalmicroservices.com/examples/chapter-09-trust-boundaries/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 9: Trust Boundaries UMA tutorial","description":"Run the Chapter 9 UMA trust boundaries tutorial to see publisher trust, permissions, provenance, and communication policy produce allow and deny decisions.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-09-trust-boundaries"},{"@type":"HowToStep","position":2,"name":"List the trust labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Validate the trusted scenario","text":"./scripts/validate_trust.sh lab1-trusted-service"},{"@type":"HowToStep","position":4,"name":"Run the trusted service scenario","text":"./scripts/run_trust_demo.sh lab1-trusted-service"},{"@type":"HowToStep","position":5,"name":"Inspect an undeclared permission change","text":"./scripts/trust_diff.sh lab1-trusted-service lab2-undeclared-permission"},{"@type":"HowToStep","position":6,"name":"Run the untrusted dependency scenario","text":"./scripts/run_trust_demo.sh lab3-untrusted-dependency"},{"@type":"HowToStep","position":7,"name":"Run the restored compliance scenario","text":"./scripts/run_trust_demo.sh lab5-restored-compliance"},{"@type":"HowToStep","position":8,"name":"Run the full smoke path","text":"./scripts/smoke_trust_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 9: Trust Boundaries","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-09-trust-boundaries","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Run the Chapter 9 UMA trust boundaries tutorial to see publisher trust, permissions, provenance, and communication policy produce allow and deny decisions."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-08-service-graph/">previous: Chapter 8</a></li><li><a href="../chapter-10-architectural-tradeoffs/">next: Chapter 10</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-09-trust-boundaries" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 9 Trust Boundaries Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 9 UMA code example</p>
           <h1>Trust boundaries tutorial</h1>
           <p>This tutorial makes trust decisions visible. The runtime evaluates metadata, permissions, dependency provenance, placement, and communication rules before allowing execution.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Keep the path visible beside the tutorial so the trust rules, source folder, and neighboring chapters are easy to jump to.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>why portable systems cannot inherit trust from location alone</li><li>how undeclared permissions and untrusted dependencies fail before execution</li><li>how trust policy governs communication across services</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
-            
+
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-09-trust-boundaries</code></pre></li><li><strong>List the trust labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the trusted scenario</strong><pre class="tutorial-code"><code>./scripts/validate_trust.sh lab1-trusted-service</code></pre></li><li><strong>Run the trusted service scenario</strong><pre class="tutorial-code"><code>./scripts/run_trust_demo.sh lab1-trusted-service</code></pre></li><li><strong>Inspect an undeclared permission change</strong><pre class="tutorial-code"><code>./scripts/trust_diff.sh lab1-trusted-service lab2-undeclared-permission</code></pre></li><li><strong>Run the untrusted dependency scenario</strong><pre class="tutorial-code"><code>./scripts/run_trust_demo.sh lab3-untrusted-dependency</code></pre></li><li><strong>Run the restored compliance scenario</strong><pre class="tutorial-code"><code>./scripts/run_trust_demo.sh lab5-restored-compliance</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_trust_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>Outcome: allow or deny</li><li>permission.undeclared</li><li>dependency.provenance.untrusted</li><li>communication.forbidden</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_trust_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 10 compares architectural tradeoffs through runtime behavior.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-09-trust-boundaries">Open source folder</a>

--- a/book-site/examples/chapter-10-architectural-tradeoffs/index.html
+++ b/book-site/examples/chapter-10-architectural-tradeoffs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 10 Architectural Tradeoffs Tutorial | UMA Examples</title>
+    <title>Chapter 10 Architectural Tradeoffs Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Use the Chapter 10 UMA architectural tradeoffs tutorial to compare coherent and degraded designs through runtime-visible warnings and decision axes." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-10-architectural-tradeoffs/" />
     <meta property="og:title" content="Chapter 10 Architectural Tradeoffs Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-10-architectural-tradeoffs/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 10 Architectural Tradeoffs Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-10-architectural-tradeoffs/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 10 Architectural Tradeoffs Tutorial","description":"Use the Chapter 10 UMA architectural tradeoffs tutorial to compare coherent and degraded designs through runtime-visible warnings and decision axes.","url":"https://www.universalmicroservices.com/examples/chapter-10-architectural-tradeoffs/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 10: Architectural Tradeoffs UMA tutorial","description":"Use the Chapter 10 UMA architectural tradeoffs tutorial to compare coherent and degraded designs through runtime-visible warnings and decision axes.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-10-architectural-tradeoffs"},{"@type":"HowToStep","position":2,"name":"List the architecture labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Validate the baseline","text":"./scripts/validate_architecture.sh lab1-baseline"},{"@type":"HowToStep","position":4,"name":"Run the coherent baseline","text":"./scripts/run_arch_demo.sh lab1-baseline"},{"@type":"HowToStep","position":5,"name":"Compare over-granular decomposition","text":"./scripts/diff_architecture.sh lab1-baseline lab2-over-granular"},{"@type":"HowToStep","position":6,"name":"Run the runtime ambiguity lab","text":"./scripts/run_arch_demo.sh lab4-runtime-ambiguity"},{"@type":"HowToStep","position":7,"name":"Run the recovered architecture lab","text":"./scripts/run_arch_demo.sh lab6-recovered-architecture"},{"@type":"HowToStep","position":8,"name":"Run the full smoke path","text":"./scripts/smoke_arch_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 10: Architectural Tradeoffs","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-10-architectural-tradeoffs","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Use the Chapter 10 UMA architectural tradeoffs tutorial to compare coherent and degraded designs through runtime-visible warnings and decision axes."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-09-trust-boundaries/">previous: Chapter 9</a></li><li><a href="../chapter-11-evolution-without-fragmentation/">next: Chapter 11</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-10-architectural-tradeoffs" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 10 Architectural Tradeoffs Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 10 UMA code example</p>
           <h1>Architectural tradeoffs tutorial</h1>
           <p>This tutorial shows architecture as runtime behavior. You will compare scenarios where service granularity, event semantics, placement rules, and orchestration choices either preserve or degrade coherence.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Keep the chapter sequence in view so the comparison path stays obvious while you read the tradeoff scenarios.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>why more services are not automatically better architecture</li><li>how metadata works as a control plane</li><li>how clearer constraints recover coherence after ambiguity or over-orchestration</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
-            
+
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-10-architectural-tradeoffs</code></pre></li><li><strong>List the architecture labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the baseline</strong><pre class="tutorial-code"><code>./scripts/validate_architecture.sh lab1-baseline</code></pre></li><li><strong>Run the coherent baseline</strong><pre class="tutorial-code"><code>./scripts/run_arch_demo.sh lab1-baseline</code></pre></li><li><strong>Compare over-granular decomposition</strong><pre class="tutorial-code"><code>./scripts/diff_architecture.sh lab1-baseline lab2-over-granular</code></pre></li><li><strong>Run the runtime ambiguity lab</strong><pre class="tutorial-code"><code>./scripts/run_arch_demo.sh lab4-runtime-ambiguity</code></pre></li><li><strong>Run the recovered architecture lab</strong><pre class="tutorial-code"><code>./scripts/run_arch_demo.sh lab6-recovered-architecture</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_arch_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>Verdict</li><li>architectural decision axes</li><li>over_granular</li><li>hidden_event_coupling</li><li>runtime_ambiguity</li><li>over_orchestrated</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_arch_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 11 focuses on evolution without fragmentation.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-10-architectural-tradeoffs">Open source folder</a>

--- a/book-site/examples/chapter-11-evolution-without-fragmentation/index.html
+++ b/book-site/examples/chapter-11-evolution-without-fragmentation/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 11 Evolution Without Fragmentation Tutorial | UMA Examples</title>
+    <title>Chapter 11 Evolution Without Fragmentation Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Follow the Chapter 11 UMA evolution tutorial to watch drift, duplication, version sprawl, governed coexistence, and hybrid adoption unfold through runnable labs." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-11-evolution-without-fragmentation/" />
     <meta property="og:title" content="Chapter 11 Evolution Without Fragmentation Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-11-evolution-without-fragmentation/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 11 Evolution Without Fragmentation Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-11-evolution-without-fragmentation/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 11 Evolution Without Fragmentation Tutorial","description":"Follow the Chapter 11 UMA evolution tutorial to watch drift, duplication, version sprawl, governed coexistence, and hybrid adoption unfold through runnable labs.","url":"https://www.universalmicroservices.com/examples/chapter-11-evolution-without-fragmentation/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 11: Evolution Without Fragmentation UMA tutorial","description":"Follow the Chapter 11 UMA evolution tutorial to watch drift, duplication, version sprawl, governed coexistence, and hybrid adoption unfold through runnable labs.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-11-evolution-without-fragmentation"},{"@type":"HowToStep","position":2,"name":"List the evolution labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Validate the contract anchor","text":"./scripts/validate_evolution.sh lab1-contract-anchor"},{"@type":"HowToStep","position":4,"name":"Run the coherent baseline","text":"./scripts/run_evolution_demo.sh lab1-contract-anchor"},{"@type":"HowToStep","position":5,"name":"Inspect behavioral drift","text":"./scripts/diff_evolution.sh lab1-contract-anchor lab2-behavioral-drift"},{"@type":"HowToStep","position":6,"name":"Run duplicate implementations","text":"./scripts/run_evolution_demo.sh lab3-duplicate-implementations"},{"@type":"HowToStep","position":7,"name":"Run governed coexistence","text":"./scripts/run_evolution_demo.sh lab5-runtime-governed-coexistence"},{"@type":"HowToStep","position":8,"name":"Run the full smoke path","text":"./scripts/smoke_evolution_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 11: Evolution Without Fragmentation","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-11-evolution-without-fragmentation","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Follow the Chapter 11 UMA evolution tutorial to watch drift, duplication, version sprawl, governed coexistence, and hybrid adoption unfold through runnable labs."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-10-architectural-tradeoffs/">previous: Chapter 10</a></li><li><a href="../chapter-12-discoverable-decisions/">next: Chapter 12</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-11-evolution-without-fragmentation" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 11 Evolution Without Fragmentation Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 11 UMA code example</p>
           <h1>Evolution without fragmentation tutorial</h1>
           <p>This tutorial shows what happens after deployment. You will follow drift, duplicated behavior, version sprawl, and runtime-governed recovery without pretending every system can be rewritten.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Use the links here to move between the evolution chapters without burying the learning path in the footer.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>how locally valid changes create fragmentation over time</li><li>why versioning needs explicit coexistence rules</li><li>how runtime governance supports brownfield adoption</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
-            
+
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-11-evolution-without-fragmentation</code></pre></li><li><strong>List the evolution labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the contract anchor</strong><pre class="tutorial-code"><code>./scripts/validate_evolution.sh lab1-contract-anchor</code></pre></li><li><strong>Run the coherent baseline</strong><pre class="tutorial-code"><code>./scripts/run_evolution_demo.sh lab1-contract-anchor</code></pre></li><li><strong>Inspect behavioral drift</strong><pre class="tutorial-code"><code>./scripts/diff_evolution.sh lab1-contract-anchor lab2-behavioral-drift</code></pre></li><li><strong>Run duplicate implementations</strong><pre class="tutorial-code"><code>./scripts/run_evolution_demo.sh lab3-duplicate-implementations</code></pre></li><li><strong>Run governed coexistence</strong><pre class="tutorial-code"><code>./scripts/run_evolution_demo.sh lab5-runtime-governed-coexistence</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_evolution_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>Verdict</li><li>behavioral_drift</li><li>duplicate_behavior</li><li>version_fragmentation</li><li>Runtime Decisions</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_evolution_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 12 turns runtime decisions into discoverable artifacts.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-11-evolution-without-fragmentation">Open source folder</a>

--- a/book-site/examples/chapter-12-discoverable-decisions/index.html
+++ b/book-site/examples/chapter-12-discoverable-decisions/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 12 Discoverable Decisions Tutorial | UMA Examples</title>
+    <title>Chapter 12 Discoverable Decisions Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Run the Chapter 12 UMA discoverable decisions tutorial to expose proposal, validation, revision, execution, and trace artifacts as inspectable runtime evidence." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-12-discoverable-decisions/" />
     <meta property="og:title" content="Chapter 12 Discoverable Decisions Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-12-discoverable-decisions/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 12 Discoverable Decisions Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-12-discoverable-decisions/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 12 Discoverable Decisions Tutorial","description":"Run the Chapter 12 UMA discoverable decisions tutorial to expose proposal, validation, revision, execution, and trace artifacts as inspectable runtime evidence.","url":"https://www.universalmicroservices.com/examples/chapter-12-discoverable-decisions/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 12: Discoverable Decisions UMA tutorial","description":"Run the Chapter 12 UMA discoverable decisions tutorial to expose proposal, validation, revision, execution, and trace artifacts as inspectable runtime evidence.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-12-discoverable-decisions"},{"@type":"HowToStep","position":2,"name":"List the decision labs","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":3,"name":"Validate the first decision scenario","text":"./scripts/validate_decisions.sh lab1-capability-projection"},{"@type":"HowToStep","position":4,"name":"Run capability projection","text":"./scripts/run_decision_demo.sh lab1-capability-projection"},{"@type":"HowToStep","position":5,"name":"Compare the edge proposal step","text":"./scripts/diff_decisions.sh lab1-capability-projection lab2-edge-proposal"},{"@type":"HowToStep","position":6,"name":"Run authority feedback","text":"./scripts/run_decision_demo.sh lab3-authority-feedback"},{"@type":"HowToStep","position":7,"name":"Run queryable trace","text":"./scripts/run_decision_demo.sh lab6-queryable-trace"},{"@type":"HowToStep","position":8,"name":"Run the full smoke path","text":"./scripts/smoke_discoverability_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 12: Discoverable Decisions","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-12-discoverable-decisions","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Run the Chapter 12 UMA discoverable decisions tutorial to expose proposal, validation, revision, execution, and trace artifacts as inspectable runtime evidence."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-11-evolution-without-fragmentation/">previous: Chapter 11</a></li><li><a href="../chapter-13-portable-mcp-runtime/">next: Chapter 13</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-12-discoverable-decisions" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 12 Discoverable Decisions Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 12 UMA code example</p>
           <h1>Discoverable decisions tutorial</h1>
           <p>This tutorial moves from systems that merely execute to systems that can explain. Each lab exposes more of the proposal, validation, revision, execution, and trace lifecycle.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Keep the decision path in front of the reader so the queryable proof is visible while the tutorial is still on screen.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>why discoverability is different from execution</li><li>how edge proposals and cloud authority cooperate</li><li>how trace artifacts make final decisions auditable</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
-            
+
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-12-discoverable-decisions</code></pre></li><li><strong>List the decision labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the first decision scenario</strong><pre class="tutorial-code"><code>./scripts/validate_decisions.sh lab1-capability-projection</code></pre></li><li><strong>Run capability projection</strong><pre class="tutorial-code"><code>./scripts/run_decision_demo.sh lab1-capability-projection</code></pre></li><li><strong>Compare the edge proposal step</strong><pre class="tutorial-code"><code>./scripts/diff_decisions.sh lab1-capability-projection lab2-edge-proposal</code></pre></li><li><strong>Run authority feedback</strong><pre class="tutorial-code"><code>./scripts/run_decision_demo.sh lab3-authority-feedback</code></pre></li><li><strong>Run queryable trace</strong><pre class="tutorial-code"><code>./scripts/run_decision_demo.sh lab6-queryable-trace</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_discoverability_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>Verdict</li><li>proposal_hidden</li><li>authority_gap</li><li>Discoverable Surfaces</li><li>Trace</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_discoverability_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>Chapter 13 applies the model to a portable MCP runtime.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-12-discoverable-decisions">Open source folder</a>

--- a/book-site/examples/chapter-13-portable-mcp-runtime/index.html
+++ b/book-site/examples/chapter-13-portable-mcp-runtime/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chapter 13 Portable MCP Runtime Tutorial | UMA Examples</title>
+    <title>Chapter 13 Portable MCP Runtime Tutorial | Universal Microservices Architecture</title>
     <meta name="description" content="Use the Chapter 13 portable MCP runtime tutorial to build WASI AI capabilities, run an UMA workflow, inspect JSON reports, and start the MCP server." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/chapter-13-portable-mcp-runtime/" />
     <meta property="og:title" content="Chapter 13 Portable MCP Runtime Tutorial" />
@@ -11,6 +11,8 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/chapter-13-portable-mcp-runtime/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Examples","item":"https://www.universalmicroservices.com/examples/"},{"@type":"ListItem","position":3,"name":"Chapter 13 Portable MCP Runtime Tutorial","item":"https://www.universalmicroservices.com/examples/chapter-13-portable-mcp-runtime/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Chapter 13 Portable MCP Runtime Tutorial","description":"Use the Chapter 13 portable MCP runtime tutorial to build WASI AI capabilities, run an UMA workflow, inspect JSON reports, and start the MCP server.","url":"https://www.universalmicroservices.com/examples/chapter-13-portable-mcp-runtime/","inLanguage":"en"}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"Chapter 13: Portable MCP Runtime UMA tutorial","description":"Use the Chapter 13 portable MCP runtime tutorial to build WASI AI capabilities, run an UMA workflow, inspect JSON reports, and start the MCP server.","step":[{"@type":"HowToStep","position":1,"name":"Enter the example","text":"cd chapter-13-portable-mcp-runtime"},{"@type":"HowToStep","position":2,"name":"Set up pinned model artifacts","text":"./scripts/setup_models.sh"},{"@type":"HowToStep","position":3,"name":"Build the PlannerAI WASI module","text":"./scripts/build_planner_ai_wasi.sh"},{"@type":"HowToStep","position":4,"name":"Build the SummarizerAI WASI module","text":"./scripts/build_summarizer_ai_wasi.sh"},{"@type":"HowToStep","position":5,"name":"Build the TranslatorFr WASI module","text":"./scripts/build_translator_ai_wasi.sh"},{"@type":"HowToStep","position":6,"name":"List workflows","text":"./scripts/list_labs.sh"},{"@type":"HowToStep","position":7,"name":"Run the French AI report workflow","text":"./scripts/run_lab.sh use-case-2-ai-report"},{"@type":"HowToStep","position":8,"name":"Render the workflow as JSON","text":"cargo run --manifest-path rust/Cargo.toml -- render use-case-2-ai-report json"},{"@type":"HowToStep","position":9,"name":"Run the MCP server smoke check","text":"./scripts/smoke_mcp_server.sh"},{"@type":"HowToStep","position":10,"name":"Run the full chapter smoke path","text":"./scripts/smoke_portable_mcp_labs.sh"}]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"Chapter 13: Portable MCP Runtime","codeRepository":"https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-13-portable-mcp-runtime","programmingLanguage":["Rust","TypeScript"],"runtimePlatform":"Rust, WASI, Node.js","description":"Use the Chapter 13 portable MCP runtime tutorial to build WASI AI capabilities, run an UMA workflow, inspect JSON reports, and start the MCP server."}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,6 +20,8 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../styles.css" />
     <link rel="stylesheet" href="../../subpages.css" />
+    <link rel="icon" href="../../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -28,23 +32,74 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <a class="brand" href="../../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../../#why-uma">Why</a><a href="../../#book-arc">What</a><a href="../../#learning-path">How</a><a href="../../#hands-on">Hands-on</a><a href="../../#team-value">Who</a><a href="../../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-you-will-learn">What you will learn</a></li><li><a href="#prerequisites">Prerequisites</a></li><li><a href="#full-tutorial">Full tutorial</a></li><li><a href="#what-to-inspect">What to inspect</a></li><li><a href="#acceptance-check">Acceptance check</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../../book/">book</a></li><li><a href="../../examples/">examples</a></li><li><a href="../../learning-path/">learning path</a></li><li><a href="../../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        <li><a href="../">examples hub</a></li><li><a href="../chapter-12-discoverable-decisions/">previous: Chapter 12</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-13-portable-mcp-runtime" target="_blank" rel="noreferrer noopener">source folder</a></li>
+      </ul>
+    </nav>
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero tutorial-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../../">Home</a></li><li><a href="../">Examples</a></li><li><span aria-current="page">Chapter 13 Portable MCP Runtime Tutorial</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero tutorial-hero">
           <p class="tutorial-kicker">Chapter 13 UMA code example</p>
           <h1>Portable MCP runtime tutorial</h1>
           <p>This tutorial is the repo reference application. It composes discoverable capabilities into workflows, lets AI propose without becoming authoritative, and explains the execution through CLI, JSON, MCP, and a browser app.</p>
         </section>
-        <div class="subpage-body tutorial-body">
+
+<div class="subpage-body tutorial-body">
           <section class="subpage-callout">
             <strong>Tutorial route</strong>
             <p>Keep the final chapter’s navigation close to the lesson so the source, the examples index, and the previous step remain visible up front.</p>
@@ -56,25 +111,25 @@
             </div>
           </section>
           <section>
-            <h2>What you will learn</h2>
+            <h2 id="what-you-will-learn">What you will learn</h2>
             <ul><li>how WASM MCP exposes discovery and invocation surfaces</li><li>how the UMA runtime validates and executes selected capabilities</li><li>how AI-backed capabilities participate with explicit fallback reporting</li></ul>
           </section>
           <section>
-            <h2>Prerequisites</h2>
+            <h2 id="prerequisites">Prerequisites</h2>
             <ul><li>Rust 1.76 or newer</li><li>wasm32-wasip1 target</li><li>Node.js 20 or newer</li><li>npm</li><li>Wasmtime on your PATH</li></ul>
             <p>Run this setup command before the lab if your machine does not already have the target installed.</p><pre class="tutorial-code"><code>rustup target add wasm32-wasip1</code></pre>
           </section>
           <section>
-            <h2>Full tutorial</h2>
+            <h2 id="full-tutorial">Full tutorial</h2>
             <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-13-portable-mcp-runtime</code></pre></li><li><strong>Set up pinned model artifacts</strong><pre class="tutorial-code"><code>./scripts/setup_models.sh</code></pre></li><li><strong>Build the PlannerAI WASI module</strong><pre class="tutorial-code"><code>./scripts/build_planner_ai_wasi.sh</code></pre></li><li><strong>Build the SummarizerAI WASI module</strong><pre class="tutorial-code"><code>./scripts/build_summarizer_ai_wasi.sh</code></pre></li><li><strong>Build the TranslatorFr WASI module</strong><pre class="tutorial-code"><code>./scripts/build_translator_ai_wasi.sh</code></pre></li><li><strong>List workflows</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Run the French AI report workflow</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh use-case-2-ai-report</code></pre></li><li><strong>Render the workflow as JSON</strong><pre class="tutorial-code"><code>cargo run --manifest-path rust/Cargo.toml -- render use-case-2-ai-report json</code></pre></li><li><strong>Run the MCP server smoke check</strong><pre class="tutorial-code"><code>./scripts/smoke_mcp_server.sh</code></pre></li><li><strong>Run the full chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_portable_mcp_labs.sh</code></pre></li></ol>
           </section>
           <section>
-            <h2>What to inspect</h2>
+            <h2 id="what-to-inspect">What to inspect</h2>
             <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
             <ul><li>capability selection</li><li>runtime validation result</li><li>structured report JSON</li><li>explicit provider fallback reporting when used</li></ul>
           </section>
           <section>
-            <h2>Acceptance check</h2>
+            <h2 id="acceptance-check">Acceptance check</h2>
             <p>The chapter-level validation path is:</p>
             <pre class="tutorial-code"><code>./scripts/smoke_portable_mcp_labs.sh</code></pre>
             <p>Return to the repository root for the final acceptance gate:</p>
@@ -82,7 +137,7 @@
 ./scripts/smoke_reader_paths.sh</code></pre>
           </section>
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>This chapter closes the validated learning path and links to the live reference application.</p>
             <div class="subpage-inline-links">
               <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-13-portable-mcp-runtime">Open source folder</a>

--- a/book-site/examples/index.html
+++ b/book-site/examples/index.html
@@ -4,37 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UMA Examples | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Explore the practical Universal Microservices Architecture examples, including chapter-aligned Rust-first labs, portable MCP runtime composition, and runnable tutorials."
-    />
+    <meta name="description" content="Explore the practical Universal Microservices Architecture examples, including chapter-aligned Rust-first labs, portable MCP runtime composition, and runnable tutorials." />
     <link rel="canonical" href="https://www.universalmicroservices.com/examples/" />
-    <meta property="og:title" content="UMA Examples | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="A practical entry point into the chapter-aligned UMA examples, including validated learning flows and runnable repository material."
-    />
+    <meta property="og:title" content="UMA Examples" />
+    <meta property="og:description" content="Explore the practical Universal Microservices Architecture examples, including chapter-aligned Rust-first labs, portable MCP runtime composition, and runnable tutorials." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.universalmicroservices.com/examples/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA Examples","item":"https://www.universalmicroservices.com/examples/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA Examples","description":"Explore the practical Universal Microservices Architecture examples, including chapter-aligned Rust-first labs, portable MCP runtime composition, and runnable tutorials.","url":"https://www.universalmicroservices.com/examples/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,69 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#why-the-examples-matter">Why the examples matter</a></li><li><a href="#a-before-and-after-way-to-read-the-repo">A before-and-after way to read the repo</a></li><li><a href="#what-makes-these-examples-different">What makes these examples different</a>
+    <ul class="page-rail-links">
+      <li><a href="#chapter-aligned">Chapter-aligned</a></li><li><a href="#rust-first">Rust-first</a></li><li><a href="#typescript-parity">TypeScript parity</a></li><li><a href="#reader-tested-flows">Reader-tested flows</a></li>
+    </ul></li><li><a href="#runnable-tutorials-for-every-code-example">Runnable tutorials for every code example</a></li><li><a href="#foundations">Foundations</a>
+    <ul class="page-rail-links">
+      <li><a href="#chapter-4-feature-flag-evaluator">Chapter 4: Feature Flag Evaluator</a></li><li><a href="#chapter-5-post-fetcher-runtime">Chapter 5: Post Fetcher Runtime</a></li><li><a href="#chapter-6-portability-lab">Chapter 6: Portability Lab</a></li>
+    </ul></li><li><a href="#orchestration-and-trust">Orchestration and trust</a>
+    <ul class="page-rail-links">
+      <li><a href="#chapter-7-metadata-orchestration">Chapter 7: Metadata Orchestration</a></li><li><a href="#chapter-8-service-graph-evolution">Chapter 8: Service Graph Evolution</a></li><li><a href="#chapter-9-trust-boundaries">Chapter 9: Trust Boundaries</a></li>
+    </ul></li><li><a href="#evolution-and-discoverability">Evolution and discoverability</a>
+    <ul class="page-rail-links">
+      <li><a href="#chapter-10-architectural-tradeoffs">Chapter 10: Architectural Tradeoffs</a></li><li><a href="#chapter-11-evolution-without-fragmentation">Chapter 11: Evolution Without Fragmentation</a></li><li><a href="#chapter-12-discoverable-decisions">Chapter 12: Discoverable Decisions</a></li><li><a href="#chapter-13-portable-mcp-runtime">Chapter 13: Portable MCP Runtime</a></li>
+    </ul></li><li><a href="#what-each-tutorial-page-includes">What each tutorial page includes</a></li><li><a href="#what-you-can-do-with-them">What you can do with them</a></li><li><a href="#how-the-repository-is-organized">How the repository is organized</a></li><li><a href="#why-rust-first-matters-here">Why Rust-first matters here</a></li><li><a href="#what-the-closing-examples-prove">What the closing examples prove</a></li><li><a href="#frequently-asked-question">Frequently asked question</a>
+    <ul class="page-rail-links">
+      <li><a href="#do-i-need-to-run-every-example-to-understand-uma">Do I need to run every example to understand UMA?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA Examples</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>UMA examples</h1>
           <p>
             The examples are the practical proof layer of Universal Microservices Architecture. They let readers inspect how a portable
@@ -80,7 +110,7 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section class="subpage-callout">
             <strong>How to navigate the examples</strong>
             <p>
@@ -96,7 +126,7 @@
           </section>
 
           <section id="why-the-examples-matter">
-            <h2>Why the examples matter</h2>
+            <h2 id="why-the-examples-matter">Why the examples matter</h2>
             <p>
               Architecture claims are easy to make and hard to validate. The examples exist to close that gap. They give the reader a way
               to compare intention against output, contracts against runtime decisions, and design coherence against the real drift that
@@ -109,7 +139,7 @@
           </section>
 
           <section id="before-and-after-repo-reading">
-            <h2>A before-and-after way to read the repo</h2>
+            <h2 id="a-before-and-after-way-to-read-the-repo">A before-and-after way to read the repo</h2>
             <p>
               Before UMA, a team often ends up with the same business rule scattered across browser logic, edge handling, backend checks,
               and workflow glue. After UMA, the question becomes whether one portable behavioral unit can stay intact while the runtime
@@ -122,7 +152,7 @@
           </section>
 
           <section id="what-makes-these-examples-different">
-            <h2>What makes these examples different</h2>
+            <h2 id="what-makes-these-examples-different">What makes these examples different</h2>
             <p>
               These examples are not generic demos attached to a book launch. Each one exists to make a specific architectural question
               visible. What does a portable service boundary look like? What belongs in the runtime layer? How does metadata shape
@@ -137,25 +167,25 @@
 
           <section id="example-props" class="subpage-grid">
             <article class="subpage-card">
-              <h3>Chapter-aligned</h3>
+              <h3 id="chapter-aligned">Chapter-aligned</h3>
               <p>The examples map directly to the later chapters so the learning path continues from explanation into runnable material.</p>
             </article>
             <article class="subpage-card">
-              <h3>Rust-first</h3>
+              <h3 id="rust-first">Rust-first</h3>
               <p>The primary validated path uses Rust for the core runtime and architecture examples.</p>
             </article>
             <article class="subpage-card">
-              <h3>TypeScript parity</h3>
+              <h3 id="typescript-parity">TypeScript parity</h3>
               <p>Selected chapters include TypeScript parity paths to make comparison easier for readers coming from different stacks.</p>
             </article>
             <article class="subpage-card">
-              <h3>Reader-tested flows</h3>
+              <h3 id="reader-tested-flows">Reader-tested flows</h3>
               <p>Scripts, smoke checks, and learning-path validation make the examples easier to follow chapter by chapter.</p>
             </article>
           </section>
 
           <section id="tutorials">
-            <h2>Runnable tutorials for every code example</h2>
+            <h2 id="runnable-tutorials-for-every-code-example">Runnable tutorials for every code example</h2>
             <p>
               Each chapter example now has a dedicated tutorial page with its own canonical URL, metadata, source link, validation
               command, and repository-level acceptance check. The pages are grouped below so the learning path is easier to scan and
@@ -164,65 +194,65 @@
           </section>
 
           <section id="foundations">
-            <h2>Foundations</h2>
+            <h2 id="foundations">Foundations</h2>
             <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
-                <h3><a href="chapter-04-feature-flag-evaluator/">Chapter 4: Feature Flag Evaluator</a></h3>
+                <h3 id="chapter-4-feature-flag-evaluator"><a href="chapter-04-feature-flag-evaluator/">Chapter 4: Feature Flag Evaluator</a></h3>
                 <p>Build and run the deterministic Rust-first evaluator, then prove TypeScript parity from output.</p>
               </article>
               <article class="subpage-card">
-                <h3><a href="chapter-05-post-fetcher-runtime/">Chapter 5: Post Fetcher Runtime</a></h3>
+                <h3 id="chapter-5-post-fetcher-runtime"><a href="chapter-05-post-fetcher-runtime/">Chapter 5: Post Fetcher Runtime</a></h3>
                 <p>Inspect validation, adapter binding, event ordering, and lifecycle evidence around a pure service.</p>
               </article>
               <article class="subpage-card">
-                <h3><a href="chapter-06-portability-lab/">Chapter 6: Portability Lab</a></h3>
+                <h3 id="chapter-6-portability-lab"><a href="chapter-06-portability-lab/">Chapter 6: Portability Lab</a></h3>
                 <p>Compare native and WASI execution through the same emitted image analysis payload.</p>
               </article>
             </div>
           </section>
 
           <section id="orchestration-and-trust">
-            <h2>Orchestration and trust</h2>
+            <h2 id="orchestration-and-trust">Orchestration and trust</h2>
             <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
-                <h3><a href="chapter-07-metadata-orchestration/">Chapter 7: Metadata Orchestration</a></h3>
+                <h3 id="chapter-7-metadata-orchestration"><a href="chapter-07-metadata-orchestration/">Chapter 7: Metadata Orchestration</a></h3>
                 <p>Run the contract-driven orchestration flow and inspect binding, policy, schema, and telemetry signals.</p>
               </article>
               <article class="subpage-card">
-                <h3><a href="chapter-08-service-graph/">Chapter 8: Service Graph Evolution</a></h3>
+                <h3 id="chapter-8-service-graph-evolution"><a href="chapter-08-service-graph/">Chapter 8: Service Graph Evolution</a></h3>
                 <p>Use graph snapshots and diffs to watch compatible services join, break, and recover.</p>
               </article>
               <article class="subpage-card">
-                <h3><a href="chapter-09-trust-boundaries/">Chapter 9: Trust Boundaries</a></h3>
+                <h3 id="chapter-9-trust-boundaries"><a href="chapter-09-trust-boundaries/">Chapter 9: Trust Boundaries</a></h3>
                 <p>See trust metadata, permissions, dependency provenance, and communication policy produce runtime decisions.</p>
               </article>
             </div>
           </section>
 
           <section id="evolution-and-discoverability">
-            <h2>Evolution and discoverability</h2>
+            <h2 id="evolution-and-discoverability">Evolution and discoverability</h2>
             <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
-                <h3><a href="chapter-10-architectural-tradeoffs/">Chapter 10: Architectural Tradeoffs</a></h3>
+                <h3 id="chapter-10-architectural-tradeoffs"><a href="chapter-10-architectural-tradeoffs/">Chapter 10: Architectural Tradeoffs</a></h3>
                 <p>Compare coherent and degraded designs using runtime-visible warnings and architectural decision axes.</p>
               </article>
               <article class="subpage-card">
-                <h3><a href="chapter-11-evolution-without-fragmentation/">Chapter 11: Evolution Without Fragmentation</a></h3>
+                <h3 id="chapter-11-evolution-without-fragmentation"><a href="chapter-11-evolution-without-fragmentation/">Chapter 11: Evolution Without Fragmentation</a></h3>
                 <p>Follow drift, duplication, version sprawl, coexistence, and hybrid adoption through runnable scenarios.</p>
               </article>
               <article class="subpage-card">
-                <h3><a href="chapter-12-discoverable-decisions/">Chapter 12: Discoverable Decisions</a></h3>
+                <h3 id="chapter-12-discoverable-decisions"><a href="chapter-12-discoverable-decisions/">Chapter 12: Discoverable Decisions</a></h3>
                 <p>Expose proposal, authority feedback, revision, execution, and trace artifacts as queryable proof.</p>
               </article>
               <article class="subpage-card">
-                <h3><a href="chapter-13-portable-mcp-runtime/">Chapter 13: Portable MCP Runtime</a></h3>
+                <h3 id="chapter-13-portable-mcp-runtime"><a href="chapter-13-portable-mcp-runtime/">Chapter 13: Portable MCP Runtime</a></h3>
                 <p>Build WASI AI capabilities, run the UMA workflow, inspect JSON reports, and smoke the MCP server.</p>
               </article>
             </div>
           </section>
 
           <section id="what-each-tutorial-page-includes">
-            <h2>What each tutorial page includes</h2>
+            <h2 id="what-each-tutorial-page-includes">What each tutorial page includes</h2>
             <p>
               Every tutorial page now keeps the navigation close to the content: an in-page route block, the validation commands, the
               source folder link, and the next step in the sequence. That makes the structure easier to scan without sending readers to
@@ -231,7 +261,7 @@
           </section>
 
           <section id="what-you-can-do">
-            <h2>What you can do with them</h2>
+            <h2 id="what-you-can-do-with-them">What you can do with them</h2>
             <p>
               Use the examples to test the book’s architectural claims against concrete behavior. You can run a minimal service, trace a
               runtime wrapper, compare implementations, follow orchestration decisions, and see where trust and compatibility start to
@@ -249,7 +279,7 @@
           </section>
 
           <section id="how-the-repository-is-organized">
-            <h2>How the repository is organized</h2>
+            <h2 id="how-the-repository-is-organized">How the repository is organized</h2>
             <p>
               The repository follows the same broad progression as the learning path. Earlier chapters keep the system intentionally small.
               Later chapters introduce orchestration, service graphs, trust boundaries, and governed evolution. That organization helps the
@@ -268,7 +298,7 @@
           </section>
 
           <section id="why-rust-first-matters">
-            <h2>Why Rust-first matters here</h2>
+            <h2 id="why-rust-first-matters-here">Why Rust-first matters here</h2>
             <p>
               The validated default path uses Rust because it makes the portable runtime story concrete and rigorous. TypeScript parity is
               included where it adds value for comparison, but the repository stays centered on one primary validated path so the learning
@@ -277,7 +307,7 @@
           </section>
 
           <section id="what-the-closing-examples-prove">
-            <h2>What the closing examples prove</h2>
+            <h2 id="what-the-closing-examples-prove">What the closing examples prove</h2>
             <p>
               The Chapter 12 example matters because it demonstrates a final architectural shift: a system should not only execute correctly,
               it should expose why it acted. That lab makes decision stages queryable so readers can inspect capability projection, proposal
@@ -299,8 +329,8 @@
           </section>
 
           <section id="frequently-asked-question">
-            <h2>Frequently asked question</h2>
-            <h3>Do I need to run every example to understand UMA?</h3>
+            <h2 id="frequently-asked-question">Frequently asked question</h2>
+            <h3 id="do-i-need-to-run-every-example-to-understand-uma">Do I need to run every example to understand UMA?</h3>
             <p>
               No, but the examples are where the architectural claims become easiest to verify. Even running a few of the core chapters
               gives much more confidence in the model than reading about it alone.
@@ -333,7 +363,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/examples/index.html
+++ b/book-site/examples/index.html
@@ -95,7 +95,7 @@
             </div>
           </section>
 
-          <section>
+          <section id="why-the-examples-matter">
             <h2>Why the examples matter</h2>
             <p>
               Architecture claims are easy to make and hard to validate. The examples exist to close that gap. They give the reader a way
@@ -108,7 +108,7 @@
             </p>
           </section>
 
-          <section>
+          <section id="before-and-after-repo-reading">
             <h2>A before-and-after way to read the repo</h2>
             <p>
               Before UMA, a team often ends up with the same business rule scattered across browser logic, edge handling, backend checks,
@@ -121,7 +121,7 @@
             </p>
           </section>
 
-          <section>
+          <section id="what-makes-these-examples-different">
             <h2>What makes these examples different</h2>
             <p>
               These examples are not generic demos attached to a book launch. Each one exists to make a specific architectural question
@@ -135,7 +135,7 @@
             </p>
           </section>
 
-          <section class="subpage-grid">
+          <section id="example-props" class="subpage-grid">
             <article class="subpage-card">
               <h3>Chapter-aligned</h3>
               <p>The examples map directly to the later chapters so the learning path continues from explanation into runnable material.</p>
@@ -154,7 +154,7 @@
             </article>
           </section>
 
-          <section>
+          <section id="tutorials">
             <h2>Runnable tutorials for every code example</h2>
             <p>
               Each chapter example now has a dedicated tutorial page with its own canonical URL, metadata, source link, validation
@@ -163,7 +163,7 @@
             </p>
           </section>
 
-          <section>
+          <section id="foundations">
             <h2>Foundations</h2>
             <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
@@ -181,7 +181,7 @@
             </div>
           </section>
 
-          <section>
+          <section id="orchestration-and-trust">
             <h2>Orchestration and trust</h2>
             <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
@@ -199,7 +199,7 @@
             </div>
           </section>
 
-          <section>
+          <section id="evolution-and-discoverability">
             <h2>Evolution and discoverability</h2>
             <div class="subpage-grid tutorial-link-grid">
               <article class="subpage-card">
@@ -221,7 +221,7 @@
             </div>
           </section>
 
-          <section>
+          <section id="what-each-tutorial-page-includes">
             <h2>What each tutorial page includes</h2>
             <p>
               Every tutorial page now keeps the navigation close to the content: an in-page route block, the validation commands, the
@@ -230,7 +230,7 @@
             </p>
           </section>
 
-          <section>
+          <section id="what-you-can-do">
             <h2>What you can do with them</h2>
             <p>
               Use the examples to test the book’s architectural claims against concrete behavior. You can run a minimal service, trace a
@@ -248,7 +248,7 @@
             </p>
           </section>
 
-          <section>
+          <section id="how-the-repository-is-organized">
             <h2>How the repository is organized</h2>
             <p>
               The repository follows the same broad progression as the learning path. Earlier chapters keep the system intentionally small.
@@ -267,7 +267,7 @@
             </p>
           </section>
 
-          <section>
+          <section id="why-rust-first-matters">
             <h2>Why Rust-first matters here</h2>
             <p>
               The validated default path uses Rust because it makes the portable runtime story concrete and rigorous. TypeScript parity is
@@ -276,7 +276,7 @@
             </p>
           </section>
 
-          <section>
+          <section id="what-the-closing-examples-prove">
             <h2>What the closing examples prove</h2>
             <p>
               The Chapter 12 example matters because it demonstrates a final architectural shift: a system should not only execute correctly,
@@ -298,7 +298,7 @@
             </p>
           </section>
 
-          <section>
+          <section id="frequently-asked-question">
             <h2>Frequently asked question</h2>
             <h3>Do I need to run every example to understand UMA?</h3>
             <p>
@@ -307,7 +307,7 @@
             </p>
           </section>
 
-          <section class="subpage-callout">
+          <section id="repository-entry-point" class="subpage-callout">
             <strong>Repository entry point</strong>
             <p>
               The examples live in the public repository and follow the same story arc as the site and the book. That makes the repository

--- a/book-site/faq/index.html
+++ b/book-site/faq/index.html
@@ -4,253 +4,34 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UMA FAQ | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Frequently asked questions about Universal Microservices Architecture, including portability, WebAssembly, runtime governance, trust boundaries, and examples."
-    />
+    <meta name="description" content="Frequently asked questions about Universal Microservices Architecture, including portability, WebAssembly, runtime governance, trust boundaries, and examples." />
     <link rel="canonical" href="https://www.universalmicroservices.com/faq/" />
-    <meta property="og:title" content="UMA FAQ | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="A maintained FAQ for Universal Microservices Architecture, designed to answer common questions clearly and support the book, site, and example repository."
-    />
+    <meta property="og:title" content="UMA FAQ" />
+    <meta property="og:description" content="Frequently asked questions about Universal Microservices Architecture, including portability, WebAssembly, runtime governance, trust boundaries, and examples." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.universalmicroservices.com/faq/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What is Universal Microservices Architecture?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Universal Microservices Architecture is an execution model for distributed systems where compute can happen in many places and the system decides where logic runs, while keeping business behavior portable and runtime decisions explicit."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Why does UMA exist?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "UMA exists because the same business behavior is often duplicated across client, edge, and server stacks, creating drift, hidden runtime decisions, and inconsistent outcomes."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What problem does UMA solve that good platform tooling still leaves behind?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "UMA addresses behavior fragmentation across runtimes. Deployment platforms can move and govern workloads, but they do not automatically preserve one business meaning across browser, edge, backend, workflow, and AI-assisted execution surfaces."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the difference between stack ownership and behavior ownership?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Stack ownership organizes systems around where code runs, while behavior ownership organizes them around the durable business meaning that must stay coherent across those runtime surfaces."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What does runtime-agnostic architecture actually mean?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Runtime-agnostic architecture means the business meaning of a service can remain stable while validation, transport, policy, trust, and placement stay explicit around it instead of redefining it in each runtime."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Is UMA only about WebAssembly?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "No. WebAssembly is a strong execution fit for UMA, but the larger subject is architectural coherence across runtimes."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How is UMA different from traditional microservices?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Traditional microservices usually emphasize deployable units and service ownership. UMA focuses on keeping service behavior portable while making contracts, runtime policy, trust, and execution boundaries visible once execution can span many runtime surfaces."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Do I need to adopt UMA all at once?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "No. UMA can start with one portable service and expand gradually as orchestration, trust, policy, and graph evolution become more important."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Where do trust boundaries live in UMA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Trust boundaries live in the runtime and governance layer around the portable service, where identity, permissions, provenance, and policy decisions are enforced."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can a service be valid and still be denied in UMA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. A service can be syntactically valid and still be denied because it requests undeclared permissions, has untrusted dependency provenance, or attempts communication the trust policy does not allow."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the difference between an agent and the runtime in UMA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "An agent can interpret goals and propose a capability path, but the runtime remains authoritative. The runtime validates contracts, enforces constraints, and decides what is actually allowed to execute."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is a capability in UMA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "A capability is a discoverable, contract-shaped unit of behavior the runtime can validate, select, reject, and compose into a workflow."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What makes a service portable in UMA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "A service becomes portable when its behavior stays stable, its contract is explicit, its outputs remain comparable across runtimes, and runtime-specific concerns remain outside the portable core."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is a workflow in UMA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "A workflow is the runtime-approved composition of capabilities used to satisfy a goal under the current constraints and rules, making the chosen execution path visible instead of hiding it in glue code."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is contract-driven orchestration?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Contract-driven orchestration means the runtime creates governed execution bindings from declared events, subscriptions, metadata, and policy instead of relying on hidden workflow glue."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is a UMA runtime?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "A UMA runtime is the governed layer that discovers capabilities, validates contracts and constraints, approves execution paths, and preserves enough evidence to explain what happened."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What makes a decision discoverable in UMA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "A decision becomes discoverable when proposal, validation, revision, approved execution, and trace remain inspectable as artifacts instead of collapsing into one opaque runtime result."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What belongs in the runtime layer?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The runtime layer should own validation, adapter binding, policy, trust, lifecycle evidence, and the governed conditions around execution, while the portable service keeps the core business behavior."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is WASM MCP in UMA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "WASM MCP is the discovery and invocation surface through which the runtime can learn which capabilities are available and expose that availability explicitly instead of hiding it in custom integration code."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How do I prove portability instead of assuming it?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Portability should be validated by running the same service behavior across more than one runtime target and comparing the observable result, contracts, and supporting evidence."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Do the UMA examples publish any benchmark or footprint data?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. The site publishes reproducible local benchmark and footprint notes for selected examples so readers can inspect artifact size and repeated execution timings without treating portability as a vague portability claim."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What should happen when compatibility breaks in a UMA service graph?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The break should stay visible. Missing edges, waiting consumers, or failed compatibility checks are healthier than silent fallback because they make graph drift inspectable and repairable."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can a UMA system work and still be architecturally incoherent?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. A system can still produce the expected result while degrading through over-granular boundaries, hidden event coupling, runtime ambiguity, or orchestration that makes the architecture harder to explain."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How can a system evolve without fragmentation?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "A system evolves without fragmentation when contracts keep behavior legible, drift stays visible, coexistence rules are explicit, and the runtime governs which implementations or versions remain valid for which consumers."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Who is UMA for?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "UMA is most useful for architects, senior engineers, platform engineers, and technical leads designing systems that must stay coherent across runtimes and over time."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Do I need to move away from Medium to use this site?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "No. Medium can remain the publishing channel while this site acts as the authority hub for the book, examples, learning path, and related topic pages."
-      }
-    }
-  ]
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA FAQ","item":"https://www.universalmicroservices.com/faq/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA FAQ","description":"Frequently asked questions about Universal Microservices Architecture, including portability, WebAssembly, runtime governance, trust boundaries, and examples.","url":"https://www.universalmicroservices.com/faq/","inLanguage":"en"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Universal Microservices Architecture?","acceptedAnswer":{"@type":"Answer","text":"Universal Microservices Architecture is an execution model for distributed systems where compute can happen in many places and the system decides where logic runs. It keeps service behavior portable while making contracts, runtime policy, trust, and execution boundaries explicit."}},{"@type":"Question","name":"Why does UMA exist?","acceptedAnswer":{"@type":"Answer","text":"UMA exists because modern systems increasingly duplicate the same business logic across many runtime surfaces. That duplication creates drift, inconsistent outcomes, and hidden architecture. UMA addresses that by preserving one portable expression of the behavior and surrounding it with explicit runtime governance."}},{"@type":"Question","name":"What problem does UMA solve that good platform tooling still leaves behind?","acceptedAnswer":{"@type":"Answer","text":"UMA solves a different problem from deployment tooling alone. Platforms can schedule, route, and observe workloads well, but they do not automatically keep one business behavior coherent across browser, edge, backend, workflow, and AI-assisted execution surfaces. UMA is meant to close that architectural gap. The dedicated what problem does UMA solve? page is the fastest entry point if you want the direct version of that argument before the wider concept cluster."}},{"@type":"Question","name":"What is the difference between stack ownership and behavior ownership?","acceptedAnswer":{"@type":"Answer","text":"Stack ownership organizes software around runtime or team boundaries. Behavior ownership organizes it around the durable rule or domain meaning that must survive across those boundaries. UMA pushes toward the second view."}},{"@type":"Question","name":"What does runtime-agnostic architecture actually mean?","acceptedAnswer":{"@type":"Answer","text":"It means the service behavior can stay semantically stable while the runtime around it changes. Validation, transport, placement, identity, permissions, and trust still matter, but they stop being the place where the business meaning of the service is quietly rewritten. The useful shorthand is not “write once, run everywhere.” It is “write once, run where it makes sense.” The dedicated runtime-agnostic architecture page goes deeper into that distinction and why it matters for modern systems that span browser, edge, backend, and workflow execution surfaces."}},{"@type":"Question","name":"How is UMA different from traditional microservices?","acceptedAnswer":{"@type":"Answer","text":"Traditional microservices usually focus on deployable units, service ownership, and networked boundaries. UMA focuses on a different question: can the same business behavior remain stable while the execution context changes? That leads to a stronger emphasis on portability, contracts, runtime visibility, and long-term system coherence. If you want the longer version of that comparison, the dedicated UMA vs traditional microservices page goes deeper without flattening the distinction into a slogan."}},{"@type":"Question","name":"Does UMA replace frontend and backend architecture?","acceptedAnswer":{"@type":"Answer","text":"No. UMA does not erase frontend, backend, edge, or cloud concerns. It gives teams a different way to place business behavior inside those environments. The important shift is that service meaning is no longer tightly bound to one stack."}},{"@type":"Question","name":"Is UMA only about WebAssembly?","acceptedAnswer":{"@type":"Answer","text":"No. WebAssembly is a strong fit because it gives portable behavior a practical execution boundary, but the larger subject is architectural coherence across runtimes. UMA is about service meaning, contracts, runtime visibility, and system evolution."}},{"@type":"Question","name":"Why does WebAssembly matter here?","acceptedAnswer":{"@type":"Answer","text":"WebAssembly matters because it gives portable service behavior a compact, sandboxed execution target that is easier to move between environments. It does not define the whole model by itself, but it makes runtime portability more practical."}},{"@type":"Question","name":"What belongs in the runtime layer?","acceptedAnswer":{"@type":"Answer","text":"The runtime layer owns the concerns around the service rather than the core behavior inside it. Validation, policy decisions, adapter binding, host capability access, transport, observability, and trust enforcement belong in the runtime because they vary by environment."}},{"@type":"Question","name":"How do I prove portability instead of assuming it?","acceptedAnswer":{"@type":"Answer","text":"Portability should be validated with evidence. Run the same service behavior in more than one runtime target, compare the outputs, and inspect the surrounding runtime behavior that shapes the result. The examples on this site are designed to make that proof visible instead of leaving it implicit. The how to prove portability page turns that answer into a more concrete checklist based on observable parity and explicit runtime differences."}},{"@type":"Question","name":"Do the UMA examples publish any benchmark or footprint data?","acceptedAnswer":{"@type":"Answer","text":"Yes. The site now includes benchmark and footprint notes for selected early chapters so readers can inspect artifact size, repeated timing data, and the exact local environment used to generate them. The point is not to claim one universal winner. It is to show the tradeoff honestly and make the portability claim inspectable. The benchmark and footprint notes page is the best place to start if you want measured proof before reading deeper into the model."}},{"@type":"Question","name":"What should happen when compatibility breaks in a UMA service graph?","acceptedAnswer":{"@type":"Answer","text":"The break should remain visible. Missing edges, waiting consumers, or failed compatibility checks are healthier than a system that quietly hides the problem, because they make graph drift inspectable and easier to repair. The service graph evolution page now covers that failure-and-recovery angle more directly."}},{"@type":"Question","name":"Can a UMA system work and still be architecturally incoherent?","acceptedAnswer":{"@type":"Answer","text":"Yes. A system can still produce the expected result while degrading through over-granular boundaries, vague event semantics, runtime ambiguity, or orchestration that makes the architecture harder to explain than the output suggests. The what makes a system coherent? page isolates that distinction directly."}},{"@type":"Question","name":"How can a system evolve without fragmentation?","acceptedAnswer":{"@type":"Answer","text":"By keeping change anchored to explicit behavior, visible compatibility, and governed coexistence. Drift does not always mean a rewrite is next, but it does mean the system needs a clear authority for deciding which behavior is still valid. The how systems evolve without fragmentation page follows that progression from contract anchor through drift, duplication, version sprawl, and runtime-governed recovery."}},{"@type":"Question","name":"Where do trust boundaries live in UMA?","acceptedAnswer":{"@type":"Answer","text":"Trust boundaries live in the runtime and governance layer around the portable service. Identity resolution, permissions, provenance, policy evaluation, and audit evidence should stay visible there rather than being hidden inside business logic."}},{"@type":"Question","name":"Can a service be valid and still be denied in UMA?","acceptedAnswer":{"@type":"Answer","text":"Yes. A service can be syntactically valid and still be denied because it requested undeclared permissions, carries untrusted dependency provenance, or attempts communication the runtime trust policy does not allow. The trust boundaries page now covers that distinction more directly, including why compatibility alone is not the same thing as authorization."}},{"@type":"Question","name":"What is the difference between an agent and the runtime in UMA?","acceptedAnswer":{"@type":"Answer","text":"The agent is the reasoning side of the system. It can interpret a goal, inspect available capabilities, and propose a path. The runtime is the authority side of the system. It validates contracts, enforces constraints, and decides what is actually allowed to execute."}},{"@type":"Question","name":"What is a capability in UMA?","acceptedAnswer":{"@type":"Answer","text":"A capability is the unit the runtime can discover and reason about. It represents a named piece of behavior with a visible contract and enough meaning for the runtime to validate, select, reject, or compose into a workflow."}},{"@type":"Question","name":"What makes a service portable in UMA?","acceptedAnswer":{"@type":"Answer","text":"A service becomes portable when its business behavior stays stable, its contract remains explicit, its outputs stay comparable across runtimes, and the runtime-specific concerns around it do not quietly redefine the rule itself. The what makes a service portable? page turns that into a practical design test instead of leaving portability as a vague promise."}},{"@type":"Question","name":"What is a workflow in UMA?","acceptedAnswer":{"@type":"Answer","text":"A workflow is the path the runtime approves from one or more capabilities in order to satisfy a goal. It is visible enough for the system to explain why that path was chosen."}},{"@type":"Question","name":"What is contract-driven orchestration?","acceptedAnswer":{"@type":"Answer","text":"Contract-driven orchestration means the runtime creates the execution path from declared events, subscriptions, metadata, and policy instead of burying the flow inside handwritten workflow glue. That makes orchestration much easier to govern and audit. The contract-driven orchestration page goes deeper into why that distinction matters once systems start emitting events and binding subscribers dynamically."}},{"@type":"Question","name":"What is a UMA runtime?","acceptedAnswer":{"@type":"Answer","text":"A UMA runtime is the governed layer around portable behavior. It discovers capabilities, checks compatibility and constraints, approves the valid execution path, and keeps enough evidence for the result to remain explainable afterward."}},{"@type":"Question","name":"What makes a decision discoverable in UMA?","acceptedAnswer":{"@type":"Answer","text":"A decision becomes discoverable when proposal, validation, revision, approved execution, and trace remain inspectable as artifacts instead of collapsing into one opaque runtime result. The what makes a decision discoverable? page turns that into a concrete lifecycle."}},{"@type":"Question","name":"What belongs in the runtime layer?","acceptedAnswer":{"@type":"Answer","text":"The runtime layer should own validation, adapter binding, policy, trust, lifecycle evidence, and the conditions around execution that vary by environment. The service should keep the durable rule; the runtime should keep the governed execution context around it. The dedicated what belongs in the runtime layer? page turns that split into a practical design question instead of leaving it as a slogan."}},{"@type":"Question","name":"What is WASM MCP in UMA?","acceptedAnswer":{"@type":"Answer","text":"WASM MCP is the discovery and invocation surface the runtime can use to understand which capabilities are available. It makes capability availability more explicit instead of leaving it buried inside implementation code."}},{"@type":"Question","name":"What does governed execution mean?","acceptedAnswer":{"@type":"Answer","text":"Governed execution means that the runtime can explain why a capability was allowed, denied, routed, or adapted in a specific way. The point is not only to run code, but to keep the decisions around that execution understandable and reviewable."}},{"@type":"Question","name":"Can UMA support enterprise systems?","acceptedAnswer":{"@type":"Answer","text":"Yes. In fact, UMA is most relevant when systems have to survive scale, multiple runtimes, organizational boundaries, and long product lifecycles. That is where hidden drift and runtime ambiguity become expensive, and where clearer contracts and boundaries matter most."}},{"@type":"Question","name":"Do I need to adopt UMA all at once?","acceptedAnswer":{"@type":"Answer","text":"No. The model can start with a single portable service and then expand as runtime, orchestration, trust, and governance concerns become more important. That is also how the book and examples are structured."}},{"@type":"Question","name":"Who is UMA for?","acceptedAnswer":{"@type":"Answer","text":"UMA is most useful for architects, senior engineers, platform engineers, and technical leads who need a more durable way to reason about systems that cross runtime boundaries and long product lifecycles."}},{"@type":"Question","name":"Where should I start?","acceptedAnswer":{"@type":"Answer","text":"Start with the What is UMA? page if you want the conceptual definition. Start with the Learning Path if you want the chapter sequence. Start with the Examples page if you want runnable proof immediately."}},{"@type":"Question","name":"Do I need to move away from Medium to use this site?","acceptedAnswer":{"@type":"Answer","text":"No. Medium can remain the publishing channel while this site acts as the authority hub for the book, examples, topic pages, and the reader journey. The two properties can support each other instead of competing."}}]}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -258,35 +39,66 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#foundations">Foundations</a>
+    <ul class="page-rail-links">
+      <li><a href="#what-is-universal-microservices-architecture">What is Universal Microservices Architecture?</a></li><li><a href="#why-does-uma-exist">Why does UMA exist?</a></li><li><a href="#what-problem-does-uma-solve-that-good-platform-tooling-still-leaves-behind">What problem does UMA solve that good platform tooling still leaves behind?</a></li><li><a href="#what-is-the-difference-between-stack-ownership-and-behavior-ownership">What is the difference between stack ownership and behavior ownership?</a></li><li><a href="#what-does-runtime-agnostic-architecture-actually-mean">What does runtime-agnostic architecture actually mean?</a></li><li><a href="#how-is-uma-different-from-traditional-microservices">How is UMA different from traditional microservices?</a></li><li><a href="#does-uma-replace-frontend-and-backend-architecture">Does UMA replace frontend and backend architecture?</a></li>
+    </ul></li><li><a href="#runtime-and-execution">Runtime and execution</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-uma-only-about-webassembly">Is UMA only about WebAssembly?</a></li><li><a href="#why-does-webassembly-matter-here">Why does WebAssembly matter here?</a></li><li><a href="#what-belongs-in-the-runtime-layer">What belongs in the runtime layer?</a></li><li><a href="#how-do-i-prove-portability-instead-of-assuming-it">How do I prove portability instead of assuming it?</a></li><li><a href="#do-the-uma-examples-publish-any-benchmark-or-footprint-data">Do the UMA examples publish any benchmark or footprint data?</a></li><li><a href="#what-should-happen-when-compatibility-breaks-in-a-uma-service-graph">What should happen when compatibility breaks in a UMA service graph?</a></li><li><a href="#can-a-uma-system-work-and-still-be-architecturally-incoherent">Can a UMA system work and still be architecturally incoherent?</a></li><li><a href="#how-can-a-system-evolve-without-fragmentation">How can a system evolve without fragmentation?</a></li>
+    </ul></li><li><a href="#governance-and-trust">Governance and trust</a>
+    <ul class="page-rail-links">
+      <li><a href="#where-do-trust-boundaries-live-in-uma">Where do trust boundaries live in UMA?</a></li><li><a href="#can-a-service-be-valid-and-still-be-denied-in-uma">Can a service be valid and still be denied in UMA?</a></li><li><a href="#what-is-the-difference-between-an-agent-and-the-runtime-in-uma">What is the difference between an agent and the runtime in UMA?</a></li><li><a href="#what-is-a-capability-in-uma">What is a capability in UMA?</a></li><li><a href="#what-makes-a-service-portable-in-uma">What makes a service portable in UMA?</a></li><li><a href="#what-is-a-workflow-in-uma">What is a workflow in UMA?</a></li><li><a href="#what-is-contract-driven-orchestration">What is contract-driven orchestration?</a></li><li><a href="#what-is-a-uma-runtime">What is a UMA runtime?</a></li><li><a href="#what-makes-a-decision-discoverable-in-uma">What makes a decision discoverable in UMA?</a></li><li><a href="#what-belongs-in-the-runtime-layer-2">What belongs in the runtime layer?</a></li><li><a href="#what-is-wasm-mcp-in-uma">What is WASM MCP in UMA?</a></li><li><a href="#what-does-governed-execution-mean">What does governed execution mean?</a></li><li><a href="#can-uma-support-enterprise-systems">Can UMA support enterprise systems?</a></li>
+    </ul></li><li><a href="#adoption-and-learning-path">Adoption and learning path</a>
+    <ul class="page-rail-links">
+      <li><a href="#do-i-need-to-adopt-uma-all-at-once">Do I need to adopt UMA all at once?</a></li><li><a href="#who-is-uma-for">Who is UMA for?</a></li><li><a href="#where-should-i-start">Where should I start?</a></li><li><a href="#do-i-need-to-move-away-from-medium-to-use-this-site">Do I need to move away from Medium to use this site?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA FAQ</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Universal Microservices Architecture FAQ</h1>
           <p>
             This FAQ is meant to be maintained over time as the site, examples, and book evolve. It collects short, direct answers to the
@@ -298,22 +110,22 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>Foundations</h2>
-            <h3>What is Universal Microservices Architecture?</h3>
+            <h2 id="foundations">Foundations</h2>
+            <h3 id="what-is-universal-microservices-architecture">What is Universal Microservices Architecture?</h3>
             <p>
               Universal Microservices Architecture is an execution model for distributed systems where compute can happen in many places
               and the system decides where logic runs. It keeps service behavior portable while making contracts, runtime policy, trust,
               and execution boundaries explicit.
             </p>
-            <h3>Why does UMA exist?</h3>
+            <h3 id="why-does-uma-exist">Why does UMA exist?</h3>
             <p>
               UMA exists because modern systems increasingly duplicate the same business logic across many runtime surfaces. That duplication
               creates drift, inconsistent outcomes, and hidden architecture. UMA addresses that by preserving one portable expression of the
               behavior and surrounding it with explicit runtime governance.
             </p>
-            <h3>What problem does UMA solve that good platform tooling still leaves behind?</h3>
+            <h3 id="what-problem-does-uma-solve-that-good-platform-tooling-still-leaves-behind">What problem does UMA solve that good platform tooling still leaves behind?</h3>
             <p>
               UMA solves a different problem from deployment tooling alone. Platforms can schedule, route, and observe workloads well, but
               they do not automatically keep one business behavior coherent across browser, edge, backend, workflow, and AI-assisted
@@ -323,12 +135,12 @@
               The dedicated <a href="../what-problem-does-uma-solve/">what problem does UMA solve?</a> page is the fastest entry point if
               you want the direct version of that argument before the wider concept cluster.
             </p>
-            <h3>What is the difference between stack ownership and behavior ownership?</h3>
+            <h3 id="what-is-the-difference-between-stack-ownership-and-behavior-ownership">What is the difference between stack ownership and behavior ownership?</h3>
             <p>
               Stack ownership organizes software around runtime or team boundaries. Behavior ownership organizes it around the durable rule
               or domain meaning that must survive across those boundaries. UMA pushes toward the second view.
             </p>
-            <h3>What does runtime-agnostic architecture actually mean?</h3>
+            <h3 id="what-does-runtime-agnostic-architecture-actually-mean">What does runtime-agnostic architecture actually mean?</h3>
             <p>
               It means the service behavior can stay semantically stable while the runtime around it changes. Validation, transport,
               placement, identity, permissions, and trust still matter, but they stop being the place where the business meaning of the
@@ -341,7 +153,7 @@
               The dedicated <a href="../runtime-agnostic-architecture/">runtime-agnostic architecture</a> page goes deeper into that
               distinction and why it matters for modern systems that span browser, edge, backend, and workflow execution surfaces.
             </p>
-            <h3>How is UMA different from traditional microservices?</h3>
+            <h3 id="how-is-uma-different-from-traditional-microservices">How is UMA different from traditional microservices?</h3>
             <p>
               Traditional microservices usually focus on deployable units, service ownership, and networked boundaries. UMA focuses on a
               different question: can the same business behavior remain stable while the execution context changes? That leads to a stronger
@@ -352,7 +164,7 @@
               <a href="../uma-vs-traditional-microservices/">UMA vs traditional microservices</a> page goes deeper without flattening the
               distinction into a slogan.
             </p>
-            <h3>Does UMA replace frontend and backend architecture?</h3>
+            <h3 id="does-uma-replace-frontend-and-backend-architecture">Does UMA replace frontend and backend architecture?</h3>
             <p>
               No. UMA does not erase frontend, backend, edge, or cloud concerns. It gives teams a different way to place business behavior
               inside those environments. The important shift is that service meaning is no longer tightly bound to one stack.
@@ -360,24 +172,24 @@
           </section>
 
           <section>
-            <h2>Runtime and execution</h2>
-            <h3>Is UMA only about WebAssembly?</h3>
+            <h2 id="runtime-and-execution">Runtime and execution</h2>
+            <h3 id="is-uma-only-about-webassembly">Is UMA only about WebAssembly?</h3>
             <p>
               No. WebAssembly is a strong fit because it gives portable behavior a practical execution boundary, but the larger subject is
               architectural coherence across runtimes. UMA is about service meaning, contracts, runtime visibility, and system evolution.
             </p>
-            <h3>Why does WebAssembly matter here?</h3>
+            <h3 id="why-does-webassembly-matter-here">Why does WebAssembly matter here?</h3>
             <p>
               WebAssembly matters because it gives portable service behavior a compact, sandboxed execution target that is easier to move
               between environments. It does not define the whole model by itself, but it makes runtime portability more practical.
             </p>
-            <h3>What belongs in the runtime layer?</h3>
+            <h3 id="what-belongs-in-the-runtime-layer">What belongs in the runtime layer?</h3>
             <p>
               The runtime layer owns the concerns around the service rather than the core behavior inside it. Validation, policy decisions,
               adapter binding, host capability access, transport, observability, and trust enforcement belong in the runtime because they
               vary by environment.
             </p>
-            <h3>How do I prove portability instead of assuming it?</h3>
+            <h3 id="how-do-i-prove-portability-instead-of-assuming-it">How do I prove portability instead of assuming it?</h3>
             <p>
               Portability should be validated with evidence. Run the same service behavior in more than one runtime target, compare the
               outputs, and inspect the surrounding runtime behavior that shapes the result. The examples on this site are designed to make
@@ -387,7 +199,7 @@
               The <a href="../how-to-prove-portability/">how to prove portability</a> page turns that answer into a more concrete checklist
               based on observable parity and explicit runtime differences.
             </p>
-            <h3>Do the UMA examples publish any benchmark or footprint data?</h3>
+            <h3 id="do-the-uma-examples-publish-any-benchmark-or-footprint-data">Do the UMA examples publish any benchmark or footprint data?</h3>
             <p>
               Yes. The site now includes benchmark and footprint notes for selected early chapters so readers can inspect artifact size,
               repeated timing data, and the exact local environment used to generate them. The point is not to claim one universal winner.
@@ -397,7 +209,7 @@
               The <a href="../benchmark-and-footprint/">benchmark and footprint notes</a> page is the best place to start if you want
               measured proof before reading deeper into the model.
             </p>
-            <h3>What should happen when compatibility breaks in a UMA service graph?</h3>
+            <h3 id="what-should-happen-when-compatibility-breaks-in-a-uma-service-graph">What should happen when compatibility breaks in a UMA service graph?</h3>
             <p>
               The break should remain visible. Missing edges, waiting consumers, or failed compatibility checks are healthier than a system
               that quietly hides the problem, because they make graph drift inspectable and easier to repair.
@@ -406,7 +218,7 @@
               The <a href="../service-graph-evolution/">service graph evolution</a> page now covers that failure-and-recovery angle more
               directly.
             </p>
-            <h3>Can a UMA system work and still be architecturally incoherent?</h3>
+            <h3 id="can-a-uma-system-work-and-still-be-architecturally-incoherent">Can a UMA system work and still be architecturally incoherent?</h3>
             <p>
               Yes. A system can still produce the expected result while degrading through over-granular boundaries, vague event semantics,
               runtime ambiguity, or orchestration that makes the architecture harder to explain than the output suggests.
@@ -414,7 +226,7 @@
             <p>
               The <a href="../what-makes-a-system-coherent/">what makes a system coherent?</a> page isolates that distinction directly.
             </p>
-            <h3>How can a system evolve without fragmentation?</h3>
+            <h3 id="how-can-a-system-evolve-without-fragmentation">How can a system evolve without fragmentation?</h3>
             <p>
               By keeping change anchored to explicit behavior, visible compatibility, and governed coexistence. Drift does not always mean
               a rewrite is next, but it does mean the system needs a clear authority for deciding which behavior is still valid.
@@ -426,13 +238,13 @@
           </section>
 
           <section>
-            <h2>Governance and trust</h2>
-            <h3>Where do trust boundaries live in UMA?</h3>
+            <h2 id="governance-and-trust">Governance and trust</h2>
+            <h3 id="where-do-trust-boundaries-live-in-uma">Where do trust boundaries live in UMA?</h3>
             <p>
               Trust boundaries live in the runtime and governance layer around the portable service. Identity resolution, permissions,
               provenance, policy evaluation, and audit evidence should stay visible there rather than being hidden inside business logic.
             </p>
-            <h3>Can a service be valid and still be denied in UMA?</h3>
+            <h3 id="can-a-service-be-valid-and-still-be-denied-in-uma">Can a service be valid and still be denied in UMA?</h3>
             <p>
               Yes. A service can be syntactically valid and still be denied because it requested undeclared permissions, carries untrusted
               dependency provenance, or attempts communication the runtime trust policy does not allow.
@@ -441,18 +253,18 @@
               The <a href="../trust-boundaries/">trust boundaries</a> page now covers that distinction more directly, including why
               compatibility alone is not the same thing as authorization.
             </p>
-            <h3>What is the difference between an agent and the runtime in UMA?</h3>
+            <h3 id="what-is-the-difference-between-an-agent-and-the-runtime-in-uma">What is the difference between an agent and the runtime in UMA?</h3>
             <p>
               The agent is the reasoning side of the system. It can interpret a goal, inspect available capabilities, and propose a path.
               The runtime is the authority side of the system. It validates contracts, enforces constraints, and decides what is actually
               allowed to execute.
             </p>
-            <h3>What is a capability in UMA?</h3>
+            <h3 id="what-is-a-capability-in-uma">What is a capability in UMA?</h3>
             <p>
               A capability is the unit the runtime can discover and reason about. It represents a named piece of behavior with a visible
               contract and enough meaning for the runtime to validate, select, reject, or compose into a workflow.
             </p>
-            <h3>What makes a service portable in UMA?</h3>
+            <h3 id="what-makes-a-service-portable-in-uma">What makes a service portable in UMA?</h3>
             <p>
               A service becomes portable when its business behavior stays stable, its contract remains explicit, its outputs stay
               comparable across runtimes, and the runtime-specific concerns around it do not quietly redefine the rule itself.
@@ -461,12 +273,12 @@
               The <a href="../what-makes-a-service-portable/">what makes a service portable?</a> page turns that into a practical design
               test instead of leaving portability as a vague promise.
             </p>
-            <h3>What is a workflow in UMA?</h3>
+            <h3 id="what-is-a-workflow-in-uma">What is a workflow in UMA?</h3>
             <p>
               A workflow is the path the runtime approves from one or more capabilities in order to satisfy a goal. It is visible enough
               for the system to explain why that path was chosen.
             </p>
-            <h3>What is contract-driven orchestration?</h3>
+            <h3 id="what-is-contract-driven-orchestration">What is contract-driven orchestration?</h3>
             <p>
               Contract-driven orchestration means the runtime creates the execution path from declared events, subscriptions, metadata, and
               policy instead of burying the flow inside handwritten workflow glue. That makes orchestration much easier to govern and audit.
@@ -475,12 +287,12 @@
               The <a href="../contract-driven-orchestration/">contract-driven orchestration</a> page goes deeper into why that distinction
               matters once systems start emitting events and binding subscribers dynamically.
             </p>
-            <h3>What is a UMA runtime?</h3>
+            <h3 id="what-is-a-uma-runtime">What is a UMA runtime?</h3>
             <p>
               A UMA runtime is the governed layer around portable behavior. It discovers capabilities, checks compatibility and
               constraints, approves the valid execution path, and keeps enough evidence for the result to remain explainable afterward.
             </p>
-            <h3>What makes a decision discoverable in UMA?</h3>
+            <h3 id="what-makes-a-decision-discoverable-in-uma">What makes a decision discoverable in UMA?</h3>
             <p>
               A decision becomes discoverable when proposal, validation, revision, approved execution, and trace remain inspectable as
               artifacts instead of collapsing into one opaque runtime result.
@@ -489,7 +301,7 @@
               The <a href="../what-makes-a-decision-discoverable/">what makes a decision discoverable?</a> page turns that into a concrete
               lifecycle.
             </p>
-            <h3>What belongs in the runtime layer?</h3>
+            <h3 id="what-belongs-in-the-runtime-layer-2">What belongs in the runtime layer?</h3>
             <p>
               The runtime layer should own validation, adapter binding, policy, trust, lifecycle evidence, and the conditions around
               execution that vary by environment. The service should keep the durable rule; the runtime should keep the governed execution
@@ -499,17 +311,17 @@
               The dedicated <a href="../what-belongs-in-the-runtime-layer/">what belongs in the runtime layer?</a> page turns that split
               into a practical design question instead of leaving it as a slogan.
             </p>
-            <h3>What is WASM MCP in UMA?</h3>
+            <h3 id="what-is-wasm-mcp-in-uma">What is WASM MCP in UMA?</h3>
             <p>
               WASM MCP is the discovery and invocation surface the runtime can use to understand which capabilities are available. It makes
               capability availability more explicit instead of leaving it buried inside implementation code.
             </p>
-            <h3>What does governed execution mean?</h3>
+            <h3 id="what-does-governed-execution-mean">What does governed execution mean?</h3>
             <p>
               Governed execution means that the runtime can explain why a capability was allowed, denied, routed, or adapted in a specific
               way. The point is not only to run code, but to keep the decisions around that execution understandable and reviewable.
             </p>
-            <h3>Can UMA support enterprise systems?</h3>
+            <h3 id="can-uma-support-enterprise-systems">Can UMA support enterprise systems?</h3>
             <p>
               Yes. In fact, UMA is most relevant when systems have to survive scale, multiple runtimes, organizational boundaries, and long
               product lifecycles. That is where hidden drift and runtime ambiguity become expensive, and where clearer contracts and
@@ -518,24 +330,24 @@
           </section>
 
           <section>
-            <h2>Adoption and learning path</h2>
-            <h3>Do I need to adopt UMA all at once?</h3>
+            <h2 id="adoption-and-learning-path">Adoption and learning path</h2>
+            <h3 id="do-i-need-to-adopt-uma-all-at-once">Do I need to adopt UMA all at once?</h3>
             <p>
               No. The model can start with a single portable service and then expand as runtime, orchestration, trust, and governance
               concerns become more important. That is also how the book and examples are structured.
             </p>
-            <h3>Who is UMA for?</h3>
+            <h3 id="who-is-uma-for">Who is UMA for?</h3>
             <p>
               UMA is most useful for architects, senior engineers, platform engineers, and technical leads who need a more durable way to
               reason about systems that cross runtime boundaries and long product lifecycles.
             </p>
-            <h3>Where should I start?</h3>
+            <h3 id="where-should-i-start">Where should I start?</h3>
             <p>
               Start with the <a href="../what-is-uma/">What is UMA?</a> page if you want the conceptual definition. Start with the
               <a href="../learning-path/">Learning Path</a> if you want the chapter sequence. Start with the
               <a href="../examples/">Examples</a> page if you want runnable proof immediately.
             </p>
-            <h3>Do I need to move away from Medium to use this site?</h3>
+            <h3 id="do-i-need-to-move-away-from-medium-to-use-this-site">Do I need to move away from Medium to use this site?</h3>
             <p>
               No. Medium can remain the publishing channel while this site acts as the authority hub for the book, examples, topic pages,
               and the reader journey. The two properties can support each other instead of competing.
@@ -571,7 +383,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/from-stack-ownership-to-behavior-ownership/index.html
+++ b/book-site/from-stack-ownership-to-behavior-ownership/index.html
@@ -3,56 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>From Stack Ownership to Behavior Ownership | UMA and Software Architecture</title>
-    <meta
-      name="description"
-      content="Learn why modern software architecture needs to move from stack ownership to behavior ownership, and how UMA reframes systems around durable business meaning."
-    />
+    <title>From Stack Ownership to Behavior Ownership | Universal Microservices Architecture</title>
+    <meta name="description" content="Learn why modern software architecture needs to move from stack ownership to behavior ownership, and how UMA reframes systems around durable business meaning." />
     <link rel="canonical" href="https://www.universalmicroservices.com/from-stack-ownership-to-behavior-ownership/" />
-    <meta property="og:title" content="From Stack Ownership to Behavior Ownership | UMA and Software Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to one of the key UMA shifts: stop organizing software architecture only around stacks, and start preserving behavior as the durable unit."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="From Stack Ownership to Behavior Ownership" />
+    <meta property="og:description" content="Learn why modern software architecture needs to move from stack ownership to behavior ownership, and how UMA reframes systems around durable business meaning." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/from-stack-ownership-to-behavior-ownership/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "From Stack Ownership to Behavior Ownership",
-  "description": "An original explanation of why software architecture drifts when business behavior is owned by stacks, and why UMA centers durable service behavior instead.",
-  "url": "https://www.universalmicroservices.com/from-stack-ownership-to-behavior-ownership/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/from-stack-ownership-to-behavior-ownership/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"From Stack Ownership to Behavior Ownership","item":"https://www.universalmicroservices.com/from-stack-ownership-to-behavior-ownership/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"From Stack Ownership to Behavior Ownership","description":"Learn why modern software architecture needs to move from stack ownership to behavior ownership, and how UMA reframes systems around durable business meaning.","url":"https://www.universalmicroservices.com/from-stack-ownership-to-behavior-ownership/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-stack-ownership-was-not-irrational">Why stack ownership was not irrational</a></li><li><a href="#what-behavior-ownership-changes">What behavior ownership changes</a>
+    <ul class="page-rail-links">
+      <li><a href="#stack-ownership">Stack ownership</a></li><li><a href="#behavior-ownership">Behavior ownership</a></li><li><a href="#stack-ownership-risk">Stack ownership risk</a></li><li><a href="#behavior-ownership-gain">Behavior ownership gain</a></li>
+    </ul></li><li><a href="#why-this-matters-more-now-than-before">Why this matters more now than before</a></li><li><a href="#how-uma-reframes-the-problem">How UMA reframes the problem</a></li><li><a href="#what-this-looks-like-in-practice">What this looks like in practice</a></li><li><a href="#how-to-tell-when-the-architecture-is-still-stack-owned">How to tell when the architecture is still stack-owned</a></li><li><a href="#what-this-idea-is-not">What this idea is not</a></li><li><a href="#a-practical-design-test">A practical design test</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#does-behavior-ownership-replace-team-ownership">Does behavior ownership replace team ownership?</a></li><li><a href="#is-behavior-ownership-just-another-name-for-reusable-business-logic">Is behavior ownership just another name for reusable business logic?</a></li><li><a href="#why-is-this-idea-useful-before-the-rest-of-uma">Why is this idea useful before the rest of UMA?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">From Stack Ownership to Behavior Ownership</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>From stack ownership to behavior ownership</h1>
           <p>
             One of the biggest hidden shifts in modern architecture is this: the durable unit of value is no longer the stack that runs the
@@ -97,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               Stack ownership organizes software around where code lives. Behavior ownership organizes software around what the system must
               keep meaningfully correct. UMA matters because modern products often lose that second perspective. Teams know who owns the
@@ -111,7 +114,7 @@
           </section>
 
           <section>
-            <h2>Why stack ownership was not irrational</h2>
+            <h2 id="why-stack-ownership-was-not-irrational">Why stack ownership was not irrational</h2>
             <p>
               Organizing work around stacks was a practical response to real engineering constraints. Teams needed clear boundaries. They
               needed ownership models that matched tools, deployment pipelines, and operational accountability. That approach still solves
@@ -125,7 +128,7 @@
           </section>
 
           <section>
-            <h2>What behavior ownership changes</h2>
+            <h2 id="what-behavior-ownership-changes">What behavior ownership changes</h2>
             <p>
               Behavior ownership asks a different question: what part of the system must remain semantically stable even when execution
               moves? Instead of starting from frontend, backend, or edge as the default unit, it starts from the rule, decision, or domain
@@ -144,25 +147,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Stack ownership</h3>
+              <h3 id="stack-ownership">Stack ownership</h3>
               <p>Clear for team boundaries, deployment pipelines, and local responsibility.</p>
             </article>
             <article class="subpage-card">
-              <h3>Behavior ownership</h3>
+              <h3 id="behavior-ownership">Behavior ownership</h3>
               <p>Clear for preserving one durable business meaning across many execution contexts.</p>
             </article>
             <article class="subpage-card">
-              <h3>Stack ownership risk</h3>
+              <h3 id="stack-ownership-risk">Stack ownership risk</h3>
               <p>The same rule gets reauthored wherever delivery pressure is highest.</p>
             </article>
             <article class="subpage-card">
-              <h3>Behavior ownership gain</h3>
+              <h3 id="behavior-ownership-gain">Behavior ownership gain</h3>
               <p>The architecture keeps one reference point for what the service actually means.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why this matters more now than before</h2>
+            <h2 id="why-this-matters-more-now-than-before">Why this matters more now than before</h2>
             <p>
               Older systems could sometimes get away with stack-centered ownership because execution surfaces were fewer and more stable.
               Modern systems rarely have that luxury. A product may need the same behavior in web UX, backend enforcement, edge response,
@@ -175,7 +178,7 @@
           </section>
 
           <section>
-            <h2>How UMA reframes the problem</h2>
+            <h2 id="how-uma-reframes-the-problem">How UMA reframes the problem</h2>
             <p>
               UMA does not erase stacks. It changes what the architecture treats as durable. The durable unit becomes the portable service
               behavior, expressed through contracts and surrounded by runtime governance. The stacks still exist. They simply stop owning
@@ -188,7 +191,7 @@
           </section>
 
           <section>
-            <h2>What this looks like in practice</h2>
+            <h2 id="what-this-looks-like-in-practice">What this looks like in practice</h2>
             <p>
               In a stack-owned design, the frontend owns part of a rule for responsiveness, the backend owns a second version for
               authority, and a workflow or report layer owns a third copy for automation. In a behavior-owned design, the rule has a more
@@ -201,7 +204,7 @@
           </section>
 
           <section>
-            <h2>How to tell when the architecture is still stack-owned</h2>
+            <h2 id="how-to-tell-when-the-architecture-is-still-stack-owned">How to tell when the architecture is still stack-owned</h2>
             <p>
               Look for moments where the same business rule is described differently depending on which team you ask. If the browser team
               describes one version, the backend team describes a second version, and the workflow or reporting layer carries a third,
@@ -214,7 +217,7 @@
           </section>
 
           <section>
-            <h2>What this idea is not</h2>
+            <h2 id="what-this-idea-is-not">What this idea is not</h2>
             <ul>
               <li>It is not an argument that teams should stop owning systems.</li>
               <li>It is not a claim that runtimes no longer matter.</li>
@@ -225,7 +228,7 @@
           </section>
 
           <section>
-            <h2>A practical design test</h2>
+            <h2 id="a-practical-design-test">A practical design test</h2>
             <p>
               Ask this question: if one important behavior changes, who owns the update? If the answer is “several stacks, in different
               ways,” the system is still stack-owned at the behavioral level. If the answer is “one durable service meaning, with runtime
@@ -237,18 +240,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Does behavior ownership replace team ownership?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="does-behavior-ownership-replace-team-ownership">Does behavior ownership replace team ownership?</h3>
             <p>
               No. Teams still need clear ownership. The shift is architectural: team boundaries should not silently become the only place
               where business meaning is defined.
             </p>
-            <h3>Is behavior ownership just another name for reusable business logic?</h3>
+            <h3 id="is-behavior-ownership-just-another-name-for-reusable-business-logic">Is behavior ownership just another name for reusable business logic?</h3>
             <p>
               Not quite. Reuse is part of it, but behavior ownership is really about preserving one durable source of semantic truth across
               multiple runtime surfaces.
             </p>
-            <h3>Why is this idea useful before the rest of UMA?</h3>
+            <h3 id="why-is-this-idea-useful-before-the-rest-of-uma">Why is this idea useful before the rest of UMA?</h3>
             <p>
               Because it explains why the later concepts matter. Capabilities, workflows, runtimes, and discovery all make more sense once
               the architecture stops centering only on stacks.
@@ -275,7 +278,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/how-systems-evolve-without-fragmentation/index.html
+++ b/book-site/how-systems-evolve-without-fragmentation/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How Do Systems Evolve Without Fragmentation? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn how UMA keeps systems evolving without fragmentation by making drift, duplication, version coexistence, and runtime governance explicit."
-    />
+    <meta name="description" content="Learn how UMA keeps systems evolving without fragmentation by making drift, duplication, version coexistence, and runtime governance explicit." />
     <link rel="canonical" href="https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/" />
-    <meta property="og:title" content="How Do Systems Evolve Without Fragmentation? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to keeping software evolution governed: from behavioral drift and duplication to version sprawl and runtime-governed coexistence."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="How Do Systems Evolve Without Fragmentation?" />
+    <meta property="og:description" content="Learn how UMA keeps systems evolving without fragmentation by making drift, duplication, version coexistence, and runtime governance explicit." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "How Do Systems Evolve Without Fragmentation?",
-  "description": "An original explanation of how systems can keep changing without splitting apart, focused on drift, duplication, version sprawl, and runtime-governed coexistence.",
-  "url": "https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"How Do Systems Evolve Without Fragmentation?","item":"https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"How Do Systems Evolve Without Fragmentation?","description":"Learn how UMA keeps systems evolving without fragmentation by making drift, duplication, version coexistence, and runtime governance explicit.","url":"https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-fragmentation-happens-gradually">Why fragmentation happens gradually</a>
+    <ul class="page-rail-links">
+      <li><a href="#drift-starts-with-meaning">Drift starts with meaning</a></li><li><a href="#duplication-multiplies-drift">Duplication multiplies drift</a></li><li><a href="#versioning-needs-rules">Versioning needs rules</a></li><li><a href="#recovery-should-be-governed">Recovery should be governed</a></li>
+    </ul></li><li><a href="#what-drift-looks-like-before-a-system-is-obviously-broken">What drift looks like before a system is obviously broken</a></li><li><a href="#why-contracts-matter-more-during-change-than-at-launch">Why contracts matter more during change than at launch</a></li><li><a href="#when-versioning-helps-and-when-it-makes-things-worse">When versioning helps and when it makes things worse</a></li><li><a href="#why-runtime-governed-coexistence-matters">Why runtime-governed coexistence matters</a></li><li><a href="#a-practical-progression-to-watch-for">A practical progression to watch for</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#does-evolving-without-fragmentation-mean-avoiding-change">Does evolving without fragmentation mean avoiding change?</a></li><li><a href="#is-duplication-always-wrong">Is duplication always wrong?</a></li><li><a href="#do-i-need-a-rewrite-to-recover-coherence">Do I need a rewrite to recover coherence?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">How Do Systems Evolve Without Fragmentation?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>How do systems evolve without fragmentation?</h1>
           <p>
             Systems rarely fragment because one team chooses chaos on purpose. They fragment because small, locally sensible changes keep
@@ -97,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               A system evolves without fragmentation when change stays anchored to explicit behavior, visible compatibility, and governed
               coexistence. The architecture needs a way to absorb drift, versioning, and brownfield constraints without letting each local
@@ -112,7 +115,7 @@
           </section>
 
           <section>
-            <h2>Why fragmentation happens gradually</h2>
+            <h2 id="why-fragmentation-happens-gradually">Why fragmentation happens gradually</h2>
             <p>
               Most systems do not jump from coherence to fragmentation in one release. They slide there through a sequence that looks
               reasonable up close: one consumer interprets behavior differently, one team duplicates an implementation to move faster, one
@@ -127,25 +130,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Drift starts with meaning</h3>
+              <h3 id="drift-starts-with-meaning">Drift starts with meaning</h3>
               <p>Two components can still look compatible in shape while quietly diverging in what they mean by the same behavior.</p>
             </article>
             <article class="subpage-card">
-              <h3>Duplication multiplies drift</h3>
+              <h3 id="duplication-multiplies-drift">Duplication multiplies drift</h3>
               <p>Copying behavior into parallel implementations often solves a short-term problem while creating two futures to govern.</p>
             </article>
             <article class="subpage-card">
-              <h3>Versioning needs rules</h3>
+              <h3 id="versioning-needs-rules">Versioning needs rules</h3>
               <p>Multiple versions can coexist safely only when the runtime can explain who may use what and under which conditions.</p>
             </article>
             <article class="subpage-card">
-              <h3>Recovery should be governed</h3>
+              <h3 id="recovery-should-be-governed">Recovery should be governed</h3>
               <p>Healthy recovery does not always mean a rewrite. It often means clearer contracts and stronger runtime approval.</p>
             </article>
           </section>
 
           <section>
-            <h2>What drift looks like before a system is obviously broken</h2>
+            <h2 id="what-drift-looks-like-before-a-system-is-obviously-broken">What drift looks like before a system is obviously broken</h2>
             <p>
               Drift usually appears before any full outage. A report still renders, but one region uses different semantics. A workflow
               still completes, but only because several compatibility assumptions remain tribal knowledge. A service still answers, but the
@@ -158,7 +161,7 @@
           </section>
 
           <section>
-            <h2>Why contracts matter more during change than at launch</h2>
+            <h2 id="why-contracts-matter-more-during-change-than-at-launch">Why contracts matter more during change than at launch</h2>
             <p>
               Contracts are often treated as launch-time artifacts. In practice, they become more valuable after the system has been in the
               wild for a while. They give the architecture a reference point for deciding whether behavior is still the same behavior, or
@@ -171,7 +174,7 @@
           </section>
 
           <section>
-            <h2>When versioning helps and when it makes things worse</h2>
+            <h2 id="when-versioning-helps-and-when-it-makes-things-worse">When versioning helps and when it makes things worse</h2>
             <p>
               Versioning is not the enemy. Ungoverned versioning is. Keeping two versions alive for a while can be entirely reasonable if
               the system knows which consumers are compatible, which policies apply, and how coexistence will eventually narrow back toward
@@ -184,7 +187,7 @@
           </section>
 
           <section>
-            <h2>Why runtime-governed coexistence matters</h2>
+            <h2 id="why-runtime-governed-coexistence-matters">Why runtime-governed coexistence matters</h2>
             <p>
               The strongest recovery pattern is often not “replace everything now.” It is “make coexistence explicit and govern it.” That
               means the runtime can resolve which implementation is valid for which consumer, which rules still hold, and what evidence
@@ -198,7 +201,7 @@
           </section>
 
           <section>
-            <h2>A practical progression to watch for</h2>
+            <h2 id="a-practical-progression-to-watch-for">A practical progression to watch for</h2>
             <ol>
               <li>One contract clearly anchors the behavior.</li>
               <li>Different consumers start stretching that meaning.</li>
@@ -214,18 +217,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Does evolving without fragmentation mean avoiding change?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="does-evolving-without-fragmentation-mean-avoiding-change">Does evolving without fragmentation mean avoiding change?</h3>
             <p>
               No. It means avoiding change that multiplies hidden meanings faster than the architecture can govern them. Healthy evolution is
               still active change, not stasis.
             </p>
-            <h3>Is duplication always wrong?</h3>
+            <h3 id="is-duplication-always-wrong">Is duplication always wrong?</h3>
             <p>
               Not automatically. The issue is whether duplication is temporary, visible, and governed, or whether it becomes a quiet second
               source of truth that keeps drifting.
             </p>
-            <h3>Do I need a rewrite to recover coherence?</h3>
+            <h3 id="do-i-need-a-rewrite-to-recover-coherence">Do I need a rewrite to recover coherence?</h3>
             <p>
               Not always. Many systems recover by clarifying contracts, making coexistence explicit, and moving final authority into the
               runtime instead of leaving it in informal coordination.
@@ -252,7 +255,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/how-to-prove-portability/index.html
+++ b/book-site/how-to-prove-portability/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>How to Prove Portability | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn how to prove portability in UMA by comparing observable behavior across runtimes instead of assuming that shared code is enough."
-    />
+    <meta name="description" content="Learn how to prove portability in UMA by comparing observable behavior across runtimes instead of assuming that shared code is enough." />
     <link rel="canonical" href="https://www.universalmicroservices.com/how-to-prove-portability/" />
-    <meta property="og:title" content="How to Prove Portability | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to proving portability in UMA through observable parity, explicit contracts, and visible runtime differences."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="How to Prove Portability" />
+    <meta property="og:description" content="Learn how to prove portability in UMA by comparing observable behavior across runtimes instead of assuming that shared code is enough." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/how-to-prove-portability/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "How to Prove Portability",
-  "description": "An original explanation of how to prove portability in Universal Microservices Architecture by comparing behavior across runtimes rather than trusting code structure alone.",
-  "url": "https://www.universalmicroservices.com/how-to-prove-portability/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/how-to-prove-portability/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"How to Prove Portability","item":"https://www.universalmicroservices.com/how-to-prove-portability/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"How to Prove Portability","description":"Learn how to prove portability in UMA by comparing observable behavior across runtimes instead of assuming that shared code is enough.","url":"https://www.universalmicroservices.com/how-to-prove-portability/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-shared-code-is-not-enough">Why shared code is not enough</a></li><li><a href="#what-to-compare-instead">What to compare instead</a>
+    <ul class="page-rail-links">
+      <li><a href="#compare-results">Compare results</a></li><li><a href="#keep-differences-visible">Keep differences visible</a></li><li><a href="#trust-emitted-evidence">Trust emitted evidence</a></li><li><a href="#let-the-contract-lead">Let the contract lead</a></li>
+    </ul></li><li><a href="#why-observable-parity-matters">Why observable parity matters</a></li><li><a href="#why-target-specific-behavior-should-stay-explicit">Why target-specific behavior should stay explicit</a></li><li><a href="#how-portability-usually-gets-overstated">How portability usually gets overstated</a></li><li><a href="#a-practical-portability-proof-checklist">A practical portability proof checklist</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#does-portability-require-byte-for-byte-identical-execution">Does portability require byte-for-byte identical execution?</a></li><li><a href="#why-compare-events-or-payloads-instead-of-internal-code-paths">Why compare events or payloads instead of internal code paths?</a></li><li><a href="#can-a-portability-check-fail-and-still-be-useful">Can a portability check fail and still be useful?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">How to Prove Portability</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>How to prove portability</h1>
           <p>
             Portability is easy to claim and harder to prove. In UMA, portability becomes credible only when the same service behavior can
@@ -96,9 +99,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               You prove portability by comparing observable behavior, not by trusting shared source code or similar intent. If two runtime
               targets emit the same governed result from the same contract and input, portability is becoming evidence instead of a slogan.
@@ -110,7 +113,7 @@
           </section>
 
           <section>
-            <h2>Why shared code is not enough</h2>
+            <h2 id="why-shared-code-is-not-enough">Why shared code is not enough</h2>
             <p>
               Shared code can be a useful starting point, but it does not prove the behavior is stable once the code is compiled, hosted,
               and run under different runtime constraints. Subtle host assumptions, missing capabilities, data-shape drift, and adapter
@@ -123,7 +126,7 @@
           </section>
 
           <section>
-            <h2>What to compare instead</h2>
+            <h2 id="what-to-compare-instead">What to compare instead</h2>
             <p>
               The most useful comparison point is observable behavior. That can mean a shared result payload, an emitted event, a stable
               output shape, or another contract-visible artifact that shows the service behaved the same way under two runtimes.
@@ -136,25 +139,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Compare results</h3>
+              <h3 id="compare-results">Compare results</h3>
               <p>Use the same contract and input, then compare the resulting behavior across runtimes.</p>
             </article>
             <article class="subpage-card">
-              <h3>Keep differences visible</h3>
+              <h3 id="keep-differences-visible">Keep differences visible</h3>
               <p>Target-specific capabilities should stay explicit instead of leaking into the portable path unnoticed.</p>
             </article>
             <article class="subpage-card">
-              <h3>Trust emitted evidence</h3>
+              <h3 id="trust-emitted-evidence">Trust emitted evidence</h3>
               <p>Event streams, payloads, and digests make parity easier to inspect than implementation claims alone.</p>
             </article>
             <article class="subpage-card">
-              <h3>Let the contract lead</h3>
+              <h3 id="let-the-contract-lead">Let the contract lead</h3>
               <p>Portability is more credible when the same contract governs both targets without hidden forks.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why observable parity matters</h2>
+            <h2 id="why-observable-parity-matters">Why observable parity matters</h2>
             <p>
               Observable parity is stronger than “both implementations look similar.” If two runtimes converge on the same contract-shaped
               result, the architecture can point to something concrete. If they do not, the system has already learned something valuable:
@@ -167,7 +170,7 @@
           </section>
 
           <section>
-            <h2>Why target-specific behavior should stay explicit</h2>
+            <h2 id="why-target-specific-behavior-should-stay-explicit">Why target-specific behavior should stay explicit</h2>
             <p>
               Proving portability does not mean pretending every runtime should behave identically in every respect. Some capabilities are
               inherently target-specific. The important point is that those differences stay visible and do not contaminate the portable
@@ -180,7 +183,7 @@
           </section>
 
           <section>
-            <h2>How portability usually gets overstated</h2>
+            <h2 id="how-portability-usually-gets-overstated">How portability usually gets overstated</h2>
             <p>
               Teams often overstate portability when they stop at “the same logic compiles” or “the implementations are based on the same
               design.” Those are encouraging signs, but they are not enough. Portability becomes trustworthy only when the system can show
@@ -193,7 +196,7 @@
           </section>
 
           <section>
-            <h2>A practical portability proof checklist</h2>
+            <h2 id="a-practical-portability-proof-checklist">A practical portability proof checklist</h2>
             <ul>
               <li>Use one explicit contract across the runtime targets you are comparing.</li>
               <li>Run the same service behavior with the same relevant input.</li>
@@ -204,18 +207,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Does portability require byte-for-byte identical execution?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="does-portability-require-byte-for-byte-identical-execution">Does portability require byte-for-byte identical execution?</h3>
             <p>
               No. What matters is that the portable behavior stays semantically aligned. Some runtime-specific details may differ, but the
               business result being protected should remain stable.
             </p>
-            <h3>Why compare events or payloads instead of internal code paths?</h3>
+            <h3 id="why-compare-events-or-payloads-instead-of-internal-code-paths">Why compare events or payloads instead of internal code paths?</h3>
             <p>
               Because emitted results are what the architecture can actually prove. Internal similarity is informative, but it does not
               settle whether the system behaved the same way in practice.
             </p>
-            <h3>Can a portability check fail and still be useful?</h3>
+            <h3 id="can-a-portability-check-fail-and-still-be-useful">Can a portability check fail and still be useful?</h3>
             <p>
               Yes. A failed portability check is still valuable because it shows exactly where the architecture is not yet as runtime-agnostic
               or contract-disciplined as it claimed to be.
@@ -242,7 +245,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/incremental-uma-adoption/index.html
+++ b/book-site/incremental-uma-adoption/index.html
@@ -7,28 +7,93 @@
     <meta name="description" content="Learn how UMA can begin with one portable capability and coexist with legacy systems through adapters, governed boundaries, and gradual runtime adoption." />
     <link rel="canonical" href="https://www.universalmicroservices.com/incremental-uma-adoption/" />
     <meta property="og:title" content="Incremental UMA Adoption" />
-    <meta property="og:description" content="A practical preview of adopting UMA without a full rewrite." />
+    <meta property="og:description" content="Learn how UMA can begin with one portable capability and coexist with legacy systems through adapters, governed boundaries, and gradual runtime adoption." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/incremental-uma-adoption/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Incremental UMA Adoption","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/incremental-uma-adoption/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Incremental UMA Adoption","item":"https://www.universalmicroservices.com/incremental-uma-adoption/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Incremental UMA Adoption","description":"Learn how UMA can begin with one portable capability and coexist with legacy systems through adapters, governed boundaries, and gradual runtime adoption.","url":"https://www.universalmicroservices.com/incremental-uma-adoption/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
   </head>
   <body>
-    <div class="page-shell">
-      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+    <div class="page-shell has-page-rail">
+      <header class="topbar">
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#start-with-the-boundary">Start with the boundary</a>
+    <ul class="page-rail-links">
+      <li><a href="#one-behavior">One behavior</a></li><li><a href="#one-contract">One contract</a></li><li><a href="#one-runtime-wrapper">One runtime wrapper</a></li><li><a href="#one-migration-path">One migration path</a></li>
+    </ul></li><li><a href="#where-the-book-goes-further">Where the book goes further</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero"><h1>Incremental UMA adoption</h1><p>UMA does not require a rewrite. It can start with one portable behavior, one contract, or one runtime-governed boundary inside a system that still has legacy services and ordinary deployment infrastructure.</p></section>
-        <div class="subpage-body">
-          <section><h2>Start with the boundary</h2><p>The practical first step is not replacing your platform. It is finding a duplicated behavior or fragile runtime decision and moving that behavior behind an explicit contract and runtime-evaluated boundary.</p><p>Adapters let existing hosts participate while the portable core stays visible.</p></section>
-          <section class="subpage-grid"><article class="subpage-card"><h3>One behavior</h3><p>Choose a rule or normalization path that is repeated across environments.</p></article><article class="subpage-card"><h3>One contract</h3><p>Define what the behavior accepts, returns, emits, and depends on.</p></article><article class="subpage-card"><h3>One runtime wrapper</h3><p>Add validation, adapter binding, and lifecycle evidence around it.</p></article><article class="subpage-card"><h3>One migration path</h3><p>Keep legacy internals where needed while governing the boundary.</p></article></section>
-          <section><h2>Where the book goes further</h2><p>The full adoption story is not only about starting. It is about avoiding fragmentation as more versions, consumers, and runtime surfaces appear. That is why Chapter 11 matters so much.</p></section>
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Incremental UMA Adoption</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero"><h1>Incremental UMA adoption</h1><p>UMA does not require a rewrite. It can start with one portable behavior, one contract, or one runtime-governed boundary inside a system that still has legacy services and ordinary deployment infrastructure.</p></section>
+
+<div class="subpage-body">
+          <section><h2 id="start-with-the-boundary">Start with the boundary</h2><p>The practical first step is not replacing your platform. It is finding a duplicated behavior or fragile runtime decision and moving that behavior behind an explicit contract and runtime-evaluated boundary.</p><p>Adapters let existing hosts participate while the portable core stays visible.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3 id="one-behavior">One behavior</h3><p>Choose a rule or normalization path that is repeated across environments.</p></article><article class="subpage-card"><h3 id="one-contract">One contract</h3><p>Define what the behavior accepts, returns, emits, and depends on.</p></article><article class="subpage-card"><h3 id="one-runtime-wrapper">One runtime wrapper</h3><p>Add validation, adapter binding, and lifecycle evidence around it.</p></article><article class="subpage-card"><h3 id="one-migration-path">One migration path</h3><p>Keep legacy internals where needed while governing the boundary.</p></article></section>
+          <section><h2 id="where-the-book-goes-further">Where the book goes further</h2><p>The full adoption story is not only about starting. It is about avoiding fragmentation as more versions, consumers, and runtime surfaces appear. That is why Chapter 11 matters so much.</p></section>
           <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapters 5 and 6 show the first runtime and portability steps. Chapter 11 explains hybrid adoption without forcing a rewrite.</p><div class="subpage-inline-links"><a href="../examples/chapter-05-post-fetcher-runtime/">Chapter 5 example</a><a href="../examples/chapter-06-portability-lab/">Chapter 6 example</a><a href="../examples/chapter-11-evolution-without-fragmentation/">Chapter 11 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
         </div>
         <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/book-site/late-bound-policy-enforcement/index.html
+++ b/book-site/late-bound-policy-enforcement/index.html
@@ -7,28 +7,93 @@
     <meta name="description" content="A conversion-focused preview of late-bound policy enforcement in UMA: how runtimes apply policy, placement, trust, and compliance rules around portable services." />
     <link rel="canonical" href="https://www.universalmicroservices.com/late-bound-policy-enforcement/" />
     <meta property="og:title" content="Late-Bound Policy Enforcement in UMA" />
-    <meta property="og:description" content="How UMA keeps policy close to execution while preserving portable service behavior." />
+    <meta property="og:description" content="A conversion-focused preview of late-bound policy enforcement in UMA: how runtimes apply policy, placement, trust, and compliance rules around portable services." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/late-bound-policy-enforcement/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Late-Bound Policy Enforcement in UMA","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/late-bound-policy-enforcement/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Late-Bound Policy Enforcement in UMA","item":"https://www.universalmicroservices.com/late-bound-policy-enforcement/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Late-Bound Policy Enforcement in UMA","description":"A conversion-focused preview of late-bound policy enforcement in UMA: how runtimes apply policy, placement, trust, and compliance rules around portable services.","url":"https://www.universalmicroservices.com/late-bound-policy-enforcement/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
   </head>
   <body>
-    <div class="page-shell">
-      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+    <div class="page-shell has-page-rail">
+      <header class="topbar">
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#why-late-bound-policy-matters">Why late-bound policy matters</a>
+    <ul class="page-rail-links">
+      <li><a href="#local-decision">Local decision</a></li><li><a href="#fail-fast">Fail fast</a></li><li><a href="#policy-evidence">Policy evidence</a></li><li><a href="#portable-core">Portable core</a></li>
+    </ul></li><li><a href="#what-this-page-does-not-replace">What this page does not replace</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero"><h1>Late-bound policy enforcement</h1><p>UMA treats policy as something evaluated near execution, not as a static diagram note. The runtime can apply placement, trust, compliance, and fail-fast rules without rewriting the portable service.</p></section>
-        <div class="subpage-body">
-          <section><h2>Why late-bound policy matters</h2><p>Distributed systems often hardwire policy into deployment scripts, gateway configuration, or application code. That makes the policy hard to audit and hard to move with the behavior it governs.</p><p>UMA keeps the portable behavior separate while letting runtime authority decide whether a specific execution path is allowed under current conditions.</p></section>
-          <section class="subpage-grid"><article class="subpage-card"><h3>Local decision</h3><p>The runtime evaluates the metadata it has, instead of relying on hidden centralized coordination for every choice.</p></article><article class="subpage-card"><h3>Fail fast</h3><p>Invalid or disallowed runs should stop before adapter execution and side effects begin.</p></article><article class="subpage-card"><h3>Policy evidence</h3><p>The run should show which policy shaped the outcome.</p></article><article class="subpage-card"><h3>Portable core</h3><p>The service logic remains stable while execution conditions change around it.</p></article></section>
-          <section><h2>What this page does not replace</h2><p>The full book goes deeper into how validation, adapter binding, policy, and lifecycle evidence fit together. This page is the orientation layer: it tells you why the idea matters and where to inspect it in code.</p></section>
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Late-Bound Policy Enforcement in UMA</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero"><h1>Late-bound policy enforcement</h1><p>UMA treats policy as something evaluated near execution, not as a static diagram note. The runtime can apply placement, trust, compliance, and fail-fast rules without rewriting the portable service.</p></section>
+
+<div class="subpage-body">
+          <section><h2 id="why-late-bound-policy-matters">Why late-bound policy matters</h2><p>Distributed systems often hardwire policy into deployment scripts, gateway configuration, or application code. That makes the policy hard to audit and hard to move with the behavior it governs.</p><p>UMA keeps the portable behavior separate while letting runtime authority decide whether a specific execution path is allowed under current conditions.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3 id="local-decision">Local decision</h3><p>The runtime evaluates the metadata it has, instead of relying on hidden centralized coordination for every choice.</p></article><article class="subpage-card"><h3 id="fail-fast">Fail fast</h3><p>Invalid or disallowed runs should stop before adapter execution and side effects begin.</p></article><article class="subpage-card"><h3 id="policy-evidence">Policy evidence</h3><p>The run should show which policy shaped the outcome.</p></article><article class="subpage-card"><h3 id="portable-core">Portable core</h3><p>The service logic remains stable while execution conditions change around it.</p></article></section>
+          <section><h2 id="what-this-page-does-not-replace">What this page does not replace</h2><p>The full book goes deeper into how validation, adapter binding, policy, and lifecycle evidence fit together. This page is the orientation layer: it tells you why the idea matters and where to inspect it in code.</p></section>
           <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 5 introduces the runtime layer, Chapter 7 applies policy in orchestration, and Chapter 9 turns trust into explicit enforcement.</p><div class="subpage-inline-links"><a href="../examples/chapter-05-post-fetcher-runtime/">Chapter 5 example</a><a href="../examples/chapter-07-metadata-orchestration/">Chapter 7 example</a><a href="../examples/chapter-09-trust-boundaries/">Chapter 9 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
         </div>
         <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/book-site/learning-path/index.html
+++ b/book-site/learning-path/index.html
@@ -4,37 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UMA Learning Path | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Follow a chapter-by-chapter Universal Microservices Architecture learning path, from portable services to trust boundaries, graph evolution, discoverable decisions, and portable MCP runtime composition."
-    />
+    <meta name="description" content="Follow a chapter-by-chapter Universal Microservices Architecture learning path, from portable services to trust boundaries, graph evolution, discoverable decisions, and portable MCP runtime composition." />
     <link rel="canonical" href="https://www.universalmicroservices.com/learning-path/" />
-    <meta property="og:title" content="UMA Learning Path | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="A practical learning path through Universal Microservices Architecture, sequenced to move from one portable service to governed system evolution, discoverable decisions, and portable MCP runtime composition."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="UMA Learning Path" />
+    <meta property="og:description" content="Follow a chapter-by-chapter Universal Microservices Architecture learning path, from portable services to trust boundaries, graph evolution, discoverable decisions, and portable MCP runtime composition." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/learning-path/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA Learning Path","item":"https://www.universalmicroservices.com/learning-path/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA Learning Path","description":"Follow a chapter-by-chapter Universal Microservices Architecture learning path, from portable services to trust boundaries, graph evolution, discoverable decisions, and portable MCP runtime composition.","url":"https://www.universalmicroservices.com/learning-path/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#why-the-path-is-sequenced">Why the path is sequenced</a></li><li><a href="#the-logic-behind-the-sequence">The logic behind the sequence</a>
+    <ul class="page-rail-links">
+      <li><a href="#start-with-one-portable-service">Start with one portable service</a></li><li><a href="#add-the-runtime-layer">Add the runtime layer</a></li><li><a href="#watch-systems-emerge">Watch systems emerge</a></li><li><a href="#follow-governance-and-evolution">Follow governance and evolution</a></li>
+    </ul></li><li><a href="#how-to-use-it-well">How to use it well</a></li><li><a href="#what-the-path-teaches-by-the-end">What the path teaches by the end</a></li><li><a href="#where-chapters-12-and-13-change-the-learning-path">Where Chapters 12 and 13 change the learning path</a></li><li><a href="#best-path-for-different-readers">Best path for different readers</a></li><li><a href="#frequently-asked-question">Frequently asked question</a>
+    <ul class="page-rail-links">
+      <li><a href="#can-i-skip-ahead-to-later-chapters">Can I skip ahead to later chapters?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA Learning Path</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>The UMA learning path</h1>
           <p>
             The Universal Microservices Architecture learning path is designed to make a demanding architectural model teachable. It begins
@@ -79,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>Why the path is sequenced</h2>
+            <h2 id="why-the-path-is-sequenced">Why the path is sequenced</h2>
             <p>
               UMA only makes sense when the reader can see how each new concern changes the meaning of the architecture. That is why the
               material is sequenced instead of presented as a loose catalog. The early chapters establish what is portable. The later
@@ -90,7 +111,7 @@
           </section>
 
           <section>
-            <h2>The logic behind the sequence</h2>
+            <h2 id="the-logic-behind-the-sequence">The logic behind the sequence</h2>
             <p>
               The early part of the path establishes the core service model. Without that, portability is just an aspiration. The middle
               part shows how a runtime layer forms around the service and what that layer must own. The later part shows how orchestration,
@@ -105,25 +126,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Start with one portable service</h3>
+              <h3 id="start-with-one-portable-service">Start with one portable service</h3>
               <p>Understand the smallest durable boundary before introducing transport, hosting, or orchestration concerns.</p>
             </article>
             <article class="subpage-card">
-              <h3>Add the runtime layer</h3>
+              <h3 id="add-the-runtime-layer">Add the runtime layer</h3>
               <p>Make validation, adapter binding, transport, and lifecycle evidence visible around the service behavior.</p>
             </article>
             <article class="subpage-card">
-              <h3>Watch systems emerge</h3>
+              <h3 id="watch-systems-emerge">Watch systems emerge</h3>
               <p>See how metadata, event compatibility, and runtime decisions cause a graph and orchestration model to appear.</p>
             </article>
             <article class="subpage-card">
-              <h3>Follow governance and evolution</h3>
+              <h3 id="follow-governance-and-evolution">Follow governance and evolution</h3>
               <p>Understand how trust, compatibility, and system change determine whether portability remains a strength or becomes risk.</p>
             </article>
           </section>
 
           <section>
-            <h2>How to use it well</h2>
+            <h2 id="how-to-use-it-well">How to use it well</h2>
             <p>
               Treat the learning path as a progression, not a menu. Each chapter answers one architectural question and gives the next one
               context. If you skip directly to the later topics, you can still learn from them, but the bigger picture will be harder to
@@ -137,7 +158,7 @@
           </section>
 
           <section>
-            <h2>What the path teaches by the end</h2>
+            <h2 id="what-the-path-teaches-by-the-end">What the path teaches by the end</h2>
             <p>
               By the end of the sequence, the reader should be able to explain more than what UMA is. They should be able to explain why a
               portable service needs contracts, why runtime behavior must remain visible, why trust belongs inside the architectural model,
@@ -150,7 +171,7 @@
           </section>
 
           <section>
-            <h2>Where Chapters 12 and 13 change the learning path</h2>
+            <h2 id="where-chapters-12-and-13-change-the-learning-path">Where Chapters 12 and 13 change the learning path</h2>
             <p>
               Chapter 12 extends the path beyond governed evolution into discoverable decisions. The reader is no longer only asking whether
               the system behaved correctly. They are asking whether projections, proposals, validation feedback, revision, approved execution,
@@ -173,7 +194,7 @@
           </section>
 
           <section>
-            <h2>Best path for different readers</h2>
+            <h2 id="best-path-for-different-readers">Best path for different readers</h2>
             <ul>
               <li>If you are new to UMA, start at the beginning and move chapter by chapter.</li>
               <li>If you already think in platform terms, pair the learning path with the examples and trust pages.</li>
@@ -182,8 +203,8 @@
           </section>
 
           <section>
-            <h2>Frequently asked question</h2>
-            <h3>Can I skip ahead to later chapters?</h3>
+            <h2 id="frequently-asked-question">Frequently asked question</h2>
+            <h3 id="can-i-skip-ahead-to-later-chapters">Can I skip ahead to later chapters?</h3>
             <p>
               You can, but the later material is much more useful when the early service and runtime model is already clear. The sequence is
               part of the teaching strategy, not just the table of contents.
@@ -211,7 +232,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/migrating-to-uma-incrementally/index.html
+++ b/book-site/migrating-to-uma-incrementally/index.html
@@ -3,19 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Migrating to UMA Incrementally | Universal Microservices Migration</title>
+    <title>Migrating to UMA Incrementally | Universal Microservices Architecture</title>
     <meta name="description" content="A practical conceptual guide to incremental UMA migration for greenfield and brownfield systems without requiring a full rewrite." />
     <link rel="canonical" href="https://www.universalmicroservices.com/migrating-to-uma-incrementally/" />
-    <meta property="og:title" content="Migrating to UMA Incrementally | Universal Microservices Migration" />
-    <meta property="og:description" content="How to adopt UMA incrementally through capability extraction, strangler paths, and runtime-governed rollout." />
+    <meta property="og:title" content="Migrating to UMA Incrementally" />
+    <meta property="og:description" content="A practical conceptual guide to incremental UMA migration for greenfield and brownfield systems without requiring a full rewrite." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/migrating-to-uma-incrementally/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Migrating to UMA incrementally","description":"A practical conceptual guide to incremental UMA migration for greenfield and brownfield systems without requiring a full rewrite.","url":"https://www.universalmicroservices.com/migrating-to-uma-incrementally/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/migrating-to-uma-incrementally/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Migrating to UMA Incrementally","item":"https://www.universalmicroservices.com/migrating-to-uma-incrementally/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Migrating to UMA Incrementally","description":"A practical conceptual guide to incremental UMA migration for greenfield and brownfield systems without requiring a full rewrite.","url":"https://www.universalmicroservices.com/migrating-to-uma-incrementally/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -26,53 +30,103 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#start-with-one-capability">Start with one capability</a></li><li><a href="#greenfield-adoption">Greenfield adoption</a></li><li><a href="#brownfield-adoption">Brownfield adoption</a></li><li><a href="#use-a-strangler-path">Use a strangler path</a></li><li><a href="#incremental-rollout">Incremental rollout</a>
+    <ul class="page-rail-links">
+      <li><a href="#find-drift">Find drift</a></li><li><a href="#extract-capability">Extract capability</a></li><li><a href="#prove-parity">Prove parity</a></li><li><a href="#expand-carefully">Expand carefully</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Migrating to UMA Incrementally</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Migrating to UMA incrementally</h1>
           <p>UMA does not require a full-platform rewrite. A practical migration begins with one behavior that is duplicated, hard to govern, or forced to run in more than one place. From there, the team extracts a capability, defines its contract, proves portability, and expands only when the result is useful.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>Start with one capability</h2>
+            <h2 id="start-with-one-capability">Start with one capability</h2>
             <p>The best first candidate is a rule or decision that already appears in multiple places. Feature flags, eligibility checks, routing decisions, and policy evaluations are common starting points.</p>
             <p>The goal is not to universalize everything. The goal is to find one behavior where portability reduces drift.</p>
           </section>
 
           <section>
-            <h2>Greenfield adoption</h2>
+            <h2 id="greenfield-adoption">Greenfield adoption</h2>
             <p>In a greenfield system, UMA can start as a design discipline. Define the capability, contract, runtime expectations, and validation path before choosing all host-specific details.</p>
             <p>That keeps the first service small enough to understand while still teaching the team the model.</p>
           </section>
 
           <section>
-            <h2>Brownfield adoption</h2>
+            <h2 id="brownfield-adoption">Brownfield adoption</h2>
             <p>In an existing system, begin beside the current implementation. Keep the old path alive, extract the behavior into a portable service, and compare outputs before moving traffic or workflow authority.</p>
             <p>This makes migration observable rather than ideological.</p>
           </section>
 
           <section>
-            <h2>Use a strangler path</h2>
+            <h2 id="use-a-strangler-path">Use a strangler path</h2>
             <p>A strangler path works well when one capability can be routed gradually to the UMA implementation. The surrounding system keeps operating while the runtime earns authority through tests, telemetry, and controlled rollout.</p>
             <p>This approach also helps teams avoid creating a second architecture that nobody trusts.</p>
           </section>
 
           <section>
-            <h2>Incremental rollout</h2>
+            <h2 id="incremental-rollout">Incremental rollout</h2>
             <p>Roll out by capability, not by layer. A team can adopt one portable service, one runtime wrapper, one validation flow, and one chapter-aligned proof point before expanding the approach to other parts of the system.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Find drift</h3><p>Look for behavior copied across client, edge, backend, and workflow paths.</p></article>
-            <article class="subpage-card"><h3>Extract capability</h3><p>Name the durable behavior before choosing the new runtime shape.</p></article>
-            <article class="subpage-card"><h3>Prove parity</h3><p>Compare outputs across the old path and the portable implementation.</p></article>
-            <article class="subpage-card"><h3>Expand carefully</h3><p>Move the next behavior only after the runtime path is understandable and governed.</p></article>
+            <article class="subpage-card"><h3 id="find-drift">Find drift</h3><p>Look for behavior copied across client, edge, backend, and workflow paths.</p></article>
+            <article class="subpage-card"><h3 id="extract-capability">Extract capability</h3><p>Name the durable behavior before choosing the new runtime shape.</p></article>
+            <article class="subpage-card"><h3 id="prove-parity">Prove parity</h3><p>Compare outputs across the old path and the portable implementation.</p></article>
+            <article class="subpage-card"><h3 id="expand-carefully">Expand carefully</h3><p>Move the next behavior only after the runtime path is understandable and governed.</p></article>
           </section>
           <section class="subpage-callout">
             <strong>Want to go deeper?</strong>

--- a/book-site/portable-business-logic/index.html
+++ b/book-site/portable-business-logic/index.html
@@ -4,37 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portable Business Logic | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Understand portable business logic through the UMA model: what should stay durable, what should stay explicit, and how to avoid stack-bound rewrites."
-    />
+    <meta name="description" content="Understand portable business logic through the UMA model: what should stay durable, what should stay explicit, and how to avoid stack-bound rewrites." />
     <link rel="canonical" href="https://www.universalmicroservices.com/portable-business-logic/" />
-    <meta property="og:title" content="Portable Business Logic | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to portable business logic and why it matters for runtime-agnostic, modular, long-lived software systems."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Portable Business Logic" />
+    <meta property="og:description" content="Understand portable business logic through the UMA model: what should stay durable, what should stay explicit, and how to avoid stack-bound rewrites." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/portable-business-logic/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Portable Business Logic","item":"https://www.universalmicroservices.com/portable-business-logic/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Portable Business Logic","description":"Understand portable business logic through the UMA model: what should stay durable, what should stay explicit, and how to avoid stack-bound rewrites.","url":"https://www.universalmicroservices.com/portable-business-logic/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-portable-business-logic-actually-means">What portable business logic actually means</a></li><li><a href="#what-should-be-portable">What should be portable</a></li><li><a href="#why-contracts-matter-so-much">Why contracts matter so much</a>
+    <ul class="page-rail-links">
+      <li><a href="#keep-the-core-stable">Keep the core stable</a></li><li><a href="#make-bindings-visible">Make bindings visible</a></li><li><a href="#version-the-behavior">Version the behavior</a></li><li><a href="#reduce-stack-ownership">Reduce stack ownership</a></li>
+    </ul></li><li><a href="#why-teams-benefit">Why teams benefit</a></li><li><a href="#what-portability-does-not-mean">What portability does not mean</a></li><li><a href="#where-teams-usually-go-wrong">Where teams usually go wrong</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-portable-business-logic-the-same-as-shared-code">Is portable business logic the same as shared code?</a></li><li><a href="#does-portable-business-logic-remove-the-need-for-runtime-specific-code">Does portable business logic remove the need for runtime-specific code?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Portable Business Logic</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Portable business logic</h1>
           <p>
             Portable business logic is the part of the system that should outlast frameworks, hosts, and deployment patterns. In UMA, that
@@ -79,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>What portable business logic actually means</h2>
+            <h2 id="what-portable-business-logic-actually-means">What portable business logic actually means</h2>
             <p>
               Portable business logic is not just shared code or a convenience library. It is the part of the system that preserves rules,
               decisions, and domain meaning even when the surrounding runtime changes. In UMA, that logic is treated as a durable service
@@ -100,7 +121,7 @@
           </section>
 
           <section>
-            <h2>What should be portable</h2>
+            <h2 id="what-should-be-portable">What should be portable</h2>
             <p>
               The most valuable behavior in a product is the part that encodes rules, decisions, and domain meaning. That is the behavior
               worth preserving. User-interface concerns, infrastructure integration, transport details, and host capabilities still matter,
@@ -114,7 +135,7 @@
           </section>
 
           <section>
-            <h2>Why contracts matter so much</h2>
+            <h2 id="why-contracts-matter-so-much">Why contracts matter so much</h2>
             <p>
               Contracts are what make portability governable instead of aspirational. They give the service a visible shape: inputs,
               outputs, constraints, and expectations. Without them, “shared logic” tends to become a soft promise that each runtime
@@ -128,25 +149,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Keep the core stable</h3>
+              <h3 id="keep-the-core-stable">Keep the core stable</h3>
               <p>Portable logic should not change just because the system moved from browser to edge or from edge to cloud.</p>
             </article>
             <article class="subpage-card">
-              <h3>Make bindings visible</h3>
+              <h3 id="make-bindings-visible">Make bindings visible</h3>
               <p>Capabilities, adapters, and runtime bindings should surround the logic instead of being fused into it.</p>
             </article>
             <article class="subpage-card">
-              <h3>Version the behavior</h3>
+              <h3 id="version-the-behavior">Version the behavior</h3>
               <p>A portable service boundary is easier to test, compare, evolve, and reason about than duplicated stack-owned logic.</p>
             </article>
             <article class="subpage-card">
-              <h3>Reduce stack ownership</h3>
+              <h3 id="reduce-stack-ownership">Reduce stack ownership</h3>
               <p>The architecture becomes more coherent when rules belong to the service model rather than to the frontend or backend toolchain.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why teams benefit</h2>
+            <h2 id="why-teams-benefit">Why teams benefit</h2>
             <p>
               When the logic stays portable, teams spend less time reconciling behavior across implementations and more time improving the
               product. It also becomes easier to reason about change because the durable business meaning of the service stops moving every
@@ -163,7 +184,7 @@
           </section>
 
           <section>
-            <h2>What portability does not mean</h2>
+            <h2 id="what-portability-does-not-mean">What portability does not mean</h2>
             <ul>
               <li>It does not mean every service should execute in every environment.</li>
               <li>It does not mean UI concerns disappear into the service layer.</li>
@@ -174,7 +195,7 @@
           </section>
 
           <section>
-            <h2>Where teams usually go wrong</h2>
+            <h2 id="where-teams-usually-go-wrong">Where teams usually go wrong</h2>
             <p>
               A common failure mode is to preserve only part of the logic while letting runtime code fill in the rest through implicit
               assumptions. Another is to call something portable while it still depends on local framework state, hidden host bindings, or
@@ -187,13 +208,13 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is portable business logic the same as shared code?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-portable-business-logic-the-same-as-shared-code">Is portable business logic the same as shared code?</h3>
             <p>
               Not exactly. Shared code can still be vague, under-governed, or tied to local assumptions. Portable business logic is shared
               through a clear service boundary with explicit contracts and a runtime story around it.
             </p>
-            <h3>Does portable business logic remove the need for runtime-specific code?</h3>
+            <h3 id="does-portable-business-logic-remove-the-need-for-runtime-specific-code">Does portable business logic remove the need for runtime-specific code?</h3>
             <p>
               No. Runtime-specific code still matters for validation, transport, trust, adaptation, and integration. The point is that this
               code should stay around the service instead of silently becoming the place where the business behavior is redefined.
@@ -220,7 +241,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/runtime-agnostic-architecture/index.html
+++ b/book-site/runtime-agnostic-architecture/index.html
@@ -3,38 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Runtime-agnostic Architecture | UMA and Portable Software Design</title>
-    <meta
-      name="description"
-      content="Understand runtime-agnostic architecture through the UMA lens: portable behavior, explicit runtime responsibilities, and more coherent software systems."
-    />
+    <title>Runtime-agnostic Architecture | Universal Microservices Architecture</title>
+    <meta name="description" content="Understand runtime-agnostic architecture through the UMA lens: portable behavior, explicit runtime responsibilities, and more coherent software systems." />
     <link rel="canonical" href="https://www.universalmicroservices.com/runtime-agnostic-architecture/" />
-    <meta property="og:title" content="Runtime-agnostic Architecture | UMA and Portable Software Design" />
-    <meta
-      property="og:description"
-      content="An original guide to runtime-agnostic architecture, focused on what should stay portable and what must remain governed by the runtime."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Runtime-agnostic Architecture" />
+    <meta property="og:description" content="Understand runtime-agnostic architecture through the UMA lens: portable behavior, explicit runtime responsibilities, and more coherent software systems." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/runtime-agnostic-architecture/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Runtime-agnostic Architecture","item":"https://www.universalmicroservices.com/runtime-agnostic-architecture/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Runtime-agnostic Architecture","description":"Understand runtime-agnostic architecture through the UMA lens: portable behavior, explicit runtime responsibilities, and more coherent software systems.","url":"https://www.universalmicroservices.com/runtime-agnostic-architecture/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-runtime-agnostic-architecture-actually-means">What runtime-agnostic architecture actually means</a></li><li><a href="#what-this-looks-like-in-practice">What this looks like in practice</a></li><li><a href="#what-should-remain-portable">What should remain portable</a></li><li><a href="#what-should-remain-explicit">What should remain explicit</a>
+    <ul class="page-rail-links">
+      <li><a href="#portable-behavior">Portable behavior</a></li><li><a href="#explicit-runtime-rules">Explicit runtime rules</a></li><li><a href="#stable-reasoning">Stable reasoning</a></li><li><a href="#safer-system-growth">Safer system growth</a></li>
+    </ul></li><li><a href="#why-teams-struggle-without-it">Why teams struggle without it</a></li><li><a href="#a-practical-test-for-runtime-agnostic-design">A practical test for runtime-agnostic design</a></li><li><a href="#why-it-matters-now">Why it matters now</a></li><li><a href="#how-uma-frames-the-problem-differently">How UMA frames the problem differently</a></li><li><a href="#common-misunderstandings">Common misunderstandings</a></li><li><a href="#what-a-good-adoption-path-looks-like">What a good adoption path looks like</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#can-a-runtime-agnostic-architecture-still-be-optimized-for-one-runtime">Can a runtime-agnostic architecture still be optimized for one runtime?</a></li><li><a href="#does-runtime-agnostic-architecture-mean-every-service-should-run-everywhere">Does runtime-agnostic architecture mean every service should run everywhere?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Runtime-agnostic Architecture</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Runtime-agnostic architecture</h1>
           <p>
             Runtime-agnostic architecture does not mean that runtimes stop mattering. It means the business behavior of the system no
@@ -79,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>What runtime-agnostic architecture actually means</h2>
+            <h2 id="what-runtime-agnostic-architecture-actually-means">What runtime-agnostic architecture actually means</h2>
             <p>
               Runtime-agnostic architecture is often described too loosely, as if it only means code that can execute in more than one
               place. That is not enough. The harder and more useful question is whether the business meaning of a service can stay stable
@@ -103,7 +124,7 @@
           </section>
 
           <section>
-            <h2>What this looks like in practice</h2>
+            <h2 id="what-this-looks-like-in-practice">What this looks like in practice</h2>
             <p>
               A runtime-agnostic system does not ask every environment to host the same logic in the same way. It asks the architecture to
               preserve one behavioral meaning while letting the runtime decide whether that logic belongs closer to the user, deeper in a
@@ -116,7 +137,7 @@
           </section>
 
           <section>
-            <h2>What should remain portable</h2>
+            <h2 id="what-should-remain-portable">What should remain portable</h2>
             <p>
               The most valuable behavior in a system is usually the part that expresses rules, decisions, and domain meaning. That is the
               behavior that should remain portable. Storage choices, transport layers, host permissions, and placement strategies still
@@ -135,7 +156,7 @@
           </section>
 
           <section>
-            <h2>What should remain explicit</h2>
+            <h2 id="what-should-remain-explicit">What should remain explicit</h2>
             <p>
               A runtime-agnostic model does not hide the runtime. It keeps runtime-specific decisions visible and governable. Validation,
               hosting, transport, permissions, identity, and placement still matter. The difference is that they stop silently redefining
@@ -150,25 +171,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Portable behavior</h3>
+              <h3 id="portable-behavior">Portable behavior</h3>
               <p>Service logic can move between execution environments without forcing a full rewrite of the business model.</p>
             </article>
             <article class="subpage-card">
-              <h3>Explicit runtime rules</h3>
+              <h3 id="explicit-runtime-rules">Explicit runtime rules</h3>
               <p>Validation, transport, trust, and capabilities stay outside the portable core and remain visible to the architect.</p>
             </article>
             <article class="subpage-card">
-              <h3>Stable reasoning</h3>
+              <h3 id="stable-reasoning">Stable reasoning</h3>
               <p>Teams can reason about one service model instead of translating behavior between many platform-specific forms.</p>
             </article>
             <article class="subpage-card">
-              <h3>Safer system growth</h3>
+              <h3 id="safer-system-growth">Safer system growth</h3>
               <p>When runtime decisions are explicit, portability is less likely to collapse into accidental duplication and drift.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why teams struggle without it</h2>
+            <h2 id="why-teams-struggle-without-it">Why teams struggle without it</h2>
             <p>
               Most organizations already support many runtime surfaces whether they planned to or not. A browser client may contain decision
               logic for speed, an edge worker may enforce a variation of the same rule for latency, and a backend service may reimplement
@@ -182,7 +203,7 @@
           </section>
 
           <section>
-            <h2>A practical test for runtime-agnostic design</h2>
+            <h2 id="a-practical-test-for-runtime-agnostic-design">A practical test for runtime-agnostic design</h2>
             <p>
               Ask whether one important behavior can be described once, validated once, and then adapted by several runtimes without
               rewriting the rule itself. If the answer is no, the architecture is still runtime-dependent in the place that matters most.
@@ -195,7 +216,7 @@
           </section>
 
           <section>
-            <h2>Why it matters now</h2>
+            <h2 id="why-it-matters-now">Why it matters now</h2>
             <p>
               Modern systems are already spread across web, mobile, server, edge, and AI-driven execution contexts. The question is no
               longer whether behavior moves. The question is whether the architecture can survive that movement without fragmenting.
@@ -207,7 +228,7 @@
           </section>
 
           <section>
-            <h2>How UMA frames the problem differently</h2>
+            <h2 id="how-uma-frames-the-problem-differently">How UMA frames the problem differently</h2>
             <p>
               UMA treats runtime-agnostic architecture as a boundary problem. It asks which part of the system should remain stable enough to
               survive movement, and which part must remain explicit because it changes with the environment. That is different from a
@@ -220,7 +241,7 @@
           </section>
 
           <section>
-            <h2>Common misunderstandings</h2>
+            <h2 id="common-misunderstandings">Common misunderstandings</h2>
             <p>
               Runtime-agnostic does not mean runtime-neutral in the sense of treating all environments as interchangeable. Some services
               belong closer to users. Some belong in controlled backend environments. Some require more policy or trust than others. UMA is
@@ -234,7 +255,7 @@
           </section>
 
           <section>
-            <h2>What a good adoption path looks like</h2>
+            <h2 id="what-a-good-adoption-path-looks-like">What a good adoption path looks like</h2>
             <p>
               The best adoption path is usually small and evidence-driven. Start with one service whose behavior is clearly defined, preserve
               that behavior through an explicit contract, and let the runtime own validation and adaptation around it. Once that pattern is
@@ -247,13 +268,13 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Can a runtime-agnostic architecture still be optimized for one runtime?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="can-a-runtime-agnostic-architecture-still-be-optimized-for-one-runtime">Can a runtime-agnostic architecture still be optimized for one runtime?</h3>
             <p>
               Yes. The architecture can preserve one portable service model while still optimizing deployment, placement, caching, or
               transport around the runtime that matters most for a given use case.
             </p>
-            <h3>Does runtime-agnostic architecture mean every service should run everywhere?</h3>
+            <h3 id="does-runtime-agnostic-architecture-mean-every-service-should-run-everywhere">Does runtime-agnostic architecture mean every service should run everywhere?</h3>
             <p>
               No. A runtime-agnostic service model is about preserving meaning, not forcing universal placement. Some services should stay
               close to users, some should stay inside governed backend environments, and some should move between both. The important point
@@ -284,7 +305,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/runtime-provenance-and-trust/index.html
+++ b/book-site/runtime-provenance-and-trust/index.html
@@ -7,28 +7,93 @@
     <meta name="description" content="Learn how UMA makes provenance, permissions, dependencies, and trust boundaries explicit in runtime decisions instead of hiding them in perimeter infrastructure." />
     <link rel="canonical" href="https://www.universalmicroservices.com/runtime-provenance-and-trust/" />
     <meta property="og:title" content="Runtime Provenance and Trust in UMA" />
-    <meta property="og:description" content="A practical preview of UMA trust boundaries and provenance-aware runtime enforcement." />
+    <meta property="og:description" content="Learn how UMA makes provenance, permissions, dependencies, and trust boundaries explicit in runtime decisions instead of hiding them in perimeter infrastructure." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/runtime-provenance-and-trust/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Runtime Provenance and Trust in UMA","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/runtime-provenance-and-trust/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Runtime Provenance and Trust in UMA","item":"https://www.universalmicroservices.com/runtime-provenance-and-trust/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Runtime Provenance and Trust in UMA","description":"Learn how UMA makes provenance, permissions, dependencies, and trust boundaries explicit in runtime decisions instead of hiding them in perimeter infrastructure.","url":"https://www.universalmicroservices.com/runtime-provenance-and-trust/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag("js", new Date()); gtag("config", "G-J5ZJHZ3D5E");</script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
   </head>
   <body>
-    <div class="page-shell">
-      <header class="topbar"><a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button><nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav><a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+    <div class="page-shell has-page-rail">
+      <header class="topbar">
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+      </header>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-architectural-shift">The architectural shift</a>
+    <ul class="page-rail-links">
+      <li><a href="#publisher">Publisher</a></li><li><a href="#permissions">Permissions</a></li><li><a href="#dependencies">Dependencies</a></li><li><a href="#communication">Communication</a></li>
+    </ul></li><li><a href="#what-readers-should-inspect">What readers should inspect</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero"><h1>Runtime provenance and trust</h1><p>Portable behavior does not automatically become trusted behavior. UMA makes publisher identity, declared permissions, dependency provenance, placement, and communication rules visible to the runtime.</p></section>
-        <div class="subpage-body">
-          <section><h2>The architectural shift</h2><p>Traditional systems often inherit trust from location: inside the network, inside the cluster, inside the gateway. UMA asks a different question: what does this module declare, who published it, what does it depend on, and what is it allowed to communicate with?</p><p>That makes trust part of the system model instead of a perimeter assumption.</p></section>
-          <section class="subpage-grid"><article class="subpage-card"><h3>Publisher</h3><p>Who produced the service matters to runtime approval.</p></article><article class="subpage-card"><h3>Permissions</h3><p>Requested capability access must match declared permissions.</p></article><article class="subpage-card"><h3>Dependencies</h3><p>Provenance and checksums can affect whether a service is trusted.</p></article><article class="subpage-card"><h3>Communication</h3><p>Event compatibility is not enough if trust policy rejects the path.</p></article></section>
-          <section><h2>What readers should inspect</h2><p>The Chapter 9 example is the proof layer: trusted services are allowed, undeclared permissions are denied, untrusted dependencies fail, forbidden communication is blocked, and restored compliance brings the system back to allow.</p></section>
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Runtime Provenance and Trust in UMA</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero"><h1>Runtime provenance and trust</h1><p>Portable behavior does not automatically become trusted behavior. UMA makes publisher identity, declared permissions, dependency provenance, placement, and communication rules visible to the runtime.</p></section>
+
+<div class="subpage-body">
+          <section><h2 id="the-architectural-shift">The architectural shift</h2><p>Traditional systems often inherit trust from location: inside the network, inside the cluster, inside the gateway. UMA asks a different question: what does this module declare, who published it, what does it depend on, and what is it allowed to communicate with?</p><p>That makes trust part of the system model instead of a perimeter assumption.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3 id="publisher">Publisher</h3><p>Who produced the service matters to runtime approval.</p></article><article class="subpage-card"><h3 id="permissions">Permissions</h3><p>Requested capability access must match declared permissions.</p></article><article class="subpage-card"><h3 id="dependencies">Dependencies</h3><p>Provenance and checksums can affect whether a service is trusted.</p></article><article class="subpage-card"><h3 id="communication">Communication</h3><p>Event compatibility is not enough if trust policy rejects the path.</p></article></section>
+          <section><h2 id="what-readers-should-inspect">What readers should inspect</h2><p>The Chapter 9 example is the proof layer: trusted services are allowed, undeclared permissions are denied, untrusted dependencies fail, forbidden communication is blocked, and restored compliance brings the system back to allow.</p></section>
           <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 9 expands this into a full trust-boundary sequence. The site gives the map; the book explains why this model changes how portable systems should be governed.</p><div class="subpage-inline-links"><a href="../trust-boundaries/">Trust boundaries</a><a href="../examples/chapter-09-trust-boundaries/">Chapter 9 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
         </div>
         <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/book-site/scripts/build_from_content.mjs
+++ b/book-site/scripts/build_from_content.mjs
@@ -1,0 +1,521 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.join(path.dirname(fileURLToPath(import.meta.url)), "..", ".."));
+const CONTENT_ROOT = path.join(ROOT, "content", "pages");
+const BOOK_SITE = path.join(ROOT, "book-site");
+
+const HOME_LINKS = [
+  ["Why", "why-uma"],
+  ["What", "book-arc"],
+  ["How", "learning-path"],
+  ["Hands-on", "hands-on"],
+  ["Who", "team-value"],
+  ["Contacts", "contacts"],
+];
+
+function escapeHtml(text) {
+  return String(text ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function stripQuotes(value) {
+  const trimmed = value.trim();
+  if (trimmed === "null") return null;
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+  return trimmed;
+}
+
+function parseFrontmatter(source) {
+  const lines = source.split(/\r?\n/);
+  if (lines[0] !== "---") {
+    throw new Error("Missing frontmatter start");
+  }
+
+  const meta = {};
+  let index = 1;
+
+  while (index < lines.length && lines[index] !== "---") {
+    const line = lines[index];
+
+    if (line === "breadcrumbs:") {
+      index += 1;
+      meta.breadcrumbs = [];
+      while (index < lines.length && lines[index].startsWith("  - ")) {
+        meta.breadcrumbs.push(stripQuotes(lines[index].slice(4)));
+        index += 1;
+      }
+      continue;
+    }
+
+    if (line === "related_refs:") {
+      index += 1;
+      meta.related_refs = [];
+      while (index < lines.length && lines[index].startsWith("  - ")) {
+        meta.related_refs.push(stripQuotes(lines[index].slice(4)));
+        index += 1;
+      }
+      continue;
+    }
+
+    const match = line.match(/^([a-z_]+):\s*(.*)$/i);
+    if (match) {
+      const [, key, value] = match;
+      meta[key] = stripQuotes(value);
+    }
+
+    index += 1;
+  }
+
+  return meta;
+}
+
+function splitSections(source) {
+  const introMarker = "\n## intro\n";
+  const mainMarker = "\n## main\n";
+  const introStart = source.indexOf(introMarker);
+  const mainStart = source.indexOf(mainMarker);
+
+  if (introStart === -1 || mainStart === -1 || mainStart <= introStart) {
+    throw new Error("Content markdown missing intro/main sections");
+  }
+
+  const intro = source.slice(introStart + introMarker.length, mainStart).trim();
+  const main = source.slice(mainStart + mainMarker.length).trim();
+  return { intro, main };
+}
+
+async function listMarkdownFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith("_")) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listMarkdownFiles(full)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(full);
+    }
+  }
+
+  return files;
+}
+
+function pagePathFromMeta(meta) {
+  if (meta.ref === "examples") {
+    return path.join(BOOK_SITE, "examples", "index.html");
+  }
+
+  if (meta.macro_area === "examples") {
+    return path.join(BOOK_SITE, "examples", meta.slug, "index.html");
+  }
+
+  return path.join(BOOK_SITE, meta.slug, "index.html");
+}
+
+function relativePrefixFor(outPath) {
+  const dir = path.dirname(outPath);
+  const relative = path.relative(dir, BOOK_SITE).replace(/\\/g, "/");
+  return relative ? `${relative}/` : "";
+}
+
+function homeAnchor(prefix, anchor) {
+  return `${prefix}#${anchor}`;
+}
+
+function renderTopNav(prefix) {
+  const links = HOME_LINKS.map(([label, anchor]) => `<a href="${homeAnchor(prefix, anchor)}">${label}</a>`).join("");
+  return `
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          ${links}
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
+        <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>`;
+}
+
+function renderMobileNav(prefix) {
+  const links = HOME_LINKS.map(([label, anchor]) => `<a href="${homeAnchor(prefix, anchor)}">${label}</a>`).join("");
+  return `
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            ${links}
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>`;
+}
+
+function stripTags(text) {
+  return String(text ?? "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function slugify(text) {
+  return String(text ?? "")
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function uniqueSlug(text, seen) {
+  const base = slugify(text);
+  let candidate = base;
+  let index = 2;
+  while (seen.has(candidate)) {
+    candidate = `${base}-${index++}`;
+  }
+  seen.add(candidate);
+  return candidate;
+}
+
+function decorateHeadings(main) {
+  const seen = new Set();
+  const outline = [];
+  let currentSection = null;
+
+  const html = main.replace(/<h([23])([^>]*)>([\s\S]*?)<\/h\1>/g, (match, level, attrs, inner) => {
+    const text = stripTags(inner);
+    const idMatch = attrs.match(/\sid="([^"]+)"/i);
+    const id = idMatch ? idMatch[1] : uniqueSlug(text, seen);
+    const updatedAttrs = idMatch ? attrs : `${attrs} id="${id}"`;
+
+    if (level === "2") {
+      currentSection = { label: text, href: `#${id}`, children: [] };
+      outline.push(currentSection);
+    } else if (currentSection) {
+      currentSection.children.push({ label: text, href: `#${id}` });
+    }
+
+    return `<h${level}${updatedAttrs}>${inner}</h${level}>`;
+  });
+
+  return { html, outline };
+}
+
+function renderBreadcrumbs(meta, prefix) {
+  const currentLabel = meta.title || "UMA";
+  const items = [{ label: "Home", href: prefix }];
+
+  if (meta.macro_area === "examples") {
+    if (meta.ref !== "examples") {
+      items.push({ label: "Examples", href: "../" });
+    }
+  }
+
+  items.push({ label: currentLabel, current: true });
+
+  return `
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            ${items
+              .map((item) =>
+                item.current
+                  ? `<li><span aria-current="page">${escapeHtml(item.label)}</span></li>`
+                  : `<li><a href="${escapeHtml(item.href)}">${escapeHtml(item.label)}</a></li>`,
+              )
+              .join("")}
+          </ol>
+        </nav>`;
+}
+
+function renderOutlineList(items, ordered = true) {
+  const tag = ordered ? "ol" : "ul";
+  return `
+    <${tag} class="${ordered ? "page-rail-outline" : "page-rail-links"}">
+      ${items
+        .map((item) => {
+          const children = item.children?.length ? renderOutlineList(item.children, false) : "";
+          return `<li><a href="${item.href}">${escapeHtml(item.label)}</a>${children}</li>`;
+        })
+        .join("")}
+    </${tag}>`;
+}
+
+function chapterNumber(ref) {
+  const match = String(ref || "").match(/(\d+)/);
+  return match ? Number(match[1]) : Number.POSITIVE_INFINITY;
+}
+
+function makeAbsoluteUrl(pathname) {
+  return new URL(pathname, "https://www.universalmicroservices.com/").href;
+}
+
+function escapeRegExp(value) {
+  return String(value ?? "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function chapterDisplayName(meta) {
+  const chapterRef = String(meta.chapter_ref || "").trim();
+  const prefixPattern = chapterRef ? new RegExp(`^${escapeRegExp(chapterRef)}\\s+`, "i") : null;
+  return String(meta.title || "")
+    .replace(prefixPattern || /^/, "")
+    .replace(/\s+Tutorial$/i, "")
+    .trim();
+}
+
+function renderStructuredData(meta, rawMain) {
+  const scripts = [];
+  const canonical = meta.canonical_url || makeAbsoluteUrl("/");
+  const breadcrumbs = [{ name: "Home", item: makeAbsoluteUrl("/") }];
+
+  if (meta.macro_area === "examples") {
+    if (meta.ref !== "examples") {
+      breadcrumbs.push({ name: "Examples", item: makeAbsoluteUrl("/examples/") });
+    }
+  }
+
+  breadcrumbs.push({ name: meta.title || "UMA", item: canonical });
+
+  scripts.push({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: breadcrumbs.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.item,
+    })),
+  });
+
+  scripts.push({
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: meta.title || "UMA",
+    description: meta.seo_description || meta.subtitle || "",
+    url: canonical,
+    inLanguage: "en",
+  });
+
+  if (meta.ref === "faq") {
+    const questions = [...rawMain.matchAll(/<h3[^>]*>([\s\S]*?)<\/h3>([\s\S]*?)(?=<h3[^>]*>|<\/section>|<\/div>)/g)].map((match) => ({
+      "@type": "Question",
+      name: stripTags(match[1]),
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: stripTags(match[2]),
+      },
+    }));
+
+    if (questions.length) {
+      scripts.push({
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: questions,
+      });
+    }
+  }
+
+  if (meta.chapter_ref) {
+    const stepSection = rawMain.match(/<ol class="tutorial-steps">([\s\S]*?)<\/ol>/);
+    const steps = stepSection
+      ? [...stepSection[1].matchAll(/<li>\s*<strong>([\s\S]*?)<\/strong>[\s\S]*?<code>([\s\S]*?)<\/code>[\s\S]*?<\/li>/g)].map((match, index) => ({
+          "@type": "HowToStep",
+          position: index + 1,
+          name: stripTags(match[1]),
+          text: stripTags(match[2]),
+        }))
+      : [];
+
+    if (steps.length) {
+      scripts.push({
+        "@context": "https://schema.org",
+        "@type": "HowTo",
+        name: `${meta.chapter_ref}: ${chapterDisplayName(meta)} UMA tutorial`,
+        description: meta.seo_description || meta.subtitle || "",
+        step: steps,
+      });
+    }
+
+    scripts.push({
+      "@context": "https://schema.org",
+      "@type": "SoftwareSourceCode",
+      name: `${meta.chapter_ref}: ${chapterDisplayName(meta)}`,
+      codeRepository: `https://github.com/enricopiovesan/UMA-code-examples/tree/main/${meta.slug}`,
+      programmingLanguage: ["Rust", "TypeScript"],
+      runtimePlatform: "Rust, WASI, Node.js",
+      description: meta.seo_description || meta.subtitle || "",
+    });
+  }
+
+  return scripts
+    .map((script) => `<script type="application/ld+json">${JSON.stringify(script)}</script>`)
+    .join("\n    ");
+}
+
+function renderPageRail(meta, outline, chapterEntries, prefix) {
+  const exploreLinks = [
+    ["home", "/"],
+    ["book", "book/"],
+    ["examples", "examples/"],
+    ["learning path", "learning-path/"],
+    ["faq", "faq/"],
+    ["blog", "https://medium.com/the-rise-of-device-independent-architecture", true],
+    ["reference application", "https://www.universalmicroservices.com/reference-application/", true],
+    ["github", "https://github.com/enricopiovesan/UMA-code-examples", true],
+  ];
+
+  const exploreMarkup = exploreLinks
+    .map(([label, href, external = false]) => {
+      const attrs = external ? ' target="_blank" rel="noreferrer noopener"' : "";
+      const linkHref = external ? href : href.startsWith("/") ? href : `${prefix}${href}`;
+      return `<li><a href="${linkHref}"${attrs}>${escapeHtml(label)}</a></li>`;
+    })
+    .join("");
+
+  const chapter = meta.chapter_ref ? chapterEntries.find((entry) => entry.meta.ref === meta.ref) : null;
+  const chapterMarkup = meta.chapter_ref
+    ? (() => {
+        const index = chapterEntries.findIndex((entry) => entry.meta.ref === meta.ref);
+        const links = [
+          `<li><a href="../">examples hub</a></li>`,
+          index > 0 ? `<li><a href="../${chapterEntries[index - 1].meta.slug}/">previous: ${escapeHtml(chapterEntries[index - 1].meta.chapter_ref)}</a></li>` : "",
+          index < chapterEntries.length - 1 ? `<li><a href="../${chapterEntries[index + 1].meta.slug}/">next: ${escapeHtml(chapterEntries[index + 1].meta.chapter_ref)}</a></li>` : "",
+          `<li><a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/${meta.slug}" target="_blank" rel="noreferrer noopener">source folder</a></li>`,
+        ]
+          .filter(Boolean)
+          .join("");
+
+        return `
+    <nav class="page-rail-block">
+      <h2>In the examples path</h2>
+      <ul class="page-rail-links">
+        ${links}
+      </ul>
+    </nav>`;
+      })()
+    : "";
+
+  return `
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+      ${renderOutlineList(outline, true)}
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        ${exploreMarkup}
+      </ul>
+    </nav>
+    ${chapterMarkup}
+      </aside>`;
+}
+
+function renderPage(meta, intro, main, outPath, outline, chapterEntries) {
+  const prefix = relativePrefixFor(outPath);
+  const title = escapeHtml(meta.title || "UMA Examples");
+  const description = escapeHtml(meta.seo_description || meta.subtitle || "");
+  const canonical = escapeHtml(meta.canonical_url || "https://www.universalmicroservices.com/");
+  const ogUrl = canonical;
+  const ogType = meta.ref === "faq" || meta.content_type === "hub" ? "website" : "article";
+  const pageTitle = `${title} | Universal Microservices Architecture`;
+  const structuredData = renderStructuredData(meta, main);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${pageTitle}</title>
+    <meta name="description" content="${description}" />
+    <link rel="canonical" href="${canonical}" />
+    <meta property="og:title" content="${title}" />
+    <meta property="og:description" content="${description}" />
+    <meta property="og:type" content="${ogType}" />
+    <meta property="og:url" content="${ogUrl}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    ${structuredData}
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="${prefix}styles.css" />
+    <link rel="stylesheet" href="${prefix}subpages.css" />
+    <link rel="icon" href="${prefix}favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="${prefix}favicon.svg" type="image/svg+xml" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
+  <body>
+    <div class="page-shell has-page-rail">
+      <header class="topbar">
+        <a class="brand" href="${prefix}#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+${renderTopNav(prefix)}
+      </header>
+${renderMobileNav(prefix)}
+
+${renderPageRail(meta, outline, chapterEntries, prefix)}
+
+      <main class="subpage-main">
+${renderBreadcrumbs(meta, prefix)}
+
+${intro}
+
+${main}
+      </main>
+    </div>
+    <script src="${prefix}app.js" type="module"></script>
+  </body>
+</html>
+`;
+}
+
+function normalizeHtml(html) {
+  return html.replace(/[ \t]+$/gm, "");
+}
+
+async function main() {
+  const files = await listMarkdownFiles(CONTENT_ROOT);
+  const pages = [];
+  for (const file of files) {
+    const source = await fs.readFile(file, "utf8");
+    const meta = parseFrontmatter(source);
+    const { intro, main: mainSection } = splitSections(source);
+    pages.push({ meta, intro, main: mainSection });
+  }
+
+  const chapterEntries = pages
+    .filter((page) => page.meta.chapter_ref)
+    .sort((a, b) => chapterNumber(a.meta.chapter_ref) - chapterNumber(b.meta.chapter_ref));
+
+  let count = 0;
+  for (const page of pages) {
+    const outPath = pagePathFromMeta(page.meta);
+    const decorated = decorateHeadings(page.main);
+    await fs.mkdir(path.dirname(outPath), { recursive: true });
+    await fs.writeFile(outPath, normalizeHtml(renderPage(page.meta, page.intro, decorated.html, outPath, decorated.outline, chapterEntries)));
+    count += 1;
+  }
+
+  console.log(`Generated ${count} book-site HTML pages from Markdown content.`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/book-site/service-graph-evolution/index.html
+++ b/book-site/service-graph-evolution/index.html
@@ -4,37 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Service Graph Evolution | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Understand service graph evolution in Universal Microservices Architecture and why compatibility, contracts, and visibility matter more than hidden rewiring."
-    />
+    <meta name="description" content="Understand service graph evolution in Universal Microservices Architecture and why compatibility, contracts, and visibility matter more than hidden rewiring." />
     <link rel="canonical" href="https://www.universalmicroservices.com/service-graph-evolution/" />
-    <meta property="og:title" content="Service Graph Evolution | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to service graph evolution, focused on compatibility, runtime discovery, and healthy system change."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Service Graph Evolution" />
+    <meta property="og:description" content="Understand service graph evolution in Universal Microservices Architecture and why compatibility, contracts, and visibility matter more than hidden rewiring." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/service-graph-evolution/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Service Graph Evolution","item":"https://www.universalmicroservices.com/service-graph-evolution/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Service Graph Evolution","description":"Understand service graph evolution in Universal Microservices Architecture and why compatibility, contracts, and visibility matter more than hidden rewiring.","url":"https://www.universalmicroservices.com/service-graph-evolution/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-a-service-graph-really-shows">What a service graph really shows</a></li><li><a href="#why-graph-evolution-matters-more-than-static-structure">Why graph evolution matters more than static structure</a></li><li><a href="#how-graphs-evolve-in-a-healthy-system">How graphs evolve in a healthy system</a>
+    <ul class="page-rail-links">
+      <li><a href="#compatibility-matters-first">Compatibility matters first</a></li><li><a href="#discovery-must-stay-visible">Discovery must stay visible</a></li><li><a href="#evolution-is-where-drift-appears">Evolution is where drift appears</a></li><li><a href="#governance-keeps-growth-healthy">Governance keeps growth healthy</a></li>
+    </ul></li><li><a href="#what-makes-a-graph-governable">What makes a graph governable</a></li><li><a href="#why-compatibility-should-fail-visibly">Why compatibility should fail visibly</a></li><li><a href="#why-inspectable-change-matters">Why inspectable change matters</a></li><li><a href="#why-this-topic-matters">Why this topic matters</a></li><li><a href="#signals-of-unhealthy-evolution">Signals of unhealthy evolution</a></li><li><a href="#what-healthy-graph-growth-looks-like-in-practice">What healthy graph growth looks like in practice</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-a-service-graph-just-another-architecture-diagram">Is a service graph just another architecture diagram?</a></li><li><a href="#does-every-uma-system-need-a-large-service-graph">Does every UMA system need a large service graph?</a></li><li><a href="#what-should-happen-when-compatibility-breaks">What should happen when compatibility breaks?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Service Graph Evolution</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Service graph evolution</h1>
           <p>
             One of the most useful ideas in Universal Microservices Architecture is that systems do not need to be hardwired into shape.
@@ -79,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>What a service graph really shows</h2>
+            <h2 id="what-a-service-graph-really-shows">What a service graph really shows</h2>
             <p>
               A service graph is more than a diagram. It is a visible expression of which services can emit, consume, and compose behavior
               together at runtime. The more that graph depends on declared compatibility rather than hidden rewiring, the more durable the
@@ -95,7 +116,7 @@
           </section>
 
           <section>
-            <h2>Why graph evolution matters more than static structure</h2>
+            <h2 id="why-graph-evolution-matters-more-than-static-structure">Why graph evolution matters more than static structure</h2>
             <p>
               Many architectures look coherent when drawn as a static picture. The harder question is whether they stay coherent as new
               services, policies, and runtime environments are added. Service graph evolution is the point where the true quality of the
@@ -110,7 +131,7 @@
           </section>
 
           <section>
-            <h2>How graphs evolve in a healthy system</h2>
+            <h2 id="how-graphs-evolve-in-a-healthy-system">How graphs evolve in a healthy system</h2>
             <p>
               A healthy service graph grows through explicit compatibility. Services can emit events, subscribe to behavior, and be selected
               for runtime participation because the contracts and metadata support those relationships. That is very different from a system
@@ -131,25 +152,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Compatibility matters first</h3>
+              <h3 id="compatibility-matters-first">Compatibility matters first</h3>
               <p>Healthy growth depends on services being able to connect through declared contracts instead of incidental implementation details.</p>
             </article>
             <article class="subpage-card">
-              <h3>Discovery must stay visible</h3>
+              <h3 id="discovery-must-stay-visible">Discovery must stay visible</h3>
               <p>The system should be able to explain how compatible services become part of the same graph.</p>
             </article>
             <article class="subpage-card">
-              <h3>Evolution is where drift appears</h3>
+              <h3 id="evolution-is-where-drift-appears">Evolution is where drift appears</h3>
               <p>Architectures rarely fail on day one; they fail when repeated changes make the graph harder to reason about.</p>
             </article>
             <article class="subpage-card">
-              <h3>Governance keeps growth healthy</h3>
+              <h3 id="governance-keeps-growth-healthy">Governance keeps growth healthy</h3>
               <p>Runtime policy, trust, and compatibility help distinguish healthy extension from architectural fragmentation.</p>
             </article>
           </section>
 
           <section>
-            <h2>What makes a graph governable</h2>
+            <h2 id="what-makes-a-graph-governable">What makes a graph governable</h2>
             <p>
               A governable graph is one where compatibility is explicit, metadata is trustworthy, and runtime selection can be explained.
               It should be possible to understand why a service is compatible, why it was selected, and what policies shape its role in the
@@ -163,7 +184,7 @@
           </section>
 
           <section>
-            <h2>Why compatibility should fail visibly</h2>
+            <h2 id="why-compatibility-should-fail-visibly">Why compatibility should fail visibly</h2>
             <p>
               Healthy graph evolution is not only about adding new relationships. It is also about what happens when compatibility breaks.
               A mature system should fail in a way that is legible. If an event shape changes, a version drifts, or a subscriber no longer
@@ -176,7 +197,7 @@
           </section>
 
           <section>
-            <h2>Why inspectable change matters</h2>
+            <h2 id="why-inspectable-change-matters">Why inspectable change matters</h2>
             <p>
               A graph becomes much more useful when change can be inspected at the level that created it. If a service joins the graph
               because of a new event contract, a changed consumer declaration, or a repaired metadata relationship, teams should be able to
@@ -189,7 +210,7 @@
           </section>
 
           <section>
-            <h2>Why this topic matters</h2>
+            <h2 id="why-this-topic-matters">Why this topic matters</h2>
             <p>
               Service graph evolution is where the real architectural cost of change becomes visible. If the graph can grow through explicit
               compatibility, the system remains teachable and governable. If growth depends on hidden rewiring, teams inherit fragility even
@@ -202,7 +223,7 @@
           </section>
 
           <section>
-            <h2>Signals of unhealthy evolution</h2>
+            <h2 id="signals-of-unhealthy-evolution">Signals of unhealthy evolution</h2>
             <ul>
               <li>New services only work after undocumented rewiring.</li>
               <li>Compatibility is inferred from implementation detail instead of declared contracts.</li>
@@ -213,7 +234,7 @@
           </section>
 
           <section>
-            <h2>What healthy graph growth looks like in practice</h2>
+            <h2 id="what-healthy-graph-growth-looks-like-in-practice">What healthy graph growth looks like in practice</h2>
             <p>
               Healthy graph growth usually starts small. One service becomes compatible with another through a contract or event boundary.
               Metadata makes that compatibility visible. Runtime policy determines whether and where that relationship is allowed. Over time,
@@ -235,18 +256,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is a service graph just another architecture diagram?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-a-service-graph-just-another-architecture-diagram">Is a service graph just another architecture diagram?</h3>
             <p>
               No. In UMA, the graph is valuable because it reflects runtime-visible compatibility and composition, not just a static drawing
               made after the fact.
             </p>
-            <h3>Does every UMA system need a large service graph?</h3>
+            <h3 id="does-every-uma-system-need-a-large-service-graph">Does every UMA system need a large service graph?</h3>
             <p>
               No. Some systems remain small and should stay small. The point is not to maximize graph complexity. The point is to make
               system growth legible and governed when it does happen.
             </p>
-            <h3>What should happen when compatibility breaks?</h3>
+            <h3 id="what-should-happen-when-compatibility-breaks">What should happen when compatibility breaks?</h3>
             <p>
               The break should be visible. A waiting consumer, a missing edge, or a failed compatibility check is more honest and much more
               useful than a system that quietly routes around the problem. Healthy graph evolution depends on visible breakage and visible
@@ -275,7 +296,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/styles.css
+++ b/book-site/styles.css
@@ -1220,12 +1220,16 @@ h3 {
 
 .footer-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(280px, 0.9fr);
-  gap: 34px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(280px, 0.95fr);
+  gap: 28px;
   max-width: min(100% - 56px, var(--content));
   margin: 34px auto 0;
   padding-top: 20px;
   border-top: 1px solid rgba(7, 7, 7, 0.28);
+}
+
+.footer-column {
+  min-width: 0;
 }
 
 .footer-column h3 {
@@ -1239,18 +1243,19 @@ h3 {
 }
 
 .footer-cluster + .footer-cluster {
-  margin-top: 24px;
+  margin-top: 22px;
 }
 
 .footer-book-cta {
   display: grid;
   align-content: start;
+  min-width: 0;
 }
 
 .footer-book-card {
   display: grid;
   grid-template-columns: 104px minmax(0, 1fr);
-  gap: 18px;
+  gap: 16px;
   align-items: start;
 }
 

--- a/book-site/subpages.css
+++ b/book-site/subpages.css
@@ -4,8 +4,8 @@
 
 .page-shell.has-page-rail {
   display: grid;
-  grid-template-columns: minmax(238px, 288px) minmax(0, 1fr);
-  column-gap: 42px;
+  grid-template-columns: minmax(260px, 300px) minmax(0, 1fr);
+  column-gap: 36px;
   align-items: start;
 }
 
@@ -17,20 +17,30 @@
 .page-shell.has-page-rail > .page-rail {
   grid-column: 1;
   position: sticky;
-  top: 96px;
-  max-height: calc(100vh - 128px);
-  padding: 28px 16px 28px 0;
+  top: 92px;
+  max-height: calc(100vh - 124px);
+  padding: 18px 16px 18px 18px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.2);
   overflow: auto;
 }
 
 .page-shell.has-page-rail > .subpage-main {
   grid-column: 2;
   width: auto;
-  padding-top: 36px;
+  padding-top: 24px;
 }
 
 .page-breadcrumbs {
-  margin: 0 0 18px;
+  display: inline-flex;
+  margin: 0 0 22px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(8px);
 }
 
 .page-breadcrumbs ol {
@@ -70,12 +80,12 @@
 }
 
 .page-rail {
-  border-right: 1px solid var(--line);
+  border-right: 0;
 }
 
 .page-rail-block + .page-rail-block {
-  margin-top: 28px;
-  padding-top: 22px;
+  margin-top: 24px;
+  padding-top: 20px;
   border-top: 1px solid var(--line);
 }
 
@@ -424,7 +434,9 @@
     position: static;
     max-height: none;
     padding: 18px 0 0;
-    border-right: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
   }
 
   .page-shell.has-page-rail > .subpage-main {
@@ -465,6 +477,7 @@
 
   .page-breadcrumbs {
     margin-bottom: 14px;
+    padding: 8px 12px;
   }
 
   .page-breadcrumbs ol {

--- a/book-site/subpages.css
+++ b/book-site/subpages.css
@@ -2,6 +2,141 @@
   padding: 72px 0 0;
 }
 
+.page-shell.has-page-rail {
+  display: grid;
+  grid-template-columns: minmax(238px, 288px) minmax(0, 1fr);
+  column-gap: 42px;
+  align-items: start;
+}
+
+.page-shell.has-page-rail > .topbar,
+.page-shell.has-page-rail > .mobile-menu {
+  grid-column: 1 / -1;
+}
+
+.page-shell.has-page-rail > .page-rail {
+  grid-column: 1;
+  position: sticky;
+  top: 96px;
+  max-height: calc(100vh - 128px);
+  padding: 28px 16px 28px 0;
+  overflow: auto;
+}
+
+.page-shell.has-page-rail > .subpage-main {
+  grid-column: 2;
+  width: auto;
+  padding-top: 36px;
+}
+
+.page-breadcrumbs {
+  margin: 0 0 18px;
+}
+
+.page-breadcrumbs ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.74rem;
+  line-height: 1.4;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.page-breadcrumbs li {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.page-breadcrumbs li:not(:last-child)::after {
+  content: "/";
+  color: var(--line);
+}
+
+.page-breadcrumbs a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.page-breadcrumbs a:hover,
+.page-breadcrumbs [aria-current="page"] {
+  color: var(--text);
+}
+
+.page-rail {
+  border-right: 1px solid var(--line);
+}
+
+.page-rail-block + .page-rail-block {
+  margin-top: 28px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+}
+
+.page-rail-block h2 {
+  margin: 0 0 14px;
+  color: var(--accent);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-rail-links,
+.page-rail-outline {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.page-rail-links {
+  display: grid;
+  gap: 10px;
+}
+
+.page-rail-outline {
+  display: grid;
+  gap: 12px;
+}
+
+.page-rail-outline > li > a,
+.page-rail-links a {
+  color: var(--text);
+  text-decoration: none;
+  text-underline-offset: 0.18em;
+  line-height: 1.4;
+}
+
+.page-rail-outline > li > a {
+  font-size: 0.92rem;
+  font-weight: 500;
+}
+
+.page-rail-outline ul {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0 14px;
+  padding: 10px 0 0 14px;
+  border-left: 1px solid var(--line);
+}
+
+.page-rail-outline ul a {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.page-rail-outline a:hover,
+.page-rail-links a:hover {
+  color: var(--accent);
+}
+
 .subpage-hero {
   padding: 24px 0 52px;
   border-bottom: 1px solid var(--line);
@@ -274,6 +409,27 @@
   .benchmark-compare {
     grid-template-columns: 1fr;
   }
+
+  .page-shell.has-page-rail {
+    grid-template-columns: 1fr;
+    column-gap: 0;
+  }
+
+  .page-shell.has-page-rail > .page-rail,
+  .page-shell.has-page-rail > .subpage-main {
+    grid-column: 1;
+  }
+
+  .page-shell.has-page-rail > .page-rail {
+    position: static;
+    max-height: none;
+    padding: 18px 0 0;
+    border-right: 0;
+  }
+
+  .page-shell.has-page-rail > .subpage-main {
+    padding-top: 28px;
+  }
 }
 
 @media (max-width: 760px) {
@@ -305,6 +461,32 @@
 
   .subpage-body h2 {
     font-size: clamp(1.45rem, 6vw, 1.95rem);
+  }
+
+  .page-breadcrumbs {
+    margin-bottom: 14px;
+  }
+
+  .page-breadcrumbs ol {
+    font-size: 0.68rem;
+  }
+
+  .page-rail-block + .page-rail-block {
+    margin-top: 22px;
+    padding-top: 18px;
+  }
+
+  .page-rail-block h2 {
+    margin-bottom: 12px;
+    font-size: 0.76rem;
+  }
+
+  .page-rail-links {
+    gap: 8px;
+  }
+
+  .page-rail-outline {
+    gap: 10px;
   }
 
   .diagram-code {

--- a/book-site/trust-boundaries/index.html
+++ b/book-site/trust-boundaries/index.html
@@ -3,38 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Trust Boundaries in UMA</title>
-    <meta
-      name="description"
-      content="Learn why trust boundaries matter in Universal Microservices Architecture and how identity, permissions, provenance, and runtime policy shape safe execution."
-    />
+    <title>Trust Boundaries in UMA | Universal Microservices Architecture</title>
+    <meta name="description" content="Learn why trust boundaries matter in Universal Microservices Architecture and how identity, permissions, provenance, and runtime policy shape safe execution." />
     <link rel="canonical" href="https://www.universalmicroservices.com/trust-boundaries/" />
     <meta property="og:title" content="Trust Boundaries in UMA" />
-    <meta
-      property="og:description"
-      content="An original overview of trust boundaries in Universal Microservices Architecture, focused on identity, permissions, provenance, and runtime enforcement."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:description" content="Learn why trust boundaries matter in Universal Microservices Architecture and how identity, permissions, provenance, and runtime policy shape safe execution." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/trust-boundaries/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Trust Boundaries in UMA","item":"https://www.universalmicroservices.com/trust-boundaries/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Trust Boundaries in UMA","description":"Learn why trust boundaries matter in Universal Microservices Architecture and how identity, permissions, provenance, and runtime policy shape safe execution.","url":"https://www.universalmicroservices.com/trust-boundaries/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#why-trust-cannot-be-added-later">Why trust cannot be added later</a></li><li><a href="#what-a-trust-boundary-means-in-uma">What a trust boundary means in UMA</a>
+    <ul class="page-rail-links">
+      <li><a href="#identity">Identity</a></li><li><a href="#permissions">Permissions</a></li><li><a href="#provenance">Provenance</a></li><li><a href="#runtime-enforcement">Runtime enforcement</a></li>
+    </ul></li><li><a href="#why-this-is-architectural-not-operational">Why this is architectural, not operational</a></li><li><a href="#what-governed-execution-means">What governed execution means</a></li><li><a href="#why-undeclared-permissions-should-fail-early">Why undeclared permissions should fail early</a></li><li><a href="#why-dependency-provenance-is-architectural">Why dependency provenance is architectural</a></li><li><a href="#why-compatibility-is-not-the-same-as-authorization">Why compatibility is not the same as authorization</a></li><li><a href="#why-trust-becomes-harder-in-portable-systems">Why trust becomes harder in portable systems</a></li><li><a href="#where-teams-usually-go-wrong">Where teams usually go wrong</a></li><li><a href="#what-good-trust-design-looks-like">What good trust design looks like</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#why-are-trust-boundaries-more-important-in-portable-systems">Why are trust boundaries more important in portable systems?</a></li><li><a href="#can-trust-be-delegated-entirely-to-the-platform-team">Can trust be delegated entirely to the platform team?</a></li><li><a href="#can-a-service-be-valid-and-still-be-denied">Can a service be valid and still be denied?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Trust Boundaries in UMA</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Trust boundaries in UMA</h1>
           <p>
             Portability only works in production if trust remains explicit. Universal Microservices Architecture treats identity,
@@ -79,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>Why trust cannot be added later</h2>
+            <h2 id="why-trust-cannot-be-added-later">Why trust cannot be added later</h2>
             <p>
               When a service moves between hosts, runtimes, and execution contexts, the questions change quickly. What is allowed to run?
               What is allowed to call what? Which capabilities can be used, and under which policy? If those answers do not live in the
@@ -95,7 +116,7 @@
           </section>
 
           <section>
-            <h2>What a trust boundary means in UMA</h2>
+            <h2 id="what-a-trust-boundary-means-in-uma">What a trust boundary means in UMA</h2>
             <p>
               A trust boundary is the point where the system decides what a portable service is allowed to do, what it is allowed to access,
               and under which identity it is allowed to execute. In UMA, that boundary is not assumed from the deployment environment. It is
@@ -114,25 +135,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Identity</h3>
+              <h3 id="identity">Identity</h3>
               <p>Each portable unit needs a stable identity so the system can reason about what is being executed.</p>
             </article>
             <article class="subpage-card">
-              <h3>Permissions</h3>
+              <h3 id="permissions">Permissions</h3>
               <p>Capabilities should be declared and enforced deliberately instead of being inherited from the host by accident.</p>
             </article>
             <article class="subpage-card">
-              <h3>Provenance</h3>
+              <h3 id="provenance">Provenance</h3>
               <p>The architecture needs a story for where the executable unit came from and why it is trusted.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime enforcement</h3>
+              <h3 id="runtime-enforcement">Runtime enforcement</h3>
               <p>Trust boundaries only matter when the runtime can explain, apply, and audit the policy consistently.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why this is architectural, not operational</h2>
+            <h2 id="why-this-is-architectural-not-operational">Why this is architectural, not operational</h2>
             <p>
               Teams often treat trust as a platform concern that appears after the software already exists. UMA makes the opposite choice.
               It treats trust as part of the design of the system itself, because portability without governance creates invisible risk.
@@ -144,7 +165,7 @@
           </section>
 
           <section>
-            <h2>What governed execution means</h2>
+            <h2 id="what-governed-execution-means">What governed execution means</h2>
             <p>
               Governed execution means the runtime can explain why a capability was allowed, denied, or adapted in a particular way. The
               important part is not only that the policy exists, but that it remains visible and reviewable as part of the system model.
@@ -157,7 +178,7 @@
           </section>
 
           <section>
-            <h2>Why undeclared permissions should fail early</h2>
+            <h2 id="why-undeclared-permissions-should-fail-early">Why undeclared permissions should fail early</h2>
             <p>
               A portable service should not gain new powers just because it arrived in a more permissive environment. If the service needs
               access to a capability, that need should be declared clearly enough that the runtime can validate it before execution begins.
@@ -170,7 +191,7 @@
           </section>
 
           <section>
-            <h2>Why dependency provenance is architectural</h2>
+            <h2 id="why-dependency-provenance-is-architectural">Why dependency provenance is architectural</h2>
             <p>
               Dependency provenance is often treated as compliance paperwork or supply-chain hygiene outside the architecture itself. UMA
               treats it differently. If the runtime cannot explain where a service or one of its critical dependencies came from, trust is
@@ -183,7 +204,7 @@
           </section>
 
           <section>
-            <h2>Why compatibility is not the same as authorization</h2>
+            <h2 id="why-compatibility-is-not-the-same-as-authorization">Why compatibility is not the same as authorization</h2>
             <p>
               Two services can look compatible in shape and still be forbidden to communicate. Matching contracts do not automatically grant
               trust. Communication also depends on policy, identity, placement, and the trust model of the system.
@@ -195,7 +216,7 @@
           </section>
 
           <section>
-            <h2>Why trust becomes harder in portable systems</h2>
+            <h2 id="why-trust-becomes-harder-in-portable-systems">Why trust becomes harder in portable systems</h2>
             <p>
               The more places a service can run, the more important it becomes to define who it is, what it can do, and what evidence the
               runtime needs before it allows execution. Portability increases freedom, but it also increases the need for precise
@@ -208,7 +229,7 @@
           </section>
 
           <section>
-            <h2>Where teams usually go wrong</h2>
+            <h2 id="where-teams-usually-go-wrong">Where teams usually go wrong</h2>
             <ul>
               <li>They assume the host environment will imply the right permissions.</li>
               <li>They treat provenance as an operational concern instead of a runtime input.</li>
@@ -219,7 +240,7 @@
           </section>
 
           <section>
-            <h2>What good trust design looks like</h2>
+            <h2 id="what-good-trust-design-looks-like">What good trust design looks like</h2>
             <p>
               Good trust design starts by naming the executable unit clearly, defining its contracts, and deciding which capabilities it is
               allowed to use. The runtime then enforces those decisions consistently, with identity and provenance visible enough that the
@@ -237,18 +258,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Why are trust boundaries more important in portable systems?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="why-are-trust-boundaries-more-important-in-portable-systems">Why are trust boundaries more important in portable systems?</h3>
             <p>
               Because portable systems cross more execution contexts. The more places a service can run, the more important it becomes to
               define who it is, what it can do, and how the runtime enforces those decisions consistently.
             </p>
-            <h3>Can trust be delegated entirely to the platform team?</h3>
+            <h3 id="can-trust-be-delegated-entirely-to-the-platform-team">Can trust be delegated entirely to the platform team?</h3>
             <p>
               The platform team can implement and operate enforcement, but the architecture still has to define what should be trusted, what
               is allowed, and which runtime inputs matter. Otherwise the platform only enforces an incomplete model.
             </p>
-            <h3>Can a service be valid and still be denied?</h3>
+            <h3 id="can-a-service-be-valid-and-still-be-denied">Can a service be valid and still be denied?</h3>
             <p>
               Yes. A service can match the expected shape and still be denied because it requested undeclared permissions, carries
               untrusted provenance, or attempts communication the trust policy does not allow.
@@ -276,7 +297,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/uma-production-readiness/index.html
+++ b/book-site/uma-production-readiness/index.html
@@ -6,16 +6,20 @@
     <title>UMA Production Readiness | Universal Microservices Architecture</title>
     <meta name="description" content="Understand what production readiness means in UMA across security, versioning, governance, observability, deployment, and runtime authority." />
     <link rel="canonical" href="https://www.universalmicroservices.com/uma-production-readiness/" />
-    <meta property="og:title" content="UMA Production Readiness | Universal Microservices Architecture" />
-    <meta property="og:description" content="A conceptual production readiness checklist for Universal Microservices Architecture." />
+    <meta property="og:title" content="UMA Production Readiness" />
+    <meta property="og:description" content="Understand what production readiness means in UMA across security, versioning, governance, observability, deployment, and runtime authority." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/uma-production-readiness/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"UMA production readiness","description":"Understand what production readiness means in UMA across security, versioning, governance, observability, deployment, and runtime authority.","url":"https://www.universalmicroservices.com/uma-production-readiness/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/uma-production-readiness/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA Production Readiness","item":"https://www.universalmicroservices.com/uma-production-readiness/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA Production Readiness","description":"Understand what production readiness means in UMA across security, versioning, governance, observability, deployment, and runtime authority.","url":"https://www.universalmicroservices.com/uma-production-readiness/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -26,53 +30,103 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#security-and-trust">Security and trust</a></li><li><a href="#versioning-and-compatibility">Versioning and compatibility</a></li><li><a href="#governance">Governance</a></li><li><a href="#observability">Observability</a></li><li><a href="#deployment">Deployment</a>
+    <ul class="page-rail-links">
+      <li><a href="#security">Security</a></li><li><a href="#versioning">Versioning</a></li><li><a href="#governance-2">Governance</a></li><li><a href="#observability-2">Observability</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA Production Readiness</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>UMA production readiness</h1>
           <p>Production readiness in UMA is not just the question of whether portable code can run. The stronger question is whether the runtime can govern that code under real trust, versioning, observability, and deployment constraints.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>Security and trust</h2>
+            <h2 id="security-and-trust">Security and trust</h2>
             <p>A portable service can create new security pressure because the same behavior may run in different contexts. UMA treats trust boundaries, permissions, provenance, and authority as part of the runtime model.</p>
             <p>The runtime must know what is allowed before it executes.</p>
           </section>
 
           <section>
-            <h2>Versioning and compatibility</h2>
+            <h2 id="versioning-and-compatibility">Versioning and compatibility</h2>
             <p>A production UMA system needs clear contracts, compatibility checks, and versioned evolution. Without that discipline, portability can turn into version sprawl.</p>
             <p>The service graph should make change visible rather than leaving teams to discover drift through incidents.</p>
           </section>
 
           <section>
-            <h2>Governance</h2>
+            <h2 id="governance">Governance</h2>
             <p>Governance means deciding who can expose a capability, who can call it, what evidence is required, and which runtime path is authoritative. UMA makes those questions architecture questions, not only operations questions.</p>
             <p>This is especially important when AI-assisted workflows participate in discovery or proposal.</p>
           </section>
 
           <section>
-            <h2>Observability</h2>
+            <h2 id="observability">Observability</h2>
             <p>Observability should show more than whether a process is alive. A UMA runtime should expose capability selection, validation decisions, approvals, rejections, execution paths, and relevant traces.</p>
             <p>That evidence is what makes runtime decisions explainable.</p>
           </section>
 
           <section>
-            <h2>Deployment</h2>
+            <h2 id="deployment">Deployment</h2>
             <p>Deployment readiness depends on the hosts involved. Browser, edge, cloud, WASI, and workflow execution each introduce different constraints. UMA does not erase those differences. It gives teams a model for deciding where a capability should run and why.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Security</h3><p>Trust, permissions, and provenance must travel with the runtime decision.</p></article>
-            <article class="subpage-card"><h3>Versioning</h3><p>Contracts and compatibility need to be visible as the system evolves.</p></article>
-            <article class="subpage-card"><h3>Governance</h3><p>Capability exposure and execution authority need explicit ownership.</p></article>
-            <article class="subpage-card"><h3>Observability</h3><p>The runtime should explain decisions, not only report activity.</p></article>
+            <article class="subpage-card"><h3 id="security">Security</h3><p>Trust, permissions, and provenance must travel with the runtime decision.</p></article>
+            <article class="subpage-card"><h3 id="versioning">Versioning</h3><p>Contracts and compatibility need to be visible as the system evolves.</p></article>
+            <article class="subpage-card"><h3 id="governance-2">Governance</h3><p>Capability exposure and execution authority need explicit ownership.</p></article>
+            <article class="subpage-card"><h3 id="observability-2">Observability</h3><p>The runtime should explain decisions, not only report activity.</p></article>
           </section>
           <section class="subpage-callout">
             <strong>Want to go deeper?</strong>

--- a/book-site/uma-vs-modular-monolith/index.html
+++ b/book-site/uma-vs-modular-monolith/index.html
@@ -6,16 +6,20 @@
     <title>UMA vs Modular Monolith | Universal Microservices Architecture</title>
     <meta name="description" content="Compare UMA and modular monoliths across modularity, deployment boundaries, runtime boundaries, and system evolution paths." />
     <link rel="canonical" href="https://www.universalmicroservices.com/uma-vs-modular-monolith/" />
-    <meta property="og:title" content="UMA vs Modular Monolith | Universal Microservices Architecture" />
-    <meta property="og:description" content="A practical comparison of UMA and modular monolith architecture." />
+    <meta property="og:title" content="UMA vs Modular Monolith" />
+    <meta property="og:description" content="Compare UMA and modular monoliths across modularity, deployment boundaries, runtime boundaries, and system evolution paths." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/uma-vs-modular-monolith/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"UMA vs modular monolith","description":"Compare UMA and modular monoliths across modularity, deployment boundaries, runtime boundaries, and system evolution paths.","url":"https://www.universalmicroservices.com/uma-vs-modular-monolith/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/uma-vs-modular-monolith/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA vs Modular Monolith","item":"https://www.universalmicroservices.com/uma-vs-modular-monolith/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA vs Modular Monolith","description":"Compare UMA and modular monoliths across modularity, deployment boundaries, runtime boundaries, and system evolution paths.","url":"https://www.universalmicroservices.com/uma-vs-modular-monolith/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -26,53 +30,103 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#modularity">Modularity</a></li><li><a href="#deployment-boundaries">Deployment boundaries</a></li><li><a href="#runtime-boundaries">Runtime boundaries</a></li><li><a href="#evolution-paths">Evolution paths</a>
+    <ul class="page-rail-links">
+      <li><a href="#modular-monolith">Modular monolith</a></li><li><a href="#uma">UMA</a></li><li><a href="#shared-strength">Shared strength</a></li><li><a href="#key-difference">Key difference</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA vs Modular Monolith</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>UMA vs modular monolith</h1>
           <p>A modular monolith can be a strong architecture when one deployment unit is acceptable and internal boundaries are clear. UMA addresses a different pressure: how to preserve one behavior when execution needs to cross runtime boundaries.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>A modular monolith organizes code inside one deployable system. UMA organizes portable behavior so it can remain coherent across multiple execution contexts.</p>
             <p>The two ideas can coexist. A modular monolith may host UMA-style capabilities, and UMA can help identify which behaviors should leave the monolith first.</p>
           </section>
 
           <section>
-            <h2>Modularity</h2>
+            <h2 id="modularity">Modularity</h2>
             <p>Modular monoliths improve internal structure by making module boundaries explicit. That is valuable. UMA adds a stronger question about whether a behavior can survive outside the original host without being rewritten.</p>
             <p>Internal modularity is not the same as runtime portability.</p>
           </section>
 
           <section>
-            <h2>Deployment boundaries</h2>
+            <h2 id="deployment-boundaries">Deployment boundaries</h2>
             <p>The modular monolith usually keeps deployment simple by shipping one unit. UMA accepts that some behavior may need to execute in different places and makes the surrounding runtime decisions explicit.</p>
             <p>This is not a claim that distributed deployment is always better. It is a claim that runtime diversity needs a model when it appears.</p>
           </section>
 
           <section>
-            <h2>Runtime boundaries</h2>
+            <h2 id="runtime-boundaries">Runtime boundaries</h2>
             <p>A module inside a monolith often assumes the host process, shared memory, local libraries, and a common framework. A Universal Microservice has to make more of its boundary explicit so the behavior can be governed elsewhere.</p>
             <p>That extra discipline is useful only when the behavior needs that freedom.</p>
           </section>
 
           <section>
-            <h2>Evolution paths</h2>
+            <h2 id="evolution-paths">Evolution paths</h2>
             <p>A modular monolith can evolve into services when pressure justifies it. UMA gives teams a way to extract behavior by capability and prove that the extracted unit remains coherent before wider rollout.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Modular monolith</h3><p>Best when deployment simplicity and internal modularity solve the main problem.</p></article>
-            <article class="subpage-card"><h3>UMA</h3><p>Best when behavior must cross browser, edge, cloud, workflow, or AI-assisted paths.</p></article>
-            <article class="subpage-card"><h3>Shared strength</h3><p>Both models value explicit boundaries over accidental coupling.</p></article>
-            <article class="subpage-card"><h3>Key difference</h3><p>UMA treats runtime movement as a first-class architectural concern.</p></article>
+            <article class="subpage-card"><h3 id="modular-monolith">Modular monolith</h3><p>Best when deployment simplicity and internal modularity solve the main problem.</p></article>
+            <article class="subpage-card"><h3 id="uma">UMA</h3><p>Best when behavior must cross browser, edge, cloud, workflow, or AI-assisted paths.</p></article>
+            <article class="subpage-card"><h3 id="shared-strength">Shared strength</h3><p>Both models value explicit boundaries over accidental coupling.</p></article>
+            <article class="subpage-card"><h3 id="key-difference">Key difference</h3><p>UMA treats runtime movement as a first-class architectural concern.</p></article>
           </section>
           <section class="subpage-callout">
             <strong>Want to go deeper?</strong>

--- a/book-site/uma-vs-serverless/index.html
+++ b/book-site/uma-vs-serverless/index.html
@@ -6,16 +6,20 @@
     <title>UMA vs Serverless | Universal Microservices Architecture</title>
     <meta name="description" content="Compare UMA and serverless across runtime model, deployment model, portability, governance, and cost considerations." />
     <link rel="canonical" href="https://www.universalmicroservices.com/uma-vs-serverless/" />
-    <meta property="og:title" content="UMA vs Serverless | Universal Microservices Architecture" />
-    <meta property="og:description" content="A clear comparison of Universal Microservices Architecture and serverless architecture." />
+    <meta property="og:title" content="UMA vs Serverless" />
+    <meta property="og:description" content="Compare UMA and serverless across runtime model, deployment model, portability, governance, and cost considerations." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/uma-vs-serverless/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"UMA vs serverless","description":"Compare UMA and serverless across runtime model, deployment model, portability, governance, and cost considerations.","url":"https://www.universalmicroservices.com/uma-vs-serverless/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/uma-vs-serverless/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA vs Serverless","item":"https://www.universalmicroservices.com/uma-vs-serverless/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA vs Serverless","description":"Compare UMA and serverless across runtime model, deployment model, portability, governance, and cost considerations.","url":"https://www.universalmicroservices.com/uma-vs-serverless/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -26,53 +30,103 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#runtime-model">Runtime model</a></li><li><a href="#deployment-model">Deployment model</a></li><li><a href="#portability">Portability</a></li><li><a href="#cost-considerations">Cost considerations</a>
+    <ul class="page-rail-links">
+      <li><a href="#serverless">Serverless</a></li><li><a href="#uma">UMA</a></li><li><a href="#serverless-risk">Serverless risk</a></li><li><a href="#uma-risk">UMA risk</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA vs Serverless</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>UMA vs serverless</h1>
           <p>UMA and serverless solve different problems. Serverless is primarily a deployment and operations model. UMA is an architectural model for keeping behavior portable, governed, and coherent as execution crosses runtime boundaries.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>Serverless asks who manages the servers and how functions are invoked. UMA asks how one business capability keeps its meaning when it can execute across browser, edge, cloud, workflow, and AI-assisted paths.</p>
             <p>A UMA service could run through a serverless platform, but serverless alone does not define the portable service boundary.</p>
           </section>
 
           <section>
-            <h2>Runtime model</h2>
+            <h2 id="runtime-model">Runtime model</h2>
             <p>Serverless runtimes are provider-shaped. They define invocation, scaling, permissions, event bindings, and operational constraints. UMA treats runtime concerns as explicit architecture, but does not assume one provider runtime is the durable model.</p>
             <p>The runtime in UMA governs where and how a portable capability executes.</p>
           </section>
 
           <section>
-            <h2>Deployment model</h2>
+            <h2 id="deployment-model">Deployment model</h2>
             <p>Serverless focuses on deploying small units without managing servers. UMA focuses on preserving business behavior across deployment shapes. The deployment target is important, but it is not the center of the model.</p>
             <p>That distinction matters when the same behavior must live in more than one environment.</p>
           </section>
 
           <section>
-            <h2>Portability</h2>
+            <h2 id="portability">Portability</h2>
             <p>A serverless function may be easy to deploy but still deeply tied to provider APIs, event models, and operational assumptions. A UMA service is designed so the core behavior can remain stable while adapters and runtimes vary.</p>
             <p>Portability is not automatic. It has to be designed and proven.</p>
           </section>
 
           <section>
-            <h2>Cost considerations</h2>
+            <h2 id="cost-considerations">Cost considerations</h2>
             <p>Serverless can reduce operational burden and align cost to usage, but provider-specific coupling and cold-start behavior can influence architecture. UMA does not prescribe a cost model. It helps teams make runtime placement decisions explicit so cost is one visible input among others.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Serverless</h3><p>A deployment and operations model for running code without managing servers.</p></article>
-            <article class="subpage-card"><h3>UMA</h3><p>An architectural model for portable behavior and governed runtime decisions.</p></article>
-            <article class="subpage-card"><h3>Serverless risk</h3><p>Provider-specific events and APIs can become hidden architecture.</p></article>
-            <article class="subpage-card"><h3>UMA risk</h3><p>The runtime and governance model must be designed deliberately.</p></article>
+            <article class="subpage-card"><h3 id="serverless">Serverless</h3><p>A deployment and operations model for running code without managing servers.</p></article>
+            <article class="subpage-card"><h3 id="uma">UMA</h3><p>An architectural model for portable behavior and governed runtime decisions.</p></article>
+            <article class="subpage-card"><h3 id="serverless-risk">Serverless risk</h3><p>Provider-specific events and APIs can become hidden architecture.</p></article>
+            <article class="subpage-card"><h3 id="uma-risk">UMA risk</h3><p>The runtime and governance model must be designed deliberately.</p></article>
           </section>
           <section class="subpage-callout">
             <strong>Want to go deeper?</strong>

--- a/book-site/uma-vs-traditional-microservices/index.html
+++ b/book-site/uma-vs-traditional-microservices/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UMA vs Traditional Microservices | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Compare Universal Microservices Architecture with traditional microservices and learn where UMA changes the architectural center of gravity."
-    />
+    <meta name="description" content="Compare Universal Microservices Architecture with traditional microservices and learn where UMA changes the architectural center of gravity." />
     <link rel="canonical" href="https://www.universalmicroservices.com/uma-vs-traditional-microservices/" />
-    <meta property="og:title" content="UMA vs Traditional Microservices | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original comparison of UMA and traditional microservices, focused on portable behavior, runtime governance, and long-term architectural coherence."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="UMA vs Traditional Microservices" />
+    <meta property="og:description" content="Compare Universal Microservices Architecture with traditional microservices and learn where UMA changes the architectural center of gravity." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/uma-vs-traditional-microservices/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "UMA vs Traditional Microservices",
-  "description": "An original comparison of Universal Microservices Architecture and traditional microservices, focused on behavior portability, runtime visibility, and governed system evolution.",
-  "url": "https://www.universalmicroservices.com/uma-vs-traditional-microservices/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/uma-vs-traditional-microservices/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"UMA vs Traditional Microservices","item":"https://www.universalmicroservices.com/uma-vs-traditional-microservices/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"UMA vs Traditional Microservices","description":"Compare Universal Microservices Architecture with traditional microservices and learn where UMA changes the architectural center of gravity.","url":"https://www.universalmicroservices.com/uma-vs-traditional-microservices/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#one-concrete-before-and-after-test">One concrete before-and-after test</a></li><li><a href="#what-traditional-microservices-do-well">What traditional microservices do well</a></li><li><a href="#where-the-center-of-gravity-changes">Where the center of gravity changes</a>
+    <ul class="page-rail-links">
+      <li><a href="#traditional-microservices">Traditional microservices</a></li><li><a href="#uma">UMA</a></li><li><a href="#traditional-microservices-2">Traditional microservices</a></li><li><a href="#uma-2">UMA</a></li>
+    </ul></li><li><a href="#why-traditional-microservices-are-no-longer-enough-by-themselves">Why traditional microservices are no longer enough by themselves</a></li><li><a href="#what-uma-adds-to-the-conversation">What UMA adds to the conversation</a></li><li><a href="#how-to-decide-which-lens-you-need">How to decide which lens you need</a></li><li><a href="#what-uma-is-not-trying-to-do">What UMA is not trying to do</a></li><li><a href="#a-practical-comparison-test">A practical comparison test</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-uma-replacing-microservices">Is UMA replacing microservices?</a></li><li><a href="#can-uma-and-traditional-microservices-coexist">Can UMA and traditional microservices coexist?</a></li><li><a href="#why-is-this-distinction-important-for-the-book">Why is this distinction important for the book?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">UMA vs Traditional Microservices</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>UMA vs traditional microservices</h1>
           <p>
             Universal Microservices Architecture is not a rejection of microservices. It is a response to a different problem. Traditional
@@ -97,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               Traditional microservices usually center the architecture on deployable service ownership. UMA centers the architecture on
               portable behavior plus governed runtime decisions. That shift matters because modern systems no longer live neatly inside one
@@ -116,7 +119,7 @@
           </section>
 
           <section>
-            <h2>One concrete before-and-after test</h2>
+            <h2 id="one-concrete-before-and-after-test">One concrete before-and-after test</h2>
             <p>
               Imagine one product rule that has to appear in a browser experience, a backend authority check, an edge optimization, and a
               generated workflow. In a typical stack-first system, each surface ends up with its own version of the rule. The system still
@@ -130,7 +133,7 @@
           </section>
 
           <section>
-            <h2>What traditional microservices do well</h2>
+            <h2 id="what-traditional-microservices-do-well">What traditional microservices do well</h2>
             <p>
               Traditional microservices remain valuable because they make service ownership, deployment independence, and bounded
               responsibility easier to reason about. They helped teams move away from monolithic stacks by making service boundaries more
@@ -144,7 +147,7 @@
           </section>
 
           <section>
-            <h2>Where the center of gravity changes</h2>
+            <h2 id="where-the-center-of-gravity-changes">Where the center of gravity changes</h2>
             <p>
               The main difference is what each model treats as the durable unit. Traditional microservices emphasize the deployable service.
               UMA emphasizes the portable service behavior and the runtime layer around it. That means contracts, capability exposure,
@@ -164,25 +167,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Traditional microservices</h3>
+              <h3 id="traditional-microservices">Traditional microservices</h3>
               <p>Strong at separating deployable backend units and clarifying ownership between services.</p>
             </article>
             <article class="subpage-card">
-              <h3>UMA</h3>
+              <h3 id="uma">UMA</h3>
               <p>Strong at preserving one service meaning while runtime, policy, trust, and workflow surfaces evolve around it.</p>
             </article>
             <article class="subpage-card">
-              <h3>Traditional microservices</h3>
+              <h3 id="traditional-microservices-2">Traditional microservices</h3>
               <p>Tend to assume the important runtime boundary is the service process or network endpoint.</p>
             </article>
             <article class="subpage-card">
-              <h3>UMA</h3>
+              <h3 id="uma-2">UMA</h3>
               <p>Treats the portable service boundary and the governed runtime around it as the more durable architectural model.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why traditional microservices are no longer enough by themselves</h2>
+            <h2 id="why-traditional-microservices-are-no-longer-enough-by-themselves">Why traditional microservices are no longer enough by themselves</h2>
             <p>
               A modern product rarely runs in only one place. Important behavior often appears in frontend validation, edge adaptation,
               backend authority, workflow automation, and AI-assisted composition. Traditional microservices can still model the backend
@@ -195,7 +198,7 @@
           </section>
 
           <section>
-            <h2>What UMA adds to the conversation</h2>
+            <h2 id="what-uma-adds-to-the-conversation">What UMA adds to the conversation</h2>
             <p>
               UMA adds a stronger story for portability, governed execution, capability discovery, runtime authority, and long-term system
               coherence. It makes room for workflows that are selected dynamically, capabilities that are surfaced explicitly, and runtime
@@ -208,7 +211,7 @@
           </section>
 
           <section>
-            <h2>How to decide which lens you need</h2>
+            <h2 id="how-to-decide-which-lens-you-need">How to decide which lens you need</h2>
             <p>
               If your main problem is separating backend ownership and deployment responsibility, traditional microservices may be enough.
               If your main problem is preserving one behavior across client, edge, server, background, and AI-assisted contexts, the
@@ -222,7 +225,7 @@
           </section>
 
           <section>
-            <h2>What UMA is not trying to do</h2>
+            <h2 id="what-uma-is-not-trying-to-do">What UMA is not trying to do</h2>
             <ul>
               <li>It is not trying to erase service ownership or operational boundaries.</li>
               <li>It is not claiming microservices were a mistake.</li>
@@ -233,7 +236,7 @@
           </section>
 
           <section>
-            <h2>A practical comparison test</h2>
+            <h2 id="a-practical-comparison-test">A practical comparison test</h2>
             <p>
               Ask one question: when the same business behavior appears in browser code, edge logic, backend authority, and a generated
               workflow, what architectural model keeps that behavior coherent? If your answer is only “we have many small services,” you
@@ -246,18 +249,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is UMA replacing microservices?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-uma-replacing-microservices">Is UMA replacing microservices?</h3>
             <p>
               No. UMA is better understood as a later architectural response to problems that traditional microservices do not fully model,
               especially portability across runtimes and visible runtime governance.
             </p>
-            <h3>Can UMA and traditional microservices coexist?</h3>
+            <h3 id="can-uma-and-traditional-microservices-coexist">Can UMA and traditional microservices coexist?</h3>
             <p>
               Yes. Many organizations will still operate microservice-based systems while using UMA ideas to preserve portable behavior and
               make runtime decisions more explicit.
             </p>
-            <h3>Why is this distinction important for the book?</h3>
+            <h3 id="why-is-this-distinction-important-for-the-book">Why is this distinction important for the book?</h3>
             <p>
               Because a reader should understand that UMA is not “microservices with WebAssembly.” It is a different architectural lens,
               one designed for systems whose behavior must survive across more varied execution contexts.
@@ -284,7 +287,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/webassembly-architecture/index.html
+++ b/book-site/webassembly-architecture/index.html
@@ -3,38 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WebAssembly Architecture and UMA</title>
-    <meta
-      name="description"
-      content="Learn how WebAssembly architecture supports Universal Microservices Architecture and why portable execution still needs contracts, policy, and runtime governance."
-    />
+    <title>WebAssembly Architecture and UMA | Universal Microservices Architecture</title>
+    <meta name="description" content="Learn how WebAssembly architecture supports Universal Microservices Architecture and why portable execution still needs contracts, policy, and runtime governance." />
     <link rel="canonical" href="https://www.universalmicroservices.com/webassembly-architecture/" />
     <meta property="og:title" content="WebAssembly Architecture and UMA" />
-    <meta
-      property="og:description"
-      content="An original guide to how WebAssembly and Universal Microservices Architecture fit together without reducing architecture to packaging."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:description" content="Learn how WebAssembly architecture supports Universal Microservices Architecture and why portable execution still needs contracts, policy, and runtime governance." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/webassembly-architecture/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"WebAssembly Architecture and UMA","item":"https://www.universalmicroservices.com/webassembly-architecture/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"WebAssembly Architecture and UMA","description":"Learn how WebAssembly architecture supports Universal Microservices Architecture and why portable execution still needs contracts, policy, and runtime governance.","url":"https://www.universalmicroservices.com/webassembly-architecture/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#what-webassembly-contributes">What WebAssembly contributes</a></li><li><a href="#why-webassembly-fits-this-model">Why WebAssembly fits this model</a>
+    <ul class="page-rail-links">
+      <li><a href="#execution-portability">Execution portability</a></li><li><a href="#runtime-boundaries">Runtime boundaries</a></li><li><a href="#capability-control">Capability control</a></li><li><a href="#architectural-consistency">Architectural consistency</a></li>
+    </ul></li><li><a href="#why-this-is-bigger-than-packaging">Why this is bigger than packaging</a></li><li><a href="#what-webassembly-does-not-solve-by-itself">What WebAssembly does not solve by itself</a></li><li><a href="#why-architects-care">Why architects care</a></li><li><a href="#what-architects-should-pay-attention-to">What architects should pay attention to</a></li><li><a href="#where-teams-go-wrong">Where teams go wrong</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#does-webassembly-automatically-make-a-system-portable">Does WebAssembly automatically make a system portable?</a></li><li><a href="#does-uma-require-webassembly-everywhere">Does UMA require WebAssembly everywhere?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">WebAssembly Architecture and UMA</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>WebAssembly architecture in UMA</h1>
           <p>
             WebAssembly matters to Universal Microservices Architecture because it gives portable service behavior a stable execution
@@ -79,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>What WebAssembly contributes</h2>
+            <h2 id="what-webassembly-contributes">What WebAssembly contributes</h2>
             <p>
               WebAssembly makes it easier to preserve a service boundary across environments because the same core behavior can be compiled
               into a portable executable form. That lowers the cost of running the same logic in multiple places, but it does not by itself
@@ -95,7 +116,7 @@
           </section>
 
           <section>
-            <h2>Why WebAssembly fits this model</h2>
+            <h2 id="why-webassembly-fits-this-model">Why WebAssembly fits this model</h2>
             <p>
               WebAssembly is useful here because it creates a repeatable execution boundary. That boundary makes it easier to preserve the
               identity of a service as it moves between hosts. Instead of re-implementing the same behavior in multiple runtime-specific
@@ -109,25 +130,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Execution portability</h3>
+              <h3 id="execution-portability">Execution portability</h3>
               <p>One service can move across client, edge, and cloud contexts without being reauthored for each one.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime boundaries</h3>
+              <h3 id="runtime-boundaries">Runtime boundaries</h3>
               <p>The host still matters, which is why UMA keeps runtime responsibilities explicit rather than pretending they disappear.</p>
             </article>
             <article class="subpage-card">
-              <h3>Capability control</h3>
+              <h3 id="capability-control">Capability control</h3>
               <p>Portable execution only stays useful when permissions, adapters, and host bindings are declared and enforced clearly.</p>
             </article>
             <article class="subpage-card">
-              <h3>Architectural consistency</h3>
+              <h3 id="architectural-consistency">Architectural consistency</h3>
               <p>WebAssembly is most powerful when it supports a durable service model instead of becoming another packaging layer.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why this is bigger than packaging</h2>
+            <h2 id="why-this-is-bigger-than-packaging">Why this is bigger than packaging</h2>
             <p>
               Many discussions about WebAssembly focus on where binaries can run. UMA is more interested in what the system becomes when the
               same business behavior can move safely across runtimes. That is an architectural question, not a distribution feature.
@@ -140,7 +161,7 @@
           </section>
 
           <section>
-            <h2>What WebAssembly does not solve by itself</h2>
+            <h2 id="what-webassembly-does-not-solve-by-itself">What WebAssembly does not solve by itself</h2>
             <p>
               WebAssembly does not automatically define the service boundary, the contract, the trust model, or the operational policy. It
               does not decide where a service should execute, how compatibility should be described, or how the system should evolve when
@@ -153,7 +174,7 @@
           </section>
 
           <section>
-            <h2>Why architects care</h2>
+            <h2 id="why-architects-care">Why architects care</h2>
             <p>
               Architects care about WebAssembly in this context because it changes the cost of preserving service behavior. Once the same
               behavior can move across controlled runtimes with stronger isolation, the architecture can stop centering everything on stack
@@ -167,7 +188,7 @@
           </section>
 
           <section>
-            <h2>What architects should pay attention to</h2>
+            <h2 id="what-architects-should-pay-attention-to">What architects should pay attention to</h2>
             <ul>
               <li>Whether the portable unit has a clear service boundary.</li>
               <li>Whether host capabilities are explicit instead of implied.</li>
@@ -178,7 +199,7 @@
           </section>
 
           <section>
-            <h2>Where teams go wrong</h2>
+            <h2 id="where-teams-go-wrong">Where teams go wrong</h2>
             <p>
               A common failure mode is to treat WebAssembly as if it alone guarantees a portable architecture. In practice, teams can still
               build brittle systems if contracts stay vague, host bindings are hidden, or runtime policy lives only in undocumented code.
@@ -190,13 +211,13 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Does WebAssembly automatically make a system portable?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="does-webassembly-automatically-make-a-system-portable">Does WebAssembly automatically make a system portable?</h3>
             <p>
               No. It makes portable execution more practical, but the system still needs contracts, trust, policy, and a coherent service
               model. Without those, WebAssembly becomes another delivery mechanism rather than a durable architectural boundary.
             </p>
-            <h3>Does UMA require WebAssembly everywhere?</h3>
+            <h3 id="does-uma-require-webassembly-everywhere">Does UMA require WebAssembly everywhere?</h3>
             <p>
               No. UMA benefits from WebAssembly as a strong portable execution target, but the architectural point is larger than one
               technology choice. The key question is whether service behavior stays durable while runtime responsibilities remain explicit.
@@ -222,7 +243,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-belongs-in-the-runtime-layer/index.html
+++ b/book-site/what-belongs-in-the-runtime-layer/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Belongs in the Runtime Layer? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what belongs in the runtime layer in UMA: validation, adapter binding, policy, lifecycle evidence, and the governed conditions around execution."
-    />
+    <meta name="description" content="Learn what belongs in the runtime layer in UMA: validation, adapter binding, policy, lifecycle evidence, and the governed conditions around execution." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/" />
-    <meta property="og:title" content="What Belongs in the Runtime Layer? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to the UMA runtime layer: what it should own, what it should not own, and why that separation matters."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Belongs in the Runtime Layer?" />
+    <meta property="og:description" content="Learn what belongs in the runtime layer in UMA: validation, adapter binding, policy, lifecycle evidence, and the governed conditions around execution." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Belongs in the Runtime Layer?",
-  "description": "An original explanation of what belongs in the runtime layer in Universal Microservices Architecture and why validation, adapter binding, and lifecycle evidence should stay outside the portable service core.",
-  "url": "https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Belongs in the Runtime Layer?","item":"https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Belongs in the Runtime Layer?","description":"Learn what belongs in the runtime layer in UMA: validation, adapter binding, policy, lifecycle evidence, and the governed conditions around execution.","url":"https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#what-should-stay-inside-the-service">What should stay inside the service</a></li><li><a href="#what-the-runtime-should-own-instead">What the runtime should own instead</a>
+    <ul class="page-rail-links">
+      <li><a href="#validation">Validation</a></li><li><a href="#adapter-binding">Adapter binding</a></li><li><a href="#policy-and-trust">Policy and trust</a></li><li><a href="#lifecycle-evidence">Lifecycle evidence</a></li>
+    </ul></li><li><a href="#why-fail-fast-validation-belongs-there">Why fail-fast validation belongs there</a></li><li><a href="#why-adapter-binding-should-stay-visible">Why adapter binding should stay visible</a></li><li><a href="#why-lifecycle-evidence-matters">Why lifecycle evidence matters</a></li><li><a href="#what-the-runtime-layer-should-not-become">What the runtime layer should not become</a></li><li><a href="#a-practical-design-test">A practical design test</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#does-the-runtime-layer-replace-the-service">Does the runtime layer replace the service?</a></li><li><a href="#why-not-keep-adapter-binding-inside-the-host-application">Why not keep adapter binding inside the host application?</a></li><li><a href="#is-lifecycle-evidence-only-useful-in-large-systems">Is lifecycle evidence only useful in large systems?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Belongs in the Runtime Layer?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What belongs in the runtime layer?</h1>
           <p>
             In UMA, the runtime layer owns the governed conditions around execution. The service keeps the durable business behavior. The
@@ -96,9 +99,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               The runtime layer should own validation, adapter selection, policy enforcement, lifecycle evidence, and the execution context
               around the service. It should not quietly become the place where the service’s core business rule is rewritten.
@@ -111,7 +114,7 @@
           </section>
 
           <section>
-            <h2>What should stay inside the service</h2>
+            <h2 id="what-should-stay-inside-the-service">What should stay inside the service</h2>
             <p>
               The service should keep the business behavior that must remain semantically stable across hosts. That usually means rules,
               normalization logic, decision semantics, and the contract-shaped meaning of the result. This is the part of the system that
@@ -124,7 +127,7 @@
           </section>
 
           <section>
-            <h2>What the runtime should own instead</h2>
+            <h2 id="what-the-runtime-should-own-instead">What the runtime should own instead</h2>
             <p>
               The runtime should own the questions around the service rather than the rule inside it. Is the request valid? Which adapter
               is allowed to satisfy the capability? Which policy applies? Should execution fail fast before side effects happen? What
@@ -138,25 +141,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Validation</h3>
+              <h3 id="validation">Validation</h3>
               <p>Input checks, constraint checks, and fail-fast rules should happen before side effects are allowed to begin.</p>
             </article>
             <article class="subpage-card">
-              <h3>Adapter binding</h3>
+              <h3 id="adapter-binding">Adapter binding</h3>
               <p>The runtime should decide which host capability or adapter implementation satisfies the requested behavior.</p>
             </article>
             <article class="subpage-card">
-              <h3>Policy and trust</h3>
+              <h3 id="policy-and-trust">Policy and trust</h3>
               <p>Permissions, placement, trust boundaries, and environment-specific rules belong around the service, not inside it.</p>
             </article>
             <article class="subpage-card">
-              <h3>Lifecycle evidence</h3>
+              <h3 id="lifecycle-evidence">Lifecycle evidence</h3>
               <p>The runtime should keep enough observable evidence to explain what path actually ran and why.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why fail-fast validation belongs there</h2>
+            <h2 id="why-fail-fast-validation-belongs-there">Why fail-fast validation belongs there</h2>
             <p>
               One of the clearest runtime responsibilities is stopping invalid execution before the system causes side effects. If the
               runtime has enough context to know that a request is malformed, incompatible, or disallowed, the architecture is stronger
@@ -169,7 +172,7 @@
           </section>
 
           <section>
-            <h2>Why adapter binding should stay visible</h2>
+            <h2 id="why-adapter-binding-should-stay-visible">Why adapter binding should stay visible</h2>
             <p>
               Adapter selection is easy to hide in helper code, but that usually makes the architecture less legible. If a capability can
               be satisfied through different bindings or wrappers, the system is easier to review when the runtime owns that decision and
@@ -182,7 +185,7 @@
           </section>
 
           <section>
-            <h2>Why lifecycle evidence matters</h2>
+            <h2 id="why-lifecycle-evidence-matters">Why lifecycle evidence matters</h2>
             <p>
               A runtime layer becomes much more valuable once it can show what happened instead of merely claiming success. Event ordering,
               binding records, validation failures, and final state markers help the architecture stay auditable instead of turning into an
@@ -195,7 +198,7 @@
           </section>
 
           <section>
-            <h2>What the runtime layer should not become</h2>
+            <h2 id="what-the-runtime-layer-should-not-become">What the runtime layer should not become</h2>
             <ul>
               <li>It should not absorb the core business rule because the host code feels more convenient.</li>
               <li>It should not become a vague utility layer with hidden architectural decisions.</li>
@@ -206,7 +209,7 @@
           </section>
 
           <section>
-            <h2>A practical design test</h2>
+            <h2 id="a-practical-design-test">A practical design test</h2>
             <p>
               Ask whether your system can point to the exact place where validation happens, the exact place where adapter choice is made,
               and the exact place where execution evidence is recorded. If those answers are scattered across helpers and host-specific
@@ -219,18 +222,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Does the runtime layer replace the service?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="does-the-runtime-layer-replace-the-service">Does the runtime layer replace the service?</h3>
             <p>
               No. The service remains the durable behavioral center. The runtime layer exists around it so execution conditions stay
               explicit instead of leaking back into the service logic.
             </p>
-            <h3>Why not keep adapter binding inside the host application?</h3>
+            <h3 id="why-not-keep-adapter-binding-inside-the-host-application">Why not keep adapter binding inside the host application?</h3>
             <p>
               You can, but the architecture becomes harder to inspect. UMA is stronger when adapter choice is treated as a visible runtime
               concern rather than an implementation accident.
             </p>
-            <h3>Is lifecycle evidence only useful in large systems?</h3>
+            <h3 id="is-lifecycle-evidence-only-useful-in-large-systems">Is lifecycle evidence only useful in large systems?</h3>
             <p>
               No. It becomes more valuable at scale, but even a small service is easier to trust when the runtime can explain what it did
               and what it chose.
@@ -258,7 +261,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-is-a-capability/index.html
+++ b/book-site/what-is-a-capability/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Is a Capability in UMA? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what a capability means in Universal Microservices Architecture, how it differs from a service or workflow, and why it matters for governed composition."
-    />
+    <meta name="description" content="Learn what a capability means in Universal Microservices Architecture, how it differs from a service or workflow, and why it matters for governed composition." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-is-a-capability/" />
-    <meta property="og:title" content="What Is a Capability in UMA? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to one of the core UMA ideas: a capability is the unit the runtime can discover, validate, select, and compose into a workflow."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Is a Capability in UMA?" />
+    <meta property="og:description" content="Learn what a capability means in Universal Microservices Architecture, how it differs from a service or workflow, and why it matters for governed composition." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-is-a-capability/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Is a Capability in UMA?",
-  "description": "An original explanation of what a capability means in Universal Microservices Architecture and why capabilities matter more than stack-owned service labels when the runtime composes work dynamically.",
-  "url": "https://www.universalmicroservices.com/what-is-a-capability/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-is-a-capability/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Is a Capability in UMA?","item":"https://www.universalmicroservices.com/what-is-a-capability/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Is a Capability in UMA?","description":"Learn what a capability means in Universal Microservices Architecture, how it differs from a service or workflow, and why it matters for governed composition.","url":"https://www.universalmicroservices.com/what-is-a-capability/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-uma-uses-capabilities-instead-of-only-services">Why UMA uses capabilities instead of only services</a></li><li><a href="#what-makes-something-a-capability">What makes something a capability</a>
+    <ul class="page-rail-links">
+      <li><a href="#named-behavior">Named behavior</a></li><li><a href="#visible-contract">Visible contract</a></li><li><a href="#runtime-relevance">Runtime relevance</a></li><li><a href="#architectural-meaning">Architectural meaning</a></li>
+    </ul></li><li><a href="#capability-versus-workflow">Capability versus workflow</a></li><li><a href="#capability-versus-agent">Capability versus agent</a></li><li><a href="#why-this-matters-for-runtime-authority">Why this matters for runtime authority</a></li><li><a href="#a-concrete-proof-point">A concrete proof point</a></li><li><a href="#what-a-capability-is-not">What a capability is not</a></li><li><a href="#a-practical-design-test">A practical design test</a></li><li><a href="#why-capabilities-make-the-architecture-easier-to-learn">Why capabilities make the architecture easier to learn</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-a-capability-the-same-as-a-microservice">Is a capability the same as a microservice?</a></li><li><a href="#can-one-service-expose-more-than-one-capability">Can one service expose more than one capability?</a></li><li><a href="#do-capabilities-only-matter-in-dynamic-or-ai-driven-systems">Do capabilities only matter in dynamic or AI-driven systems?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Is a Capability in UMA?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What is a capability in UMA?</h1>
           <p>
             A capability is the unit the runtime can actually reason about. In Universal Microservices Architecture, a capability is not
@@ -97,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               In UMA, a capability is the actionable shape of a service. It tells the runtime what this piece of the system can do, what
               it expects, what it produces, and under which conditions it should be considered valid. That makes it more useful than a
@@ -121,7 +124,7 @@
           </section>
 
           <section>
-            <h2>Why UMA uses capabilities instead of only services</h2>
+            <h2 id="why-uma-uses-capabilities-instead-of-only-services">Why UMA uses capabilities instead of only services</h2>
             <p>
               The word service is useful, but it can stay too broad. It often tells you that some behavior exists without telling you what
               the runtime can do with it. A capability is more specific. It expresses the part of the service that is operationally
@@ -140,7 +143,7 @@
           </section>
 
           <section>
-            <h2>What makes something a capability</h2>
+            <h2 id="what-makes-something-a-capability">What makes something a capability</h2>
             <p>
               A capability is not defined only by where it runs or which team owns it. It is defined by whether the runtime can treat it
               as a clear architectural unit. That usually means four things are visible: the behavior it offers, the input it expects, the
@@ -154,25 +157,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Named behavior</h3>
+              <h3 id="named-behavior">Named behavior</h3>
               <p>A capability should express a meaningful action such as enriching, summarizing, translating, validating, or formatting.</p>
             </article>
             <article class="subpage-card">
-              <h3>Visible contract</h3>
+              <h3 id="visible-contract">Visible contract</h3>
               <p>The runtime should be able to inspect inputs, outputs, and compatibility expectations without guessing.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime relevance</h3>
+              <h3 id="runtime-relevance">Runtime relevance</h3>
               <p>The capability should be selectable, rejectable, and composable as part of a governed workflow.</p>
             </article>
             <article class="subpage-card">
-              <h3>Architectural meaning</h3>
+              <h3 id="architectural-meaning">Architectural meaning</h3>
               <p>The capability should explain what value it adds to the workflow, not just where a piece of code happens to live.</p>
             </article>
           </section>
 
           <section>
-            <h2>Capability versus workflow</h2>
+            <h2 id="capability-versus-workflow">Capability versus workflow</h2>
             <p>
               A capability is not the same thing as a workflow. A capability is one participant. A workflow is the approved path the
               runtime builds from one or more capabilities to satisfy a goal. Mixing those two ideas makes dynamic systems harder to
@@ -185,7 +188,7 @@
           </section>
 
           <section>
-            <h2>Capability versus agent</h2>
+            <h2 id="capability-versus-agent">Capability versus agent</h2>
             <p>
               This is another useful distinction. An agent can help interpret the goal and propose which capabilities might fit. But the
               capability is still the unit of work the runtime validates and selects. Agents help with reasoning. Capabilities are the
@@ -199,7 +202,7 @@
           </section>
 
           <section>
-            <h2>Why this matters for runtime authority</h2>
+            <h2 id="why-this-matters-for-runtime-authority">Why this matters for runtime authority</h2>
             <p>
               The runtime cannot remain authoritative if the units of work are fuzzy. It can only approve or reject what is visible enough
               to inspect. Capabilities give the runtime something concrete to reason about: what behavior is being requested, what contract
@@ -212,7 +215,7 @@
           </section>
 
           <section>
-            <h2>A concrete proof point</h2>
+            <h2 id="a-concrete-proof-point">A concrete proof point</h2>
             <p>
               The easiest proof is to watch one workflow in the reference app. You can see which capabilities are available, which one is
               proposed or selected, and where the runtime keeps authority over the final path. That is much clearer than treating
@@ -221,7 +224,7 @@
           </section>
 
           <section>
-            <h2>What a capability is not</h2>
+            <h2 id="what-a-capability-is-not">What a capability is not</h2>
             <ul>
               <li>It is not every function or class in the codebase.</li>
               <li>It is not the same thing as a deployable service boundary.</li>
@@ -232,7 +235,7 @@
           </section>
 
           <section>
-            <h2>A practical design test</h2>
+            <h2 id="a-practical-design-test">A practical design test</h2>
             <p>
               If you are unsure whether something in your system is a capability, ask two questions. First: can the runtime understand
               what this unit does and when it is valid? Second: can it be selected or rejected as part of a larger workflow without reading
@@ -246,7 +249,7 @@
           </section>
 
           <section>
-            <h2>Why capabilities make the architecture easier to learn</h2>
+            <h2 id="why-capabilities-make-the-architecture-easier-to-learn">Why capabilities make the architecture easier to learn</h2>
             <p>
               Capabilities give the reader a stable mental unit. Instead of thinking in terms of full applications, hidden helpers, or
               stack-specific modules, the reader can ask simpler questions: what capabilities exist, what goal is being satisfied, which
@@ -260,18 +263,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is a capability the same as a microservice?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-a-capability-the-same-as-a-microservice">Is a capability the same as a microservice?</h3>
             <p>
               Not necessarily. A microservice is often described as a deployable unit. A capability is the unit the runtime can discover,
               validate, and compose. Sometimes those ideas overlap. Often they do not.
             </p>
-            <h3>Can one service expose more than one capability?</h3>
+            <h3 id="can-one-service-expose-more-than-one-capability">Can one service expose more than one capability?</h3>
             <p>
               Yes. One service boundary can expose multiple meaningful capabilities, especially if the runtime needs to distinguish between
               different kinds of behavior that should be validated or composed separately.
             </p>
-            <h3>Do capabilities only matter in dynamic or AI-driven systems?</h3>
+            <h3 id="do-capabilities-only-matter-in-dynamic-or-ai-driven-systems">Do capabilities only matter in dynamic or AI-driven systems?</h3>
             <p>
               No. They matter even in simpler systems because they make the service behavior more visible. Dynamic planning just makes the
               need for them more obvious.
@@ -301,7 +304,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-is-a-uma-runtime/index.html
+++ b/book-site/what-is-a-uma-runtime/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Is a UMA Runtime? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what the UMA runtime is, what it owns, and why runtime authority matters in Universal Microservices Architecture."
-    />
+    <meta name="description" content="Learn what the UMA runtime is, what it owns, and why runtime authority matters in Universal Microservices Architecture." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-is-a-uma-runtime/" />
-    <meta property="og:title" content="What Is a UMA Runtime? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original explanation of the UMA runtime: the governed layer that discovers capabilities, validates execution, and keeps the system authoritative."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Is a UMA Runtime?" />
+    <meta property="og:description" content="Learn what the UMA runtime is, what it owns, and why runtime authority matters in Universal Microservices Architecture." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-is-a-uma-runtime/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Is a UMA Runtime?",
-  "description": "An original guide to the UMA runtime and why it must remain the governed authority around capability discovery, validation, selection, and execution.",
-  "url": "https://www.universalmicroservices.com/what-is-a-uma-runtime/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-is-a-uma-runtime/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Is a UMA Runtime?","item":"https://www.universalmicroservices.com/what-is-a-uma-runtime/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Is a UMA Runtime?","description":"Learn what the UMA runtime is, what it owns, and why runtime authority matters in Universal Microservices Architecture.","url":"https://www.universalmicroservices.com/what-is-a-uma-runtime/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-the-runtime-is-not-just-infrastructure">Why the runtime is not just infrastructure</a></li><li><a href="#what-the-runtime-owns">What the runtime owns</a>
+    <ul class="page-rail-links">
+      <li><a href="#discovery">Discovery</a></li><li><a href="#validation">Validation</a></li><li><a href="#selection">Selection</a></li><li><a href="#evidence">Evidence</a></li>
+    </ul></li><li><a href="#capability-and-runtime-belong-together">Capability and runtime belong together</a></li><li><a href="#why-this-matters-once-agents-appear">Why this matters once agents appear</a></li><li><a href="#what-a-uma-runtime-is-not">What a UMA runtime is not</a></li><li><a href="#a-practical-design-test">A practical design test</a></li><li><a href="#why-the-runtime-improves-learning-not-just-execution">Why the runtime improves learning, not just execution</a></li><li><a href="#a-concrete-proof-point">A concrete proof point</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-the-runtime-the-same-thing-as-the-host-platform">Is the runtime the same thing as the host platform?</a></li><li><a href="#can-a-uma-runtime-exist-without-ai">Can a UMA runtime exist without AI?</a></li><li><a href="#why-not-let-the-workflow-decide-itself">Why not let the workflow decide itself?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Is a UMA Runtime?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What is a UMA runtime?</h1>
           <p>
             The UMA runtime is the governed layer around portable behavior. It is the part of the system that discovers capabilities,
@@ -98,9 +101,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               In Universal Microservices Architecture, the runtime is not just a host process. It is the architectural authority that turns
               portable behavior into governed execution. It knows which capabilities exist, which ones match the active goal, which ones
@@ -117,7 +120,7 @@
           </section>
 
           <section>
-            <h2>Why the runtime is not just infrastructure</h2>
+            <h2 id="why-the-runtime-is-not-just-infrastructure">Why the runtime is not just infrastructure</h2>
             <p>
               Many systems treat the runtime as invisible plumbing. It launches code, moves data, and stays mostly out of the
               architectural conversation. UMA uses the term differently. The runtime is where the architecture keeps its authority once the
@@ -131,7 +134,7 @@
           </section>
 
           <section>
-            <h2>What the runtime owns</h2>
+            <h2 id="what-the-runtime-owns">What the runtime owns</h2>
             <p>
               The runtime owns the questions that should stay visible around the portable core: what is available, what matches the active
               goal, what contracts are compatible, what policy applies, what trust boundary is in effect, and what final path is approved.
@@ -151,25 +154,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Discovery</h3>
+              <h3 id="discovery">Discovery</h3>
               <p>The runtime can see which capabilities exist and which of them are even candidates for the current goal.</p>
             </article>
             <article class="subpage-card">
-              <h3>Validation</h3>
+              <h3 id="validation">Validation</h3>
               <p>The runtime checks compatibility, constraints, policies, and trust rules before execution is approved.</p>
             </article>
             <article class="subpage-card">
-              <h3>Selection</h3>
+              <h3 id="selection">Selection</h3>
               <p>The runtime decides which valid capability or workflow path will actually run, even when planning is dynamic.</p>
             </article>
             <article class="subpage-card">
-              <h3>Evidence</h3>
+              <h3 id="evidence">Evidence</h3>
               <p>The runtime preserves enough state and explanation for a person or tool to understand what happened afterward.</p>
             </article>
           </section>
 
           <section>
-            <h2>Capability and runtime belong together</h2>
+            <h2 id="capability-and-runtime-belong-together">Capability and runtime belong together</h2>
             <p>
               Capabilities are the units the runtime reasons about. Without capabilities, the runtime has nothing precise to discover or
               validate. Without the runtime, capabilities remain descriptive rather than governed. That is why these two concepts work as a
@@ -183,7 +186,7 @@
           </section>
 
           <section>
-            <h2>Why this matters once agents appear</h2>
+            <h2 id="why-this-matters-once-agents-appear">Why this matters once agents appear</h2>
             <p>
               Agents make the need for a strong runtime easier to see. If an agent can interpret goals and propose a path, something still
               has to decide whether that path should be trusted. In UMA, that answer is the runtime. The agent can help reason. The runtime
@@ -196,7 +199,7 @@
           </section>
 
           <section>
-            <h2>What a UMA runtime is not</h2>
+            <h2 id="what-a-uma-runtime-is-not">What a UMA runtime is not</h2>
             <ul>
               <li>It is not just a process launcher.</li>
               <li>It is not a synonym for one host, one server, or one deployment environment.</li>
@@ -207,7 +210,7 @@
           </section>
 
           <section>
-            <h2>A practical design test</h2>
+            <h2 id="a-practical-design-test">A practical design test</h2>
             <p>
               If you want to know whether your system has a real runtime story, ask a simple question: when two capabilities could satisfy
               the same goal, who decides which one is allowed to run? If the answer is “whichever one the code happened to call” or “the
@@ -220,7 +223,7 @@
           </section>
 
           <section>
-            <h2>Why the runtime improves learning, not just execution</h2>
+            <h2 id="why-the-runtime-improves-learning-not-just-execution">Why the runtime improves learning, not just execution</h2>
             <p>
               The runtime also makes UMA easier to teach because it turns vague system behavior into visible steps. Readers can ask what
               the runtime discovered, why it rejected one path, why it approved another, and what evidence it produced. That is much
@@ -237,7 +240,7 @@
           </section>
 
           <section>
-            <h2>A concrete proof point</h2>
+            <h2 id="a-concrete-proof-point">A concrete proof point</h2>
             <p>
               The simplest proof is not theoretical. Open the reference app and watch one workflow execute. The planner can propose, the
               runtime can reject or approve, the capability path stays visible, and the result is explained afterward. That is much closer
@@ -246,18 +249,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is the runtime the same thing as the host platform?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-the-runtime-the-same-thing-as-the-host-platform">Is the runtime the same thing as the host platform?</h3>
             <p>
               No. The host platform matters, but the UMA runtime is the governed layer that sits around portable behavior and owns the
               architectural decisions required for valid execution.
             </p>
-            <h3>Can a UMA runtime exist without AI?</h3>
+            <h3 id="can-a-uma-runtime-exist-without-ai">Can a UMA runtime exist without AI?</h3>
             <p>
               Yes. UMA does not require AI to make the runtime meaningful. The runtime still matters in deterministic systems because it
               owns discovery, validation, policy, and execution authority.
             </p>
-            <h3>Why not let the workflow decide itself?</h3>
+            <h3 id="why-not-let-the-workflow-decide-itself">Why not let the workflow decide itself?</h3>
             <p>
               Because workflows do not govern themselves. A system still needs a layer that can validate compatibility, enforce rules, and
               explain why the approved path was valid in the current context.
@@ -287,7 +290,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-is-a-universal-microservice/index.html
+++ b/book-site/what-is-a-universal-microservice/index.html
@@ -6,16 +6,20 @@
     <title>What Is a Universal Microservice? | Universal Microservices Architecture</title>
     <meta name="description" content="Define a Universal Microservice, what makes it portable, how its lifecycle works, and how it differs from a traditional service." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-is-a-universal-microservice/" />
-    <meta property="og:title" content="What Is a Universal Microservice? | Universal Microservices Architecture" />
-    <meta property="og:description" content="A clear definition of a Universal Microservice and the portable service boundary at the center of UMA." />
+    <meta property="og:title" content="What Is a Universal Microservice?" />
+    <meta property="og:description" content="Define a Universal Microservice, what makes it portable, how its lifecycle works, and how it differs from a traditional service." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-is-a-universal-microservice/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What is a Universal Microservice?","description":"Define a Universal Microservice, what makes it portable, how its lifecycle works, and how it differs from a traditional service.","url":"https://www.universalmicroservices.com/what-is-a-universal-microservice/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/what-is-a-universal-microservice/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Is a Universal Microservice?","item":"https://www.universalmicroservices.com/what-is-a-universal-microservice/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Is a Universal Microservice?","description":"Define a Universal Microservice, what makes it portable, how its lifecycle works, and how it differs from a traditional service.","url":"https://www.universalmicroservices.com/what-is-a-universal-microservice/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -26,53 +30,103 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-definition">The short definition</a></li><li><a href="#properties-that-define-it">Properties that define it</a></li><li><a href="#how-it-differs-from-a-traditional-service">How it differs from a traditional service</a></li><li><a href="#what-makes-it-portable">What makes it portable</a></li><li><a href="#lifecycle-of-a-universal-microservice">Lifecycle of a Universal Microservice</a>
+    <ul class="page-rail-links">
+      <li><a href="#capability">Capability</a></li><li><a href="#contract">Contract</a></li><li><a href="#portable-core">Portable core</a></li><li><a href="#runtime-governance">Runtime governance</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Is a Universal Microservice?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What is a Universal Microservice?</h1>
           <p>A Universal Microservice is a small unit of business behavior that can remain recognizable across runtime contexts. It is not just a service that has been packaged differently. It is a capability with an explicit contract, portable core logic, and a runtime boundary that makes validation, placement, trust, and execution visible.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>The short definition</h2>
+            <h2 id="the-short-definition">The short definition</h2>
             <p>A Universal Microservice is the primary object in UMA. It owns a specific behavior, exposes a clear contract, and can be executed through more than one runtime path without changing what the behavior means.</p>
             <p>The portable summary is write once, run where it makes sense. That matters because the runtime may change while the service meaning should not.</p>
           </section>
 
           <section>
-            <h2>Properties that define it</h2>
+            <h2 id="properties-that-define-it">Properties that define it</h2>
             <p>A Universal Microservice has a narrow responsibility, deterministic inputs and outputs where possible, explicit capability expectations, and a boundary that does not depend on one host framework. It can be wrapped by different adapters, but the adapters do not become the service.</p>
             <p>The core question is simple: can the behavior be understood, tested, and governed without assuming one permanent deployment surface?</p>
           </section>
 
           <section>
-            <h2>How it differs from a traditional service</h2>
+            <h2 id="how-it-differs-from-a-traditional-service">How it differs from a traditional service</h2>
             <p>A traditional microservice is usually defined by deployment, ownership, and network boundaries. A Universal Microservice is defined first by portable behavior and then by the runtime decisions that surround it.</p>
             <p>This does not make conventional services obsolete. It makes the durable behavioral unit more explicit when the same capability needs to appear in browser, edge, cloud, workflow, or AI-assisted execution paths.</p>
           </section>
 
           <section>
-            <h2>What makes it portable</h2>
+            <h2 id="what-makes-it-portable">What makes it portable</h2>
             <p>Portability comes from separating core behavior from host concerns. Contracts describe what the service accepts and returns. The runtime handles validation, transport, policy, and placement. That separation lets the same behavior move without dragging a whole application stack behind it.</p>
             <p>WebAssembly can provide a strong execution boundary, but UMA is the architectural model that keeps the boundary meaningful.</p>
           </section>
 
           <section>
-            <h2>Lifecycle of a Universal Microservice</h2>
+            <h2 id="lifecycle-of-a-universal-microservice">Lifecycle of a Universal Microservice</h2>
             <p>The lifecycle begins with a capability, then a contract, then a portable implementation, then runtime exposure, validation, observation, and versioned evolution. The service is not complete just because it compiles. It is complete when the runtime can govern how and where it is used.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Capability</h3><p>The service exists because the system needs one specific behavior to remain coherent.</p></article>
-            <article class="subpage-card"><h3>Contract</h3><p>Inputs, outputs, events, and expectations are explicit enough for humans and tools to inspect.</p></article>
-            <article class="subpage-card"><h3>Portable core</h3><p>The behavior is not hidden inside framework glue or a single host process.</p></article>
-            <article class="subpage-card"><h3>Runtime governance</h3><p>Placement, policy, trust, and validation stay visible as the service moves.</p></article>
+            <article class="subpage-card"><h3 id="capability">Capability</h3><p>The service exists because the system needs one specific behavior to remain coherent.</p></article>
+            <article class="subpage-card"><h3 id="contract">Contract</h3><p>Inputs, outputs, events, and expectations are explicit enough for humans and tools to inspect.</p></article>
+            <article class="subpage-card"><h3 id="portable-core">Portable core</h3><p>The behavior is not hidden inside framework glue or a single host process.</p></article>
+            <article class="subpage-card"><h3 id="runtime-governance">Runtime governance</h3><p>Placement, policy, trust, and validation stay visible as the service moves.</p></article>
           </section>
           <section class="subpage-callout">
             <strong>Want to go deeper?</strong>

--- a/book-site/what-is-a-workflow/index.html
+++ b/book-site/what-is-a-workflow/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Is a Workflow in UMA? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what a workflow means in Universal Microservices Architecture and how workflows differ from capabilities, agents, and the runtime."
-    />
+    <meta name="description" content="Learn what a workflow means in Universal Microservices Architecture and how workflows differ from capabilities, agents, and the runtime." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-is-a-workflow/" />
-    <meta property="og:title" content="What Is a Workflow in UMA? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to workflows in UMA: runtime-approved compositions of capabilities built to satisfy a goal."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Is a Workflow in UMA?" />
+    <meta property="og:description" content="Learn what a workflow means in Universal Microservices Architecture and how workflows differ from capabilities, agents, and the runtime." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-is-a-workflow/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Is a Workflow in UMA?",
-  "description": "An original explanation of what a workflow means in Universal Microservices Architecture and why workflows should remain visible, approved compositions of capabilities rather than hidden chains of calls.",
-  "url": "https://www.universalmicroservices.com/what-is-a-workflow/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-is-a-workflow/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Is a Workflow in UMA?","item":"https://www.universalmicroservices.com/what-is-a-workflow/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Is a Workflow in UMA?","description":"Learn what a workflow means in Universal Microservices Architecture and how workflows differ from capabilities, agents, and the runtime.","url":"https://www.universalmicroservices.com/what-is-a-workflow/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#workflow-versus-capability">Workflow versus capability</a></li><li><a href="#workflow-versus-agent">Workflow versus agent</a>
+    <ul class="page-rail-links">
+      <li><a href="#goal-oriented">Goal-oriented</a></li><li><a href="#capability-based">Capability-based</a></li><li><a href="#runtime-approved">Runtime-approved</a></li><li><a href="#explainable">Explainable</a></li>
+    </ul></li><li><a href="#why-workflows-matter-more-in-modern-systems">Why workflows matter more in modern systems</a></li><li><a href="#why-the-runtime-owns-the-workflow-outcome">Why the runtime owns the workflow outcome</a></li><li><a href="#what-a-workflow-is-not">What a workflow is not</a></li><li><a href="#a-practical-design-test">A practical design test</a></li><li><a href="#how-the-reference-app-makes-workflows-useful">How the reference app makes workflows useful</a></li><li><a href="#a-concrete-proof-point">A concrete proof point</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#does-every-uma-system-need-dynamic-workflows">Does every UMA system need dynamic workflows?</a></li><li><a href="#can-one-goal-map-to-more-than-one-valid-workflow">Can one goal map to more than one valid workflow?</a></li><li><a href="#why-not-just-call-it-orchestration">Why not just call it orchestration?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Is a Workflow in UMA?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What is a workflow in UMA?</h1>
           <p>
             In Universal Microservices Architecture, a workflow is the approved path the runtime builds from capabilities to satisfy a
@@ -97,9 +100,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               A workflow in UMA is the composition the runtime approves after considering the goal, the available capabilities, the active
               constraints, and any planning help from agents. That makes a workflow more than an implementation detail. It becomes an
@@ -117,7 +120,7 @@
           </section>
 
           <section>
-            <h2>Workflow versus capability</h2>
+            <h2 id="workflow-versus-capability">Workflow versus capability</h2>
             <p>
               A capability is one unit of behavior. A workflow is a composition of capabilities used to reach an outcome. Confusing those
               two ideas makes systems harder to reason about because the reusable units and the approved path stop being distinct.
@@ -129,7 +132,7 @@
           </section>
 
           <section>
-            <h2>Workflow versus agent</h2>
+            <h2 id="workflow-versus-agent">Workflow versus agent</h2>
             <p>
               An agent can help propose a workflow. It can interpret the goal, rank possible capabilities, and suggest a plausible route.
               But the workflow itself does not become authoritative just because it was proposed. The runtime still has to approve it.
@@ -142,25 +145,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Goal-oriented</h3>
+              <h3 id="goal-oriented">Goal-oriented</h3>
               <p>A workflow exists to satisfy a goal, not just to reflect implementation structure.</p>
             </article>
             <article class="subpage-card">
-              <h3>Capability-based</h3>
+              <h3 id="capability-based">Capability-based</h3>
               <p>A workflow is built from capabilities that the runtime can inspect and govern.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime-approved</h3>
+              <h3 id="runtime-approved">Runtime-approved</h3>
               <p>The path becomes real only when the runtime validates it against the current rules and conditions.</p>
             </article>
             <article class="subpage-card">
-              <h3>Explainable</h3>
+              <h3 id="explainable">Explainable</h3>
               <p>A useful workflow is one the system can describe after execution, not just one that happened to succeed.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why workflows matter more in modern systems</h2>
+            <h2 id="why-workflows-matter-more-in-modern-systems">Why workflows matter more in modern systems</h2>
             <p>
               The more dynamic a system becomes, the more important workflows become as a visible concept. Once there are multiple possible
               paths to the same outcome, the architecture has to explain not only what capabilities exist, but how they were assembled into
@@ -174,7 +177,7 @@
           </section>
 
           <section>
-            <h2>Why the runtime owns the workflow outcome</h2>
+            <h2 id="why-the-runtime-owns-the-workflow-outcome">Why the runtime owns the workflow outcome</h2>
             <p>
               A workflow is where many architectural concerns meet: compatibility, trust, policy, ordering, and execution authority. Those
               are not concerns a capability should own alone, and they are not concerns an agent should own by itself either. The runtime
@@ -191,7 +194,7 @@
           </section>
 
           <section>
-            <h2>What a workflow is not</h2>
+            <h2 id="what-a-workflow-is-not">What a workflow is not</h2>
             <ul>
               <li>It is not every internal call chain in the codebase.</li>
               <li>It is not the same thing as a static pipeline definition.</li>
@@ -202,7 +205,7 @@
           </section>
 
           <section>
-            <h2>A practical design test</h2>
+            <h2 id="a-practical-design-test">A practical design test</h2>
             <p>
               If you want to know whether your system has a real workflow model, ask whether it can answer four simple questions after
               execution: what was the goal, which capabilities were available, which path was approved, and why that path was valid. If the
@@ -215,7 +218,7 @@
           </section>
 
           <section>
-            <h2>How the reference app makes workflows useful</h2>
+            <h2 id="how-the-reference-app-makes-workflows-useful">How the reference app makes workflows useful</h2>
             <p>
               The live reference app works because it treats the workflow as a first-class explanation layer. It does not just show the
               result. It shows the path from discovery to planning to runtime approval to capability execution. That helps readers grasp
@@ -228,7 +231,7 @@
           </section>
 
           <section>
-            <h2>A concrete proof point</h2>
+            <h2 id="a-concrete-proof-point">A concrete proof point</h2>
             <p>
               The reference app is useful because it shows one workflow as graph, narrative, and runtime state at the same time. That lets
               you see the difference between a possible path and an approved path instead of guessing what the orchestration layer did.
@@ -236,18 +239,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Does every UMA system need dynamic workflows?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="does-every-uma-system-need-dynamic-workflows">Does every UMA system need dynamic workflows?</h3>
             <p>
               No. A workflow can still be explicit and valuable in a more deterministic system. Dynamic selection simply makes the need for
               visible workflows more obvious.
             </p>
-            <h3>Can one goal map to more than one valid workflow?</h3>
+            <h3 id="can-one-goal-map-to-more-than-one-valid-workflow">Can one goal map to more than one valid workflow?</h3>
             <p>
               Yes. That is one of the reasons the runtime matters. It may need to choose between multiple valid paths depending on policy,
               constraints, trust, or current environment conditions.
             </p>
-            <h3>Why not just call it orchestration?</h3>
+            <h3 id="why-not-just-call-it-orchestration">Why not just call it orchestration?</h3>
             <p>
               Orchestration is part of the story, but workflow is the clearer reader-facing term for the approved path through capabilities
               that satisfies a goal.
@@ -275,7 +278,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-is-uma/index.html
+++ b/book-site/what-is-uma/index.html
@@ -4,37 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Is UMA? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what Universal Microservices Architecture is, why it matters, and how it keeps business behavior portable across client, edge, and cloud runtimes."
-    />
+    <meta name="description" content="Learn what Universal Microservices Architecture is, why it matters, and how it keeps business behavior portable across client, edge, and cloud runtimes." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-is-uma/" />
-    <meta property="og:title" content="What Is UMA? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original introduction to Universal Microservices Architecture, focused on portable business behavior, runtime clarity, and long-term system coherence."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Is UMA?" />
+    <meta property="og:description" content="Learn what Universal Microservices Architecture is, why it matters, and how it keeps business behavior portable across client, edge, and cloud runtimes." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-is-uma/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Is UMA?","item":"https://www.universalmicroservices.com/what-is-uma/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Is UMA?","description":"Learn what Universal Microservices Architecture is, why it matters, and how it keeps business behavior portable across client, edge, and cloud runtimes.","url":"https://www.universalmicroservices.com/what-is-uma/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -42,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-problem-uma-is-trying-to-solve">The problem UMA is trying to solve</a></li><li><a href="#a-practical-definition-of-uma">A practical definition of UMA</a>
+    <ul class="page-rail-links">
+      <li><a href="#portable-service-behavior">Portable service behavior</a></li><li><a href="#explicit-contracts">Explicit contracts</a></li><li><a href="#governed-runtime-decisions">Governed runtime decisions</a></li><li><a href="#long-term-coherence">Long-term coherence</a></li>
+    </ul></li><li><a href="#how-uma-differs-from-conventional-boundaries">How UMA differs from conventional boundaries</a></li><li><a href="#why-this-matters-in-real-systems">Why this matters in real systems</a></li><li><a href="#what-uma-is-not">What UMA is not</a></li><li><a href="#who-should-care-about-this-model">Who should care about this model</a></li><li><a href="#frequently-asked-question">Frequently asked question</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-uma-only-relevant-if-i-use-webassembly">Is UMA only relevant if I use WebAssembly?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-          <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Is UMA?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
             <h1>What is Universal Microservices Architecture?</h1>
             <p>
               Universal Microservices Architecture, or UMA, is an execution model for distributed systems where compute can happen in many
@@ -79,9 +100,9 @@
             </p>
           </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The problem UMA is trying to solve</h2>
+            <h2 id="the-problem-uma-is-trying-to-solve">The problem UMA is trying to solve</h2>
             <p>
               Most software teams do not struggle because they cannot build services. They struggle because the same behavior keeps being
               reimplemented in different places. A decision appears once in the browser, once in the backend, once in an edge worker, and
@@ -105,7 +126,7 @@
           </section>
 
           <section>
-            <h2>A practical definition of UMA</h2>
+            <h2 id="a-practical-definition-of-uma">A practical definition of UMA</h2>
             <p>
               UMA is a design model for software that must survive across many execution environments without losing its architectural
               clarity. It treats the portable service boundary as the durable unit of the system, while treating validation, transport,
@@ -120,25 +141,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Portable service behavior</h3>
+              <h3 id="portable-service-behavior">Portable service behavior</h3>
               <p>Rules, decisions, and business intent should survive across runtimes without being rewritten every time execution moves.</p>
             </article>
             <article class="subpage-card">
-              <h3>Explicit contracts</h3>
+              <h3 id="explicit-contracts">Explicit contracts</h3>
               <p>Inputs, outputs, events, and capability expectations should be machine-readable instead of hidden in framework glue code.</p>
             </article>
             <article class="subpage-card">
-              <h3>Governed runtime decisions</h3>
+              <h3 id="governed-runtime-decisions">Governed runtime decisions</h3>
               <p>Placement, policy, trust, and orchestration are still important, but they become visible parts of the model.</p>
             </article>
             <article class="subpage-card">
-              <h3>Long-term coherence</h3>
+              <h3 id="long-term-coherence">Long-term coherence</h3>
               <p>Versioning, change, compatibility, and system growth remain architectural topics instead of operational cleanup work.</p>
             </article>
           </section>
 
           <section>
-            <h2>How UMA differs from conventional boundaries</h2>
+            <h2 id="how-uma-differs-from-conventional-boundaries">How UMA differs from conventional boundaries</h2>
             <p>
               Traditional architectural labels mostly describe where code runs or which team owns it. UMA is more interested in whether the
               behavior itself can remain stable while the runtime context changes. That is why the model aligns naturally with WebAssembly:
@@ -153,7 +174,7 @@
           </section>
 
           <section>
-            <h2>Why this matters in real systems</h2>
+            <h2 id="why-this-matters-in-real-systems">Why this matters in real systems</h2>
             <p>
               Organizations rarely plan to duplicate important business behavior. It happens because teams are rewarded for shipping inside
               local boundaries. The browser team adds a rule for responsiveness. The backend team repeats it for safety. The edge layer
@@ -167,7 +188,7 @@
           </section>
 
           <section>
-            <h2>What UMA is not</h2>
+            <h2 id="what-uma-is-not">What UMA is not</h2>
             <ul>
               <li>It is not a promise that every service should run everywhere.</li>
               <li>It is not a claim that runtimes stop mattering once logic is portable.</li>
@@ -177,7 +198,7 @@
           </section>
 
           <section>
-            <h2>Who should care about this model</h2>
+            <h2 id="who-should-care-about-this-model">Who should care about this model</h2>
             <p>
               UMA is useful for architects, platform engineers, senior developers, and technical leads who need a more stable way to think
               about software that crosses runtime boundaries. It is especially useful when systems must preserve behavior across product
@@ -186,8 +207,8 @@
           </section>
 
           <section>
-            <h2>Frequently asked question</h2>
-            <h3>Is UMA only relevant if I use WebAssembly?</h3>
+            <h2 id="frequently-asked-question">Frequently asked question</h2>
+            <h3 id="is-uma-only-relevant-if-i-use-webassembly">Is UMA only relevant if I use WebAssembly?</h3>
             <p>
               No. WebAssembly is a strong fit because it provides a practical execution boundary for portable behavior, but the architectural
               model is larger than the compilation target. UMA is fundamentally about keeping service meaning stable and runtime decisions
@@ -218,7 +239,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-is-wasm-mcp/index.html
+++ b/book-site/what-is-wasm-mcp/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Is WASM MCP in UMA? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what WASM MCP means in Universal Microservices Architecture and why it matters as a discoverable capability surface instead of a hidden integration layer."
-    />
+    <meta name="description" content="Learn what WASM MCP means in Universal Microservices Architecture and why it matters as a discoverable capability surface instead of a hidden integration layer." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-is-wasm-mcp/" />
-    <meta property="og:title" content="What Is WASM MCP in UMA? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to WASM MCP in UMA: a practical discovery and invocation surface for capabilities that the runtime can inspect and govern."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Is WASM MCP in UMA?" />
+    <meta property="og:description" content="Learn what WASM MCP means in Universal Microservices Architecture and why it matters as a discoverable capability surface instead of a hidden integration layer." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-is-wasm-mcp/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Is WASM MCP in UMA?",
-  "description": "An original explanation of WASM MCP in Universal Microservices Architecture and why it matters as a discoverable capability surface the runtime can govern.",
-  "url": "https://www.universalmicroservices.com/what-is-wasm-mcp/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-is-wasm-mcp/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Is WASM MCP in UMA?","item":"https://www.universalmicroservices.com/what-is-wasm-mcp/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Is WASM MCP in UMA?","description":"Learn what WASM MCP means in Universal Microservices Architecture and why it matters as a discoverable capability surface instead of a hidden integration layer.","url":"https://www.universalmicroservices.com/what-is-wasm-mcp/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-this-layer-exists">Why this layer exists</a></li><li><a href="#why-it-is-not-just-another-protocol-page">Why it is not just another protocol page</a>
+    <ul class="page-rail-links">
+      <li><a href="#discovery-surface">Discovery surface</a></li><li><a href="#invocation-bridge">Invocation bridge</a></li><li><a href="#runtime-support">Runtime support</a></li><li><a href="#architectural-evidence">Architectural evidence</a></li>
+    </ul></li><li><a href="#how-it-fits-with-capability-planner-and-runtime">How it fits with capability, planner, and runtime</a></li><li><a href="#what-problem-it-solves-in-practice">What problem it solves in practice</a></li><li><a href="#a-concrete-proof-point">A concrete proof point</a></li><li><a href="#why-this-matters-for-seo-and-reader-understanding-too">Why this matters for SEO and reader understanding too</a></li><li><a href="#what-wasm-mcp-is-not">What WASM MCP is not</a></li><li><a href="#a-practical-design-test">A practical design test</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-wasm-mcp-required-for-uma">Is WASM MCP required for UMA?</a></li><li><a href="#why-not-let-the-runtime-keep-an-internal-registry-instead">Why not let the runtime keep an internal registry instead?</a></li><li><a href="#does-wasm-mcp-replace-runtime-authority">Does WASM MCP replace runtime authority?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Is WASM MCP in UMA?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What is WASM MCP in UMA?</h1>
           <p>
             In the UMA reference experience, <strong>WASM MCP</strong> is the discovery and invocation surface through which the runtime
@@ -98,9 +101,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               WASM MCP is the capability-facing control surface in the Chapter 13 model. It exposes what capabilities exist, how they can
               be described, and how the runtime can interact with them. That makes it easier for the runtime to discover, validate, and
@@ -117,7 +120,7 @@
           </section>
 
           <section>
-            <h2>Why this layer exists</h2>
+            <h2 id="why-this-layer-exists">Why this layer exists</h2>
             <p>
               A runtime cannot compose workflows from capabilities it cannot see. In simpler systems, those capabilities are often hidden
               behind internal calls, framework-specific bindings, or undocumented operational knowledge. That may work for a static path,
@@ -130,7 +133,7 @@
           </section>
 
           <section>
-            <h2>Why it is not just another protocol page</h2>
+            <h2 id="why-it-is-not-just-another-protocol-page">Why it is not just another protocol page</h2>
             <p>
               This page is not trying to turn UMA into a protocol discussion. The key idea is not that one acronym is fashionable. The key
               idea is that runtime discovery needs a real interface. If a system claims to compose work from capabilities dynamically, it
@@ -144,25 +147,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Discovery surface</h3>
+              <h3 id="discovery-surface">Discovery surface</h3>
               <p>WASM MCP exposes capabilities so the runtime can inspect what exists before trying to build a workflow.</p>
             </article>
             <article class="subpage-card">
-              <h3>Invocation bridge</h3>
+              <h3 id="invocation-bridge">Invocation bridge</h3>
               <p>It supports calling into capability providers through a visible, structured boundary instead of hidden glue code.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime support</h3>
+              <h3 id="runtime-support">Runtime support</h3>
               <p>The runtime can pair capability discovery with compatibility checks, policy evaluation, and final approval.</p>
             </article>
             <article class="subpage-card">
-              <h3>Architectural evidence</h3>
+              <h3 id="architectural-evidence">Architectural evidence</h3>
               <p>Readers can see where capability availability comes from instead of assuming the workflow path was magically known.</p>
             </article>
           </section>
 
           <section>
-            <h2>How it fits with capability, planner, and runtime</h2>
+            <h2 id="how-it-fits-with-capability-planner-and-runtime">How it fits with capability, planner, and runtime</h2>
             <p>
               The capability is the unit of behavior. The planner can help interpret the goal and rank possible paths. The runtime remains
               authoritative over what is approved. WASM MCP sits earlier in that chain: it is the surface that makes available capabilities
@@ -175,7 +178,7 @@
           </section>
 
           <section>
-            <h2>What problem it solves in practice</h2>
+            <h2 id="what-problem-it-solves-in-practice">What problem it solves in practice</h2>
             <p>
               Without a discovery surface like this, teams often end up with dynamic behavior that is only dynamic inside implementation
               code. The runtime “knows” about capabilities because somebody programmed a list, a registry, or a service map in one local
@@ -188,7 +191,7 @@
           </section>
 
           <section>
-            <h2>A concrete proof point</h2>
+            <h2 id="a-concrete-proof-point">A concrete proof point</h2>
             <p>
               In the reference app, the `WASM MCP` node matters because it shows where discovery begins. The runtime does not simply know
               what to call. It sees available capabilities through an explicit surface, and that makes the rest of the workflow easier to
@@ -197,7 +200,7 @@
           </section>
 
           <section>
-            <h2>Why this matters for SEO and reader understanding too</h2>
+            <h2 id="why-this-matters-for-seo-and-reader-understanding-too">Why this matters for SEO and reader understanding too</h2>
             <p>
               Readers who see `WASM MCP` in the live app or Chapter 13 CLI output will naturally ask what it means. If the site does not
               answer that, the reference experience feels more advanced than it really is. This page exists to close that gap: it explains
@@ -210,7 +213,7 @@
           </section>
 
           <section>
-            <h2>What WASM MCP is not</h2>
+            <h2 id="what-wasm-mcp-is-not">What WASM MCP is not</h2>
             <ul>
               <li>It is not the runtime itself.</li>
               <li>It is not the capability itself.</li>
@@ -221,7 +224,7 @@
           </section>
 
           <section>
-            <h2>A practical design test</h2>
+            <h2 id="a-practical-design-test">A practical design test</h2>
             <p>
               If your system claims to support runtime composition, ask where the runtime learns what capabilities exist. If that answer is
               hidden in internal code or tribal knowledge, the architecture still lacks a proper discovery story. A visible discovery
@@ -234,18 +237,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is WASM MCP required for UMA?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-wasm-mcp-required-for-uma">Is WASM MCP required for UMA?</h3>
             <p>
               No. UMA as an architectural model is larger than one discovery surface. But Chapter 13 uses WASM MCP because it is a strong
               way to make capability discovery and invocation visible in a runtime-centered workflow.
             </p>
-            <h3>Why not let the runtime keep an internal registry instead?</h3>
+            <h3 id="why-not-let-the-runtime-keep-an-internal-registry-instead">Why not let the runtime keep an internal registry instead?</h3>
             <p>
               It can, but an explicit discovery surface is easier to inspect, explain, and evolve. It keeps capability availability from
               becoming a hidden implementation detail.
             </p>
-            <h3>Does WASM MCP replace runtime authority?</h3>
+            <h3 id="does-wasm-mcp-replace-runtime-authority">Does WASM MCP replace runtime authority?</h3>
             <p>
               No. It helps expose what exists. The runtime still decides what is valid and what can actually run.
             </p>
@@ -272,7 +275,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-makes-a-decision-discoverable/index.html
+++ b/book-site/what-makes-a-decision-discoverable/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Makes a Decision Discoverable? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what makes a runtime decision discoverable in UMA: visible proposals, authoritative validation, bounded revision, approved execution, and traceable artifacts."
-    />
+    <meta name="description" content="Learn what makes a runtime decision discoverable in UMA: visible proposals, authoritative validation, bounded revision, approved execution, and traceable artifacts." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-makes-a-decision-discoverable/" />
-    <meta property="og:title" content="What Makes a Decision Discoverable? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to discoverable decisions in UMA, focused on proposal, validation, revision, approved execution, and queryable trace artifacts."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Makes a Decision Discoverable?" />
+    <meta property="og:description" content="Learn what makes a runtime decision discoverable in UMA: visible proposals, authoritative validation, bounded revision, approved execution, and traceable artifacts." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-makes-a-decision-discoverable/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Makes a Decision Discoverable?",
-  "description": "An original explanation of discoverable decisions in UMA, focused on visible proposals, authoritative validation, bounded revision, approved execution, and trace artifacts.",
-  "url": "https://www.universalmicroservices.com/what-makes-a-decision-discoverable/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-makes-a-decision-discoverable/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Makes a Decision Discoverable?","item":"https://www.universalmicroservices.com/what-makes-a-decision-discoverable/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Makes a Decision Discoverable?","description":"Learn what makes a runtime decision discoverable in UMA: visible proposals, authoritative validation, bounded revision, approved execution, and traceable artifacts.","url":"https://www.universalmicroservices.com/what-makes-a-decision-discoverable/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-execution-alone-is-not-enough">Why execution alone is not enough</a>
+    <ul class="page-rail-links">
+      <li><a href="#projection-is-useful-not-authoritative">Projection is useful, not authoritative</a></li><li><a href="#proposals-should-declare-assumptions">Proposals should declare assumptions</a></li><li><a href="#validation-should-return-guidance">Validation should return guidance</a></li><li><a href="#trace-completes-the-story">Trace completes the story</a></li>
+    </ul></li><li><a href="#what-discoverability-looks-like-in-practice">What discoverability looks like in practice</a></li><li><a href="#why-bounded-revision-matters">Why bounded revision matters</a></li><li><a href="#why-trace-artifacts-matter-more-than-logs">Why trace artifacts matter more than logs</a></li><li><a href="#what-makes-a-discoverable-decision-stronger-than-a-hidden-one">What makes a discoverable decision stronger than a hidden one</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-discoverability-the-same-as-observability">Is discoverability the same as observability?</a></li><li><a href="#does-every-uma-system-need-the-full-decision-ladder">Does every UMA system need the full decision ladder?</a></li><li><a href="#why-not-just-let-the-planner-decide-everything">Why not just let the planner decide everything?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Makes a Decision Discoverable?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What makes a decision discoverable?</h1>
           <p>
             A decision becomes discoverable when the system can expose how it reached an outcome instead of only reporting that the outcome
@@ -96,9 +99,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               A discoverable decision is one a person or tool can inspect before and after execution. The system should be able to show the
               proposal, the constraints it could not resolve locally, the authoritative validation response, the approved path, and the
@@ -111,7 +114,7 @@
           </section>
 
           <section>
-            <h2>Why execution alone is not enough</h2>
+            <h2 id="why-execution-alone-is-not-enough">Why execution alone is not enough</h2>
             <p>
               Many systems can execute correctly while keeping the actual decision path buried inside code, logs, or implicit behavior. A
               request succeeds, but no one can tell what alternatives were considered, what assumptions were made at the edge, which
@@ -126,25 +129,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Projection is useful, not authoritative</h3>
+              <h3 id="projection-is-useful-not-authoritative">Projection is useful, not authoritative</h3>
               <p>A local surface may expose likely capabilities and constraints, but it should not pretend it owns final approval.</p>
             </article>
             <article class="subpage-card">
-              <h3>Proposals should declare assumptions</h3>
+              <h3 id="proposals-should-declare-assumptions">Proposals should declare assumptions</h3>
               <p>The system becomes easier to reason about when unresolved constraints stay explicit instead of being hidden in optimistic planning.</p>
             </article>
             <article class="subpage-card">
-              <h3>Validation should return guidance</h3>
+              <h3 id="validation-should-return-guidance">Validation should return guidance</h3>
               <p>Authority is more useful when it explains why a proposal failed and what would make it valid.</p>
             </article>
             <article class="subpage-card">
-              <h3>Trace completes the story</h3>
+              <h3 id="trace-completes-the-story">Trace completes the story</h3>
               <p>A successful execution is not fully discoverable until the approved path can be replayed as evidence afterward.</p>
             </article>
           </section>
 
           <section>
-            <h2>What discoverability looks like in practice</h2>
+            <h2 id="what-discoverability-looks-like-in-practice">What discoverability looks like in practice</h2>
             <p>
               A discoverable system usually reveals a ladder of decision surfaces. First it exposes a capability projection or local view of
               the likely path. Then it emits a proposal that declares assumptions. Next, authority validates that proposal and returns
@@ -159,7 +162,7 @@
           </section>
 
           <section>
-            <h2>Why bounded revision matters</h2>
+            <h2 id="why-bounded-revision-matters">Why bounded revision matters</h2>
             <p>
               Many systems become hard to understand because validation and planning collapse into endless negotiation. Each side keeps
               revising the plan until execution finally happens, but no one can explain where the decisive authority really lived. UMA is
@@ -172,7 +175,7 @@
           </section>
 
           <section>
-            <h2>Why trace artifacts matter more than logs</h2>
+            <h2 id="why-trace-artifacts-matter-more-than-logs">Why trace artifacts matter more than logs</h2>
             <p>
               Logs are often chronological but not architectural. A trace artifact is stronger because it tells the decision story in terms
               the model itself understands: what was proposed, what was rejected, what was revised, what was approved, and what executed.
@@ -185,7 +188,7 @@
           </section>
 
           <section>
-            <h2>What makes a discoverable decision stronger than a hidden one</h2>
+            <h2 id="what-makes-a-discoverable-decision-stronger-than-a-hidden-one">What makes a discoverable decision stronger than a hidden one</h2>
             <ul>
               <li>The system can distinguish proposal from approval.</li>
               <li>Constraint failures are explicit enough to be acted on.</li>
@@ -196,18 +199,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is discoverability the same as observability?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-discoverability-the-same-as-observability">Is discoverability the same as observability?</h3>
             <p>
               No. Observability helps you inspect runtime behavior. Discoverability is narrower and more architectural. It is about whether
               the system exposes its decision path in a structured, queryable way.
             </p>
-            <h3>Does every UMA system need the full decision ladder?</h3>
+            <h3 id="does-every-uma-system-need-the-full-decision-ladder">Does every UMA system need the full decision ladder?</h3>
             <p>
               Not always. Smaller systems may not need explicit proposal and revision stages yet. The important part is that authority and
               execution still remain visible once decision complexity starts to grow.
             </p>
-            <h3>Why not just let the planner decide everything?</h3>
+            <h3 id="why-not-just-let-the-planner-decide-everything">Why not just let the planner decide everything?</h3>
             <p>
               Because proposal usefulness and execution authority are not the same architectural role. When they blur together, systems may
               look smart while becoming harder to govern.
@@ -234,7 +237,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-makes-a-service-portable/index.html
+++ b/book-site/what-makes-a-service-portable/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Makes a Service Portable? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what makes a service portable in UMA: deterministic behavior, explicit contracts, visible runtime boundaries, and stable output semantics."
-    />
+    <meta name="description" content="Learn what makes a service portable in UMA: deterministic behavior, explicit contracts, visible runtime boundaries, and stable output semantics." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-makes-a-service-portable/" />
-    <meta property="og:title" content="What Makes a Service Portable? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to portable services in UMA: what stays durable, what the runtime owns, and why deterministic behavior matters."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Makes a Service Portable?" />
+    <meta property="og:description" content="Learn what makes a service portable in UMA: deterministic behavior, explicit contracts, visible runtime boundaries, and stable output semantics." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-makes-a-service-portable/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Makes a Service Portable?",
-  "description": "An original explanation of what makes a service portable in Universal Microservices Architecture and why deterministic behavior, explicit contracts, and visible runtime boundaries matter.",
-  "url": "https://www.universalmicroservices.com/what-makes-a-service-portable/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-makes-a-service-portable/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Makes a Service Portable?","item":"https://www.universalmicroservices.com/what-makes-a-service-portable/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Makes a Service Portable?","description":"Learn what makes a service portable in UMA: deterministic behavior, explicit contracts, visible runtime boundaries, and stable output semantics.","url":"https://www.universalmicroservices.com/what-makes-a-service-portable/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#portability-starts-with-deterministic-behavior">Portability starts with deterministic behavior</a></li><li><a href="#contracts-make-portability-governable">Contracts make portability governable</a>
+    <ul class="page-rail-links">
+      <li><a href="#stable-behavior">Stable behavior</a></li><li><a href="#visible-contract">Visible contract</a></li><li><a href="#runtime-separation">Runtime separation</a></li><li><a href="#comparable-output">Comparable output</a></li>
+    </ul></li><li><a href="#what-the-runtime-should-not-own">What the runtime should not own</a></li><li><a href="#why-small-services-matter-first">Why small services matter first</a></li><li><a href="#how-portability-is-usually-lost">How portability is usually lost</a></li><li><a href="#a-practical-portability-test">A practical portability test</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#is-portability-the-same-as-code-sharing">Is portability the same as code sharing?</a></li><li><a href="#does-a-portable-service-have-to-run-everywhere">Does a portable service have to run everywhere?</a></li><li><a href="#why-does-deterministic-behavior-matter-so-much">Why does deterministic behavior matter so much?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Makes a Service Portable?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What makes a service portable?</h1>
           <p>
             A portable service is not just code that happens to compile in more than one place. In UMA, a service becomes portable when
@@ -96,9 +99,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               A service is portable when four things stay true at the same time: its behavior remains semantically stable, its contract is
               explicit, its output stays comparable across runtimes, and the runtime-specific concerns remain outside the portable core.
@@ -110,7 +113,7 @@
           </section>
 
           <section>
-            <h2>Portability starts with deterministic behavior</h2>
+            <h2 id="portability-starts-with-deterministic-behavior">Portability starts with deterministic behavior</h2>
             <p>
               The first thing a portable service needs is stable behavior. If the same input produces different decisions depending on the
               host, the integration layer, or the deployment surface, the service is not really portable. It is only being re-expressed in
@@ -124,7 +127,7 @@
           </section>
 
           <section>
-            <h2>Contracts make portability governable</h2>
+            <h2 id="contracts-make-portability-governable">Contracts make portability governable</h2>
             <p>
               Portability becomes much easier to reason about when inputs and outputs are explicit. Without that, teams often mistake
               “shared intention” for portable behavior. One implementation seems close enough to another, but the architecture still lacks
@@ -138,25 +141,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Stable behavior</h3>
+              <h3 id="stable-behavior">Stable behavior</h3>
               <p>The same input should lead to the same business decision across the runtimes you claim to support.</p>
             </article>
             <article class="subpage-card">
-              <h3>Visible contract</h3>
+              <h3 id="visible-contract">Visible contract</h3>
               <p>Inputs, outputs, and expectations should be explicit enough to test, compare, and govern.</p>
             </article>
             <article class="subpage-card">
-              <h3>Runtime separation</h3>
+              <h3 id="runtime-separation">Runtime separation</h3>
               <p>Transport, hosting, trust, and adapters should surround the service instead of quietly redefining it.</p>
             </article>
             <article class="subpage-card">
-              <h3>Comparable output</h3>
+              <h3 id="comparable-output">Comparable output</h3>
               <p>Portability is easier to prove when different implementations converge on the same observable result.</p>
             </article>
           </section>
 
           <section>
-            <h2>What the runtime should not own</h2>
+            <h2 id="what-the-runtime-should-not-own">What the runtime should not own</h2>
             <p>
               The runtime should own validation, policy, placement, capabilities, trust, and integration concerns around the service. It
               should not own the business rule that gives the service its meaning. When the runtime starts smuggling business behavior into
@@ -169,7 +172,7 @@
           </section>
 
           <section>
-            <h2>Why small services matter first</h2>
+            <h2 id="why-small-services-matter-first">Why small services matter first</h2>
             <p>
               The easiest place to understand portability is a small service with clear rules and low ambiguity. If a team cannot keep one
               small service deterministic and contract-shaped, it will struggle even more when orchestration, trust, workflow selection,
@@ -182,7 +185,7 @@
           </section>
 
           <section>
-            <h2>How portability is usually lost</h2>
+            <h2 id="how-portability-is-usually-lost">How portability is usually lost</h2>
             <p>
               A service often stops being portable gradually. One runtime adds a convenience branch. Another adds a host-specific shortcut.
               A third enriches the output shape because a local consumer needs more context. None of those changes looks dramatic by
@@ -195,7 +198,7 @@
           </section>
 
           <section>
-            <h2>A practical portability test</h2>
+            <h2 id="a-practical-portability-test">A practical portability test</h2>
             <p>
               Ask three questions. First: can the service be described through one explicit contract? Second: do the same inputs produce
               the same business result across the runtimes you claim to support? Third: can runtime-specific code change without rewriting
@@ -213,18 +216,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Is portability the same as code sharing?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="is-portability-the-same-as-code-sharing">Is portability the same as code sharing?</h3>
             <p>
               No. Code can be shared while behavior still drifts. Portability is stronger: it means the behavior itself remains stable and
               the runtime differences stay explicit around it.
             </p>
-            <h3>Does a portable service have to run everywhere?</h3>
+            <h3 id="does-a-portable-service-have-to-run-everywhere">Does a portable service have to run everywhere?</h3>
             <p>
               No. A service can be portable without being deployed in every environment. Portability is about preserving one durable
               behavior, not forcing universal placement.
             </p>
-            <h3>Why does deterministic behavior matter so much?</h3>
+            <h3 id="why-does-deterministic-behavior-matter-so-much">Why does deterministic behavior matter so much?</h3>
             <p>
               Because deterministic behavior makes portability testable. If the same service produces different decisions across runtimes,
               the architecture no longer has one stable expression of the rule.
@@ -252,7 +255,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-makes-a-system-coherent/index.html
+++ b/book-site/what-makes-a-system-coherent/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Makes a System Coherent? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Learn what makes a UMA system coherent instead of merely functional, and how metadata, capability boundaries, event semantics, and runtime decisions shape that outcome."
-    />
+    <meta name="description" content="Learn what makes a UMA system coherent instead of merely functional, and how metadata, capability boundaries, event semantics, and runtime decisions shape that outcome." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-makes-a-system-coherent/" />
-    <meta property="og:title" content="What Makes a System Coherent? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original guide to architectural coherence in UMA: how runtime-visible decisions reveal whether a system is healthy or only barely working."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Makes a System Coherent?" />
+    <meta property="og:description" content="Learn what makes a UMA system coherent instead of merely functional, and how metadata, capability boundaries, event semantics, and runtime decisions shape that outcome." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-makes-a-system-coherent/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Makes a System Coherent?",
-  "description": "An original explanation of what makes a UMA system coherent instead of merely functional, focused on metadata clarity, capability boundaries, event semantics, and runtime-visible outcomes.",
-  "url": "https://www.universalmicroservices.com/what-makes-a-system-coherent/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-makes-a-system-coherent/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Makes a System Coherent?","item":"https://www.universalmicroservices.com/what-makes-a-system-coherent/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Makes a System Coherent?","description":"Learn what makes a UMA system coherent instead of merely functional, and how metadata, capability boundaries, event semantics, and runtime decisions shape that outcome.","url":"https://www.universalmicroservices.com/what-makes-a-system-coherent/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,60 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#why-functionality-is-not-enough">Why functionality is not enough</a></li><li><a href="#where-coherence-becomes-visible">Where coherence becomes visible</a>
+    <ul class="page-rail-links">
+      <li><a href="#focused-capability-boundaries">Focused capability boundaries</a></li><li><a href="#stable-event-semantics">Stable event semantics</a></li><li><a href="#deterministic-runtime-choices">Deterministic runtime choices</a></li><li><a href="#metadata-with-purpose">Metadata with purpose</a></li>
+    </ul></li><li><a href="#what-makes-a-system-drift-away-from-coherence">What makes a system drift away from coherence</a></li><li><a href="#why-recovery-matters-as-much-as-diagnosis">Why recovery matters as much as diagnosis</a></li><li><a href="#a-practical-coherence-test">A practical coherence test</a></li><li><a href="#frequently-asked-questions">Frequently asked questions</a>
+    <ul class="page-rail-links">
+      <li><a href="#can-a-system-be-functional-but-not-coherent">Can a system be functional but not coherent?</a></li><li><a href="#does-coherence-mean-fewer-services">Does coherence mean fewer services?</a></li><li><a href="#why-is-this-a-runtime-question-and-not-only-a-design-question">Why is this a runtime question and not only a design question?</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Makes a System Coherent?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What makes a system coherent?</h1>
           <p>
             A UMA system is coherent when its runtime behavior still reflects the architectural model it claims to have. That is a higher
@@ -96,9 +99,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               Coherence means the system’s boundaries, events, metadata, capability choices, and runtime decisions reinforce one another
               instead of fighting each other. The architecture stays easier to explain because the runtime outcomes still match the declared
@@ -111,7 +114,7 @@
           </section>
 
           <section>
-            <h2>Why functionality is not enough</h2>
+            <h2 id="why-functionality-is-not-enough">Why functionality is not enough</h2>
             <p>
               A system can produce the expected output while still accumulating architectural damage. It may split behavior into too many
               capability fragments, hide meaning inside vague events, let runtime selection become ambiguous, or pile orchestration logic
@@ -124,7 +127,7 @@
           </section>
 
           <section>
-            <h2>Where coherence becomes visible</h2>
+            <h2 id="where-coherence-becomes-visible">Where coherence becomes visible</h2>
             <p>
               In UMA, coherence becomes visible in runtime behavior. Which capability was selected? Why was it selected? Do the event
               names still reflect stable domain meaning? Is metadata clarifying the flow or bloating it? Can the system explain the path in
@@ -138,25 +141,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Focused capability boundaries</h3>
+              <h3 id="focused-capability-boundaries">Focused capability boundaries</h3>
               <p>Capabilities should be meaningful enough to govern without being split into tiny steps that add more complexity than value.</p>
             </article>
             <article class="subpage-card">
-              <h3>Stable event semantics</h3>
+              <h3 id="stable-event-semantics">Stable event semantics</h3>
               <p>Events should describe durable domain facts, not vague workflow hints that only local code can interpret.</p>
             </article>
             <article class="subpage-card">
-              <h3>Deterministic runtime choices</h3>
+              <h3 id="deterministic-runtime-choices">Deterministic runtime choices</h3>
               <p>When multiple paths exist, the system should still explain why one was chosen and under which declared conditions.</p>
             </article>
             <article class="subpage-card">
-              <h3>Metadata with purpose</h3>
+              <h3 id="metadata-with-purpose">Metadata with purpose</h3>
               <p>Metadata should clarify compatibility and governance, not become a dumping ground for hidden orchestration detail.</p>
             </article>
           </section>
 
           <section>
-            <h2>What makes a system drift away from coherence</h2>
+            <h2 id="what-makes-a-system-drift-away-from-coherence">What makes a system drift away from coherence</h2>
             <p>
               Several patterns create drift quickly: over-granular capability splits, hidden event coupling, runtime ambiguity, and
               over-orchestrated flows that try to control every step centrally. Each one can still look justified locally. Together they
@@ -169,7 +172,7 @@
           </section>
 
           <section>
-            <h2>Why recovery matters as much as diagnosis</h2>
+            <h2 id="why-recovery-matters-as-much-as-diagnosis">Why recovery matters as much as diagnosis</h2>
             <p>
               A good architecture page should not only help a reader spot what is wrong. It should also help them see what recovery looks
               like. In UMA, recovery usually comes from clearer constraints, sharper capability boundaries, more stable event meaning, and
@@ -182,7 +185,7 @@
           </section>
 
           <section>
-            <h2>A practical coherence test</h2>
+            <h2 id="a-practical-coherence-test">A practical coherence test</h2>
             <p>
               Ask whether the system can explain a runtime outcome in the same terms the architecture uses to describe itself. If the
               runtime says one thing and the architecture slides say another, coherence is already weakening.
@@ -195,18 +198,18 @@
           </section>
 
           <section>
-            <h2>Frequently asked questions</h2>
-            <h3>Can a system be functional but not coherent?</h3>
+            <h2 id="frequently-asked-questions">Frequently asked questions</h2>
+            <h3 id="can-a-system-be-functional-but-not-coherent">Can a system be functional but not coherent?</h3>
             <p>
               Yes. That is exactly the point of this concept. A system may still produce the right output while becoming harder to explain,
               govern, and evolve safely.
             </p>
-            <h3>Does coherence mean fewer services?</h3>
+            <h3 id="does-coherence-mean-fewer-services">Does coherence mean fewer services?</h3>
             <p>
               Not automatically. The issue is not service count by itself. The issue is whether boundaries, events, metadata, and runtime
               choices are still making the architecture clearer or only more fragmented.
             </p>
-            <h3>Why is this a runtime question and not only a design question?</h3>
+            <h3 id="why-is-this-a-runtime-question-and-not-only-a-design-question">Why is this a runtime question and not only a design question?</h3>
             <p>
               Because runtime outcomes expose tradeoffs that static structure can hide. Coherence becomes easiest to judge when the system
               has to act, select, emit, and explain itself.
@@ -234,7 +237,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/what-problem-does-uma-solve/index.html
+++ b/book-site/what-problem-does-uma-solve/index.html
@@ -4,55 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>What Problem Does UMA Solve? | Universal Microservices Architecture</title>
-    <meta
-      name="description"
-      content="Understand the core problem Universal Microservices Architecture solves: keeping one business behavior coherent across browser, edge, cloud, workflows, and AI-assisted execution."
-    />
+    <meta name="description" content="Understand the core problem Universal Microservices Architecture solves: keeping one business behavior coherent across browser, edge, cloud, workflows, and AI-assisted execution." />
     <link rel="canonical" href="https://www.universalmicroservices.com/what-problem-does-uma-solve/" />
-    <meta property="og:title" content="What Problem Does UMA Solve? | Universal Microservices Architecture" />
-    <meta
-      property="og:description"
-      content="An original explanation of the architectural problem UMA addresses: behavior fragmentation across runtimes, hidden runtime authority, and systems that become harder to explain as they evolve."
-    />
-    <meta property="og:type" content="website" />
+    <meta property="og:title" content="What Problem Does UMA Solve?" />
+    <meta property="og:description" content="Understand the core problem Universal Microservices Architecture solves: keeping one business behavior coherent across browser, edge, cloud, workflows, and AI-assisted execution." />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/what-problem-does-uma-solve/" />
-    <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "What Problem Does UMA Solve?",
-  "description": "An original explanation of the architectural problem Universal Microservices Architecture addresses: behavior fragmentation across runtimes, hidden runtime authority, and systems that become harder to explain as they evolve.",
-  "url": "https://www.universalmicroservices.com/what-problem-does-uma-solve/",
-  "author": {
-    "@type": "Person",
-    "name": "Enrico Piovesan"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "Universal Microservices Architecture"
-  },
-  "mainEntityOfPage": "https://www.universalmicroservices.com/what-problem-does-uma-solve/"
-}
-    </script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"What Problem Does UMA Solve?","item":"https://www.universalmicroservices.com/what-problem-does-uma-solve/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"What Problem Does UMA Solve?","description":"Understand the core problem Universal Microservices Architecture solves: keeping one business behavior coherent across browser, edge, cloud, workflows, and AI-assisted execution.","url":"https://www.universalmicroservices.com/what-problem-does-uma-solve/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag("js", new Date());
-    gtag("config", "G-J5ZJHZ3D5E");
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-J5ZJHZ3D5E");
+    </script>
+  </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
         <a class="brand" href="../#top">
           <span class="brand-mark">UMA</span>
@@ -60,35 +38,57 @@
             <strong>Universal Microservices Architecture</strong>
           </span>
         </a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
         <nav class="topnav" aria-label="Primary">
-          <a href="../#why-uma">Why</a>
-          <a href="../#book-arc">What</a>
-          <a href="../#learning-path">How</a>
-          <a href="../#hands-on">Hands-on</a>
-          <a href="../#team-value">Who</a>
-          <a href="../#contacts">Contacts</a>
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
           <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
         </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
+
       <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
         <div class="mobile-menu-panel">
           <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
           <nav class="mobile-menu-nav">
-            <a href="../#why-uma">Why</a>
-            <a href="../#book-arc">What</a>
-            <a href="../#learning-path">How</a>
-            <a href="../#hands-on">Hands-on</a>
-            <a href="../#team-value">Who</a>
-            <a href="../#contacts">Contacts</a>
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
             <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
           </nav>
         </div>
       </aside>
 
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-short-answer">The short answer</a></li><li><a href="#what-the-pain-looks-like-in-real-teams">What the pain looks like in real teams</a>
+    <ul class="page-rail-links">
+      <li><a href="#repeated-business-rules">Repeated business rules</a></li><li><a href="#hidden-runtime-authority">Hidden runtime authority</a></li><li><a href="#expensive-change">Expensive change</a></li><li><a href="#weaker-explanation">Weaker explanation</a></li>
+    </ul></li><li><a href="#why-common-platform-tooling-does-not-fully-solve-it">Why common platform tooling does not fully solve it</a></li><li><a href="#what-uma-changes">What UMA changes</a></li><li><a href="#why-this-matters-more-now">Why this matters more now</a></li><li><a href="#a-fast-test-for-whether-this-is-your-problem">A fast test for whether this is your problem</a></li><li><a href="#where-to-go-next">Where to go next</a></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">What Problem Does UMA Solve?</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>What problem does UMA solve?</h1>
           <p>
             UMA exists because modern systems keep preserving deployment freedom while losing behavioral coherence. The same business rule
@@ -97,9 +97,9 @@
           </p>
         </section>
 
-        <div class="subpage-body">
+<div class="subpage-body">
           <section>
-            <h2>The short answer</h2>
+            <h2 id="the-short-answer">The short answer</h2>
             <p>
               UMA solves the problem of behavior fragmentation across runtimes. It gives teams an execution model for distributed systems
               where compute can happen in many places and the system decides where logic runs, while still keeping one business behavior
@@ -115,7 +115,7 @@
           </section>
 
           <section>
-            <h2>What the pain looks like in real teams</h2>
+            <h2 id="what-the-pain-looks-like-in-real-teams">What the pain looks like in real teams</h2>
             <p>
               A product rule starts in one place and then spreads. The frontend adds a local check for responsiveness. The backend repeats
               it for authority. An edge adapter copies part of it for latency. A workflow or agent path recreates it because the original
@@ -130,25 +130,25 @@
 
           <section class="subpage-grid">
             <article class="subpage-card">
-              <h3>Repeated business rules</h3>
+              <h3 id="repeated-business-rules">Repeated business rules</h3>
               <p>The same logic is expressed several times because each runtime surface wants a local version of the rule.</p>
             </article>
             <article class="subpage-card">
-              <h3>Hidden runtime authority</h3>
+              <h3 id="hidden-runtime-authority">Hidden runtime authority</h3>
               <p>Placement, adapters, policy, trust, and orchestration start deciding outcomes without staying legible in the architecture.</p>
             </article>
             <article class="subpage-card">
-              <h3>Expensive change</h3>
+              <h3 id="expensive-change">Expensive change</h3>
               <p>Simple rule updates require touching multiple stacks, increasing the chance of inconsistency and regression.</p>
             </article>
             <article class="subpage-card">
-              <h3>Weaker explanation</h3>
+              <h3 id="weaker-explanation">Weaker explanation</h3>
               <p>The system can still work while becoming harder to audit, reason about, and evolve safely.</p>
             </article>
           </section>
 
           <section>
-            <h2>Why common platform tooling does not fully solve it</h2>
+            <h2 id="why-common-platform-tooling-does-not-fully-solve-it">Why common platform tooling does not fully solve it</h2>
             <p>
               Good platform tooling can deploy services, route traffic, scale workloads, and wrap them with observability or policy. Those
               are necessary capabilities. They still do not guarantee that one business behavior remains coherent as execution spreads
@@ -162,7 +162,7 @@
           </section>
 
           <section>
-            <h2>What UMA changes</h2>
+            <h2 id="what-uma-changes">What UMA changes</h2>
             <p>
               UMA changes the center of gravity. Instead of treating the deployable unit as the main architectural anchor, it treats
               portable behavior as the durable unit and makes the runtime around it explicit. That runtime can then discover capabilities,
@@ -179,7 +179,7 @@
           </section>
 
           <section>
-            <h2>Why this matters more now</h2>
+            <h2 id="why-this-matters-more-now">Why this matters more now</h2>
             <p>
               The problem is sharper today because more systems now include workflow engines, edge execution, local client logic, and
               agent-assisted planning. If the architecture only models backend service ownership, it leaves too much of the real system
@@ -193,7 +193,7 @@
           </section>
 
           <section>
-            <h2>A fast test for whether this is your problem</h2>
+            <h2 id="a-fast-test-for-whether-this-is-your-problem">A fast test for whether this is your problem</h2>
             <p>
               Ask one blunt question: if a core product rule changes tomorrow, how many runtime surfaces need to be inspected, rewritten,
               or revalidated before you trust the result? If the answer is browser, backend, workflow, edge, and maybe an AI-generated
@@ -202,7 +202,7 @@
           </section>
 
           <section>
-            <h2>Where to go next</h2>
+            <h2 id="where-to-go-next">Where to go next</h2>
             <p>
               This page is the short version of the problem statement. The site covers the vocabulary needed to evaluate the model in more
               concrete terms, and the examples repository shows how that model behaves when it is pushed into runnable systems. In the
@@ -230,7 +230,6 @@
         <section id="contacts" class="section contacts-band" data-shared-footer></section>
       </main>
     </div>
-
     <script src="../app.js" type="module"></script>
   </body>
 </html>

--- a/book-site/why-universal-microservices-exist/index.html
+++ b/book-site/why-universal-microservices-exist/index.html
@@ -3,19 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Why Universal Microservices Exist | Portable Architecture and UMA</title>
+    <title>Why Universal Microservices Exist | Universal Microservices Architecture</title>
     <meta name="description" content="Learn why Universal Microservices exist, including infrastructure coupling, runtime dependence, portability pressure, and AI-driven architecture change." />
     <link rel="canonical" href="https://www.universalmicroservices.com/why-universal-microservices-exist/" />
-    <meta property="og:title" content="Why Universal Microservices Exist | Portable Architecture and UMA" />
-    <meta property="og:description" content="The strategic motivation for Universal Microservices and portable architecture." />
+    <meta property="og:title" content="Why Universal Microservices Exist" />
+    <meta property="og:description" content="Learn why Universal Microservices exist, including infrastructure coupling, runtime dependence, portability pressure, and AI-driven architecture change." />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://www.universalmicroservices.com/why-universal-microservices-exist/" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Why Universal Microservices exist","description":"Learn why Universal Microservices exist, including infrastructure coupling, runtime dependence, portability pressure, and AI-driven architecture change.","url":"https://www.universalmicroservices.com/why-universal-microservices-exist/","author":{"@type":"Person","name":"Enrico Piovesan"},"publisher":{"@type":"Organization","name":"Universal Microservices Architecture"},"mainEntityOfPage":"https://www.universalmicroservices.com/why-universal-microservices-exist/"}</script>
+    <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.universalmicroservices.com/"},{"@type":"ListItem","position":2,"name":"Why Universal Microservices Exist","item":"https://www.universalmicroservices.com/why-universal-microservices-exist/"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Why Universal Microservices Exist","description":"Learn why Universal Microservices exist, including infrastructure coupling, runtime dependence, portability pressure, and AI-driven architecture change.","url":"https://www.universalmicroservices.com/why-universal-microservices-exist/","inLanguage":"en"}</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,500;8..60,700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="../subpages.css" />
+    <link rel="icon" href="../favicon.png" type="image/png" sizes="64x64" />
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5ZJHZ3D5E"></script>
     <script>
@@ -26,53 +30,103 @@
     </script>
   </head>
   <body>
-    <div class="page-shell">
+    <div class="page-shell has-page-rail">
       <header class="topbar">
-        <a class="brand" href="../#top"><span class="brand-mark">UMA</span><span class="brand-copy"><strong>Universal Microservices Architecture</strong></span></a>
-        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
-        <nav class="topnav" aria-label="Primary"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav>
+        <a class="brand" href="../#top">
+          <span class="brand-mark">UMA</span>
+          <span class="brand-copy">
+            <strong>Universal Microservices Architecture</strong>
+          </span>
+        </a>
+
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu">
+          Menu
+        </button>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+          <a class="topnav-github" href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+        </nav>
         <a class="button button-primary header-cta" href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
       </header>
-      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden><div class="mobile-menu-panel"><button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button><nav class="mobile-menu-nav"><a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a><a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a></nav></div></aside>
+
+      <aside class="mobile-menu" id="mobile-menu" aria-label="Mobile navigation" hidden>
+        <div class="mobile-menu-panel">
+          <button class="mobile-menu-close" type="button" aria-label="Close menu">Close</button>
+          <nav class="mobile-menu-nav">
+            <a href="../#why-uma">Why</a><a href="../#book-arc">What</a><a href="../#learning-path">How</a><a href="../#hands-on">Hands-on</a><a href="../#team-value">Who</a><a href="../#contacts">Contacts</a>
+            <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub</a>
+          </nav>
+        </div>
+      </aside>
+
+
+      <aside class="page-rail" aria-label="Page navigation">
+    <nav class="page-rail-block">
+      <h2>On this page</h2>
+
+    <ol class="page-rail-outline">
+      <li><a href="#the-pressure-underneath-the-model">The pressure underneath the model</a></li><li><a href="#infrastructure-coupling">Infrastructure coupling</a></li><li><a href="#runtime-dependence">Runtime dependence</a></li><li><a href="#ai-driven-architectural-pressure">AI-driven architectural pressure</a></li><li><a href="#why-this-matters-now">Why this matters now</a>
+    <ul class="page-rail-links">
+      <li><a href="#less-duplication">Less duplication</a></li><li><a href="#clearer-authority">Clearer authority</a></li><li><a href="#better-evolution">Better evolution</a></li><li><a href="#more-credible-ai-use">More credible AI use</a></li>
+    </ul></li>
+    </ol>
+    </nav>
+    <nav class="page-rail-block">
+      <h2>Explore UMA</h2>
+      <ul class="page-rail-links">
+        <li><a href="/">home</a></li><li><a href="../book/">book</a></li><li><a href="../examples/">examples</a></li><li><a href="../learning-path/">learning path</a></li><li><a href="../faq/">faq</a></li><li><a href="https://medium.com/the-rise-of-device-independent-architecture" target="_blank" rel="noreferrer noopener">blog</a></li><li><a href="https://www.universalmicroservices.com/reference-application/" target="_blank" rel="noreferrer noopener">reference application</a></li><li><a href="https://github.com/enricopiovesan/UMA-code-examples" target="_blank" rel="noreferrer noopener">github</a></li>
+      </ul>
+    </nav>
+
+      </aside>
+
       <main class="subpage-main">
-        <section class="subpage-hero">
+
+        <nav class="page-breadcrumbs" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="../">Home</a></li><li><span aria-current="page">Why Universal Microservices Exist</span></li>
+          </ol>
+        </nav>
+
+<section class="subpage-hero">
           <h1>Why Universal Microservices exist</h1>
           <p>Universal Microservices exist because modern systems no longer execute in one stable place. Business behavior now crosses browsers, edge runtimes, cloud services, workflows, and AI-assisted paths. Without an architectural model for that movement, systems duplicate behavior and lose coherence.</p>
         </section>
-        <div class="subpage-body">
+
+<div class="subpage-body">
           <section>
-            <h2>The pressure underneath the model</h2>
+            <h2 id="the-pressure-underneath-the-model">The pressure underneath the model</h2>
             <p>Teams already know how to deploy services. The harder problem is preserving service meaning when execution spreads across many runtimes. UMA starts from that pressure rather than from a new packaging technique.</p>
             <p>The model exists to make runtime diversity manageable without pretending every runtime is equivalent.</p>
           </section>
 
           <section>
-            <h2>Infrastructure coupling</h2>
+            <h2 id="infrastructure-coupling">Infrastructure coupling</h2>
             <p>Many systems look modular from the outside but keep business behavior bound to a specific framework, queue, database adapter, or hosting assumption. That coupling limits where the behavior can run and makes change expensive.</p>
             <p>UMA separates the portable service boundary from the infrastructure concerns that surround it.</p>
           </section>
 
           <section>
-            <h2>Runtime dependence</h2>
+            <h2 id="runtime-dependence">Runtime dependence</h2>
             <p>Runtime dependence becomes a problem when local choices quietly redefine the service. A browser rule, an edge optimization, and a backend authority check may all claim to implement the same behavior while drifting apart over time.</p>
             <p>Universal Microservices make the runtime layer explicit so placement, validation, and policy are governed decisions.</p>
           </section>
 
           <section>
-            <h2>AI-driven architectural pressure</h2>
+            <h2 id="ai-driven-architectural-pressure">AI-driven architectural pressure</h2>
             <p>AI-assisted flows increase the need for visible authority. Agents can propose paths, rank options, or assemble workflows, but the runtime still needs to validate what is allowed and what actually executes.</p>
             <p>That is why UMA draws a firm distinction between proposal and authority.</p>
           </section>
 
           <section>
-            <h2>Why this matters now</h2>
+            <h2 id="why-this-matters-now">Why this matters now</h2>
             <p>Portable architecture is no longer a niche concern. It is a response to systems that must keep one behavior consistent across many execution surfaces while still respecting trust, latency, cost, and operational context.</p>
           </section>
           <section class="subpage-grid">
-            <article class="subpage-card"><h3>Less duplication</h3><p>One behavior can remain the durable center instead of being reimplemented surface by surface.</p></article>
-            <article class="subpage-card"><h3>Clearer authority</h3><p>The runtime becomes responsible for validation and policy rather than leaving those decisions implicit.</p></article>
-            <article class="subpage-card"><h3>Better evolution</h3><p>Versioning and compatibility become visible system concerns.</p></article>
-            <article class="subpage-card"><h3>More credible AI use</h3><p>Agents can participate without becoming the source of operational authority.</p></article>
+            <article class="subpage-card"><h3 id="less-duplication">Less duplication</h3><p>One behavior can remain the durable center instead of being reimplemented surface by surface.</p></article>
+            <article class="subpage-card"><h3 id="clearer-authority">Clearer authority</h3><p>The runtime becomes responsible for validation and policy rather than leaving those decisions implicit.</p></article>
+            <article class="subpage-card"><h3 id="better-evolution">Better evolution</h3><p>Versioning and compatibility become visible system concerns.</p></article>
+            <article class="subpage-card"><h3 id="more-credible-ai-use">More credible AI use</h3><p>Agents can participate without becoming the source of operational authority.</p></article>
           </section>
           <section class="subpage-callout">
             <strong>Want to go deeper?</strong>

--- a/content/README.md
+++ b/content/README.md
@@ -1,0 +1,84 @@
+# UMA Content Source of Truth
+
+This directory is the authoring source for the UMA website content.
+The HTML website is generated from these Markdown files at build time.
+
+## Layout
+
+- `site-map.md` - the canonical website structure and page ordering
+- `pages/` - one Markdown file per page, grouped by macro area
+- `pages/_shared/` - reusable authoring fragments or partials, if needed later
+
+## Rules
+
+- Do not publish these files directly as website pages.
+- Keep the homepage separate unless explicitly instructed otherwise.
+- Keep URLs stable even if page titles change.
+- Use the semantic taxonomy and subpage template spec in `docs/site/`.
+
+## Recommended Page Layout
+
+```text
+content/
+|- site-map.md
+|- pages/
+|  |- why-uma/
+|  |  |- what-problem-does-uma-solve.md
+|  |  |- what-is-uma.md
+|  |  |- why-universal-microservices-exist.md
+|  |
+|  |- core-model/
+|  |  |- what-is-a-capability.md
+|  |  |- what-is-a-workflow.md
+|  |  |- what-is-a-uma-runtime.md
+|  |
+|  |- how-uma-works/
+|  |  |- what-makes-a-service-portable.md
+|  |  |- how-to-prove-portability.md
+|  |  |- runtime-agnostic-architecture.md
+|  |
+|  |- examples/
+|  |  |- chapter-04-feature-flag-evaluator.md
+|  |  |- chapter-05-post-fetcher-runtime.md
+|  |  |- chapter-06-portability-lab.md
+|  |
+|  |- evolve-uma/
+|  |  |- service-graph-evolution.md
+|  |  |- trust-boundaries.md
+|  |  |- evolution-without-fragmentation.md
+|  |
+|  |- discoverability/
+|  |  |- faq.md
+|  |  |- diagrams.md
+|  |  |- book.md
+```
+
+## Frontmatter Contract
+
+Each page Markdown file should start with frontmatter containing:
+
+- `ref`
+- `title`
+- `subtitle`
+- `macro_area`
+- `content_type`
+- `slug`
+- `canonical_url`
+- `breadcrumbs`
+- `left_nav_group`
+- `chapter_ref` when relevant
+- `seo_description`
+- `related_refs`
+
+## Body Contract
+
+Each page body should use structured sections so the generator can assemble consistent HTML:
+
+- `intro`
+- `main`
+- `book_ref`
+- `related`
+- `faq`
+
+Use section markers or a small schema so content stays easy to generate and validate.
+

--- a/content/pages/comparisons/common-criticisms-and-tradeoffs-of-uma.md
+++ b/content/pages/comparisons/common-criticisms-and-tradeoffs-of-uma.md
@@ -1,0 +1,79 @@
+---
+ref: common-criticisms-and-tradeoffs-of-uma
+title: "Common Criticisms and Tradeoffs of UMA"
+subtitle: "Common criticisms and tradeoffs of UMA UMA is not a free upgrade to every architecture. It introduces a stronger model for portable behavior, but that model brings learning curve, runtime design work, governance responsibility, and organizational questions. Those tradeoffs are real and should be evaluated directly."
+macro_area: comparisons
+content_type: comparison
+slug: common-criticisms-and-tradeoffs-of-uma
+canonical_url: "https://www.universalmicroservices.com/common-criticisms-and-tradeoffs-of-uma/"
+left_nav_group: comparisons
+chapter_ref: null
+seo_description: "A credible look at UMA tradeoffs, including learning curve, runtime complexity, governance needs, and organizational readiness."
+breadcrumbs:
+  - "Home"
+  - "Comparisons"
+  - "Common Criticisms and Tradeoffs of UMA"
+related_refs:
+  - uma-vs-modular-monolith
+  - uma-vs-serverless
+  - uma-vs-traditional-microservices
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Common criticisms and tradeoffs of UMA</h1>
+          <p>UMA is not a free upgrade to every architecture. It introduces a stronger model for portable behavior, but that model brings learning curve, runtime design work, governance responsibility, and organizational questions. Those tradeoffs are real and should be evaluated directly.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The learning curve is real</h2>
+            <p>UMA asks teams to separate behavior, contract, runtime, adapter, trust, and workflow concerns more deliberately than many stack-first systems do. That can feel heavier at first.</p>
+            <p>The tradeoff is clarity. A team pays some design cost upfront to reduce hidden duplication later.</p>
+          </section>
+
+          <section>
+            <h2>Runtime complexity does not disappear</h2>
+            <p>A portable service still needs a runtime. Validation, transport, placement, events, observability, and policy all have to live somewhere.</p>
+            <p>UMA does not remove runtime complexity. It makes that complexity explicit so teams can reason about it.</p>
+          </section>
+
+          <section>
+            <h2>Governance becomes part of the architecture</h2>
+            <p>Portability without governance can make risk travel faster. A service that runs in more contexts needs clearer trust boundaries, versioning, and authority checks.</p>
+            <p>This is one reason the book treats governance as core methodology rather than as a late production appendix.</p>
+          </section>
+
+          <section>
+            <h2>Organizational readiness matters</h2>
+            <p>UMA works best when teams can agree on capability ownership and runtime responsibility. If every team optimizes only for its local stack, the model will be hard to sustain.</p>
+            <p>That does not mean the organization must transform all at once. It means adoption should begin where the ownership problem is visible.</p>
+          </section>
+
+          <section>
+            <h2>When UMA may be too much</h2>
+            <p>If a service has one stable deployment surface, little duplicated behavior, and no meaningful runtime diversity, UMA may not repay the design cost. The point is to apply it where portability and governance are actually needed.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Criticism</h3><p>It can feel more complex than a local service implementation.</p></article>
+            <article class="subpage-card"><h3>Response</h3><p>The complexity already exists when behavior crosses runtimes. UMA makes it visible.</p></article>
+            <article class="subpage-card"><h3>Criticism</h3><p>It requires governance discipline.</p></article>
+            <article class="subpage-card"><h3>Response</h3><p>That discipline is necessary when portable behavior becomes operationally important.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page is intentionally candid. The book expands the tradeoff analysis into decision criteria, governance patterns, and implementation guidance. The repository includes examples that expose both coherent and degraded designs.</p>
+            <div class="subpage-inline-links">
+              <a href="../uma-vs-traditional-microservices/">UMA vs traditional microservices</a>
+              <a href="../what-makes-a-system-coherent/">What makes a system coherent?</a>
+              <a href="../trust-boundaries/">Trust boundaries</a>
+              <a href="../examples/chapter-10-architectural-tradeoffs/">Architectural tradeoffs example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/comparisons/uma-vs-modular-monolith.md
+++ b/content/pages/comparisons/uma-vs-modular-monolith.md
@@ -1,0 +1,79 @@
+---
+ref: uma-vs-modular-monolith
+title: "UMA vs Modular Monolith"
+subtitle: "UMA vs modular monolith A modular monolith can be a strong architecture when one deployment unit is acceptable and internal boundaries are clear. UMA addresses a different pressure: how to preserve one behavior when execution needs to cross runtime boundaries."
+macro_area: comparisons
+content_type: comparison
+slug: uma-vs-modular-monolith
+canonical_url: "https://www.universalmicroservices.com/uma-vs-modular-monolith/"
+left_nav_group: comparisons
+chapter_ref: null
+seo_description: "Compare UMA and modular monoliths across modularity, deployment boundaries, runtime boundaries, and system evolution paths."
+breadcrumbs:
+  - "Home"
+  - "Comparisons"
+  - "UMA vs Modular Monolith"
+related_refs:
+  - common-criticisms-and-tradeoffs-of-uma
+  - uma-vs-serverless
+  - uma-vs-traditional-microservices
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>UMA vs modular monolith</h1>
+          <p>A modular monolith can be a strong architecture when one deployment unit is acceptable and internal boundaries are clear. UMA addresses a different pressure: how to preserve one behavior when execution needs to cross runtime boundaries.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>A modular monolith organizes code inside one deployable system. UMA organizes portable behavior so it can remain coherent across multiple execution contexts.</p>
+            <p>The two ideas can coexist. A modular monolith may host UMA-style capabilities, and UMA can help identify which behaviors should leave the monolith first.</p>
+          </section>
+
+          <section>
+            <h2>Modularity</h2>
+            <p>Modular monoliths improve internal structure by making module boundaries explicit. That is valuable. UMA adds a stronger question about whether a behavior can survive outside the original host without being rewritten.</p>
+            <p>Internal modularity is not the same as runtime portability.</p>
+          </section>
+
+          <section>
+            <h2>Deployment boundaries</h2>
+            <p>The modular monolith usually keeps deployment simple by shipping one unit. UMA accepts that some behavior may need to execute in different places and makes the surrounding runtime decisions explicit.</p>
+            <p>This is not a claim that distributed deployment is always better. It is a claim that runtime diversity needs a model when it appears.</p>
+          </section>
+
+          <section>
+            <h2>Runtime boundaries</h2>
+            <p>A module inside a monolith often assumes the host process, shared memory, local libraries, and a common framework. A Universal Microservice has to make more of its boundary explicit so the behavior can be governed elsewhere.</p>
+            <p>That extra discipline is useful only when the behavior needs that freedom.</p>
+          </section>
+
+          <section>
+            <h2>Evolution paths</h2>
+            <p>A modular monolith can evolve into services when pressure justifies it. UMA gives teams a way to extract behavior by capability and prove that the extracted unit remains coherent before wider rollout.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Modular monolith</h3><p>Best when deployment simplicity and internal modularity solve the main problem.</p></article>
+            <article class="subpage-card"><h3>UMA</h3><p>Best when behavior must cross browser, edge, cloud, workflow, or AI-assisted paths.</p></article>
+            <article class="subpage-card"><h3>Shared strength</h3><p>Both models value explicit boundaries over accidental coupling.</p></article>
+            <article class="subpage-card"><h3>Key difference</h3><p>UMA treats runtime movement as a first-class architectural concern.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page compares the architectural lenses. The book expands the decision model for when to keep behavior inside one system and when to extract it into a portable capability.</p>
+            <div class="subpage-inline-links">
+              <a href="../from-stack-ownership-to-behavior-ownership/">From stack ownership to behavior ownership</a>
+              <a href="../what-is-a-universal-microservice/">What is a Universal Microservice?</a>
+              <a href="../service-graph-evolution/">Service graph evolution</a>
+              <a href="../examples/chapter-08-service-graph/">Service graph example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/comparisons/uma-vs-serverless.md
+++ b/content/pages/comparisons/uma-vs-serverless.md
@@ -1,0 +1,79 @@
+---
+ref: uma-vs-serverless
+title: "UMA vs Serverless"
+subtitle: "UMA vs serverless UMA and serverless solve different problems. Serverless is primarily a deployment and operations model. UMA is an architectural model for keeping behavior portable, governed, and coherent as execution crosses runtime boundaries."
+macro_area: comparisons
+content_type: comparison
+slug: uma-vs-serverless
+canonical_url: "https://www.universalmicroservices.com/uma-vs-serverless/"
+left_nav_group: comparisons
+chapter_ref: null
+seo_description: "Compare UMA and serverless across runtime model, deployment model, portability, governance, and cost considerations."
+breadcrumbs:
+  - "Home"
+  - "Comparisons"
+  - "UMA vs Serverless"
+related_refs:
+  - common-criticisms-and-tradeoffs-of-uma
+  - uma-vs-modular-monolith
+  - uma-vs-traditional-microservices
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>UMA vs serverless</h1>
+          <p>UMA and serverless solve different problems. Serverless is primarily a deployment and operations model. UMA is an architectural model for keeping behavior portable, governed, and coherent as execution crosses runtime boundaries.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>Serverless asks who manages the servers and how functions are invoked. UMA asks how one business capability keeps its meaning when it can execute across browser, edge, cloud, workflow, and AI-assisted paths.</p>
+            <p>A UMA service could run through a serverless platform, but serverless alone does not define the portable service boundary.</p>
+          </section>
+
+          <section>
+            <h2>Runtime model</h2>
+            <p>Serverless runtimes are provider-shaped. They define invocation, scaling, permissions, event bindings, and operational constraints. UMA treats runtime concerns as explicit architecture, but does not assume one provider runtime is the durable model.</p>
+            <p>The runtime in UMA governs where and how a portable capability executes.</p>
+          </section>
+
+          <section>
+            <h2>Deployment model</h2>
+            <p>Serverless focuses on deploying small units without managing servers. UMA focuses on preserving business behavior across deployment shapes. The deployment target is important, but it is not the center of the model.</p>
+            <p>That distinction matters when the same behavior must live in more than one environment.</p>
+          </section>
+
+          <section>
+            <h2>Portability</h2>
+            <p>A serverless function may be easy to deploy but still deeply tied to provider APIs, event models, and operational assumptions. A UMA service is designed so the core behavior can remain stable while adapters and runtimes vary.</p>
+            <p>Portability is not automatic. It has to be designed and proven.</p>
+          </section>
+
+          <section>
+            <h2>Cost considerations</h2>
+            <p>Serverless can reduce operational burden and align cost to usage, but provider-specific coupling and cold-start behavior can influence architecture. UMA does not prescribe a cost model. It helps teams make runtime placement decisions explicit so cost is one visible input among others.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Serverless</h3><p>A deployment and operations model for running code without managing servers.</p></article>
+            <article class="subpage-card"><h3>UMA</h3><p>An architectural model for portable behavior and governed runtime decisions.</p></article>
+            <article class="subpage-card"><h3>Serverless risk</h3><p>Provider-specific events and APIs can become hidden architecture.</p></article>
+            <article class="subpage-card"><h3>UMA risk</h3><p>The runtime and governance model must be designed deliberately.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This comparison stays at the concept level. The book goes deeper into runtime placement, operational tradeoffs, and production patterns, while the repository lets you inspect how portable services are validated outside one platform assumption.</p>
+            <div class="subpage-inline-links">
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../what-belongs-in-the-runtime-layer/">What belongs in the runtime layer?</a>
+              <a href="../how-to-prove-portability/">How to prove portability</a>
+              <a href="../examples/chapter-05-post-fetcher-runtime/">Post fetcher runtime example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/comparisons/uma-vs-traditional-microservices.md
+++ b/content/pages/comparisons/uma-vs-traditional-microservices.md
@@ -1,0 +1,219 @@
+---
+ref: uma-vs-traditional-microservices
+title: "UMA vs Traditional Microservices"
+subtitle: "UMA vs traditional microservices Universal Microservices Architecture is not a rejection of microservices. It is a response to a different problem. Traditional microservices explain deployable service boundaries well. UMA is an execution model for distributed systems where compute can happen in many places and the system decides where logic runs without losing behavioral coherence."
+macro_area: comparisons
+content_type: comparison
+slug: uma-vs-traditional-microservices
+canonical_url: "https://www.universalmicroservices.com/uma-vs-traditional-microservices/"
+left_nav_group: comparisons
+chapter_ref: null
+seo_description: "Compare Universal Microservices Architecture with traditional microservices and learn where UMA changes the architectural center of gravity."
+breadcrumbs:
+  - "Home"
+  - "Comparisons"
+  - "UMA vs Traditional Microservices"
+related_refs:
+  - common-criticisms-and-tradeoffs-of-uma
+  - uma-vs-modular-monolith
+  - uma-vs-serverless
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>UMA vs traditional microservices</h1>
+          <p>
+            Universal Microservices Architecture is not a rejection of microservices. It is a response to a different problem. Traditional
+            microservices explain deployable service boundaries well. UMA is an execution model for distributed systems where compute can
+            happen in many places and the system decides where logic runs without losing behavioral coherence.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              Traditional microservices usually center the architecture on deployable service ownership. UMA centers the architecture on
+              portable behavior plus governed runtime decisions. That shift matters because modern systems no longer live neatly inside one
+              backend service boundary. They stretch across browser, edge, server, background, and increasingly AI-assisted execution
+              contexts.
+            </p>
+            <p>
+              Microservices answer an important question: how should service responsibilities be separated? UMA answers a newer one: how do
+              you preserve service meaning when execution no longer belongs to one runtime surface?
+            </p>
+            <p>
+              The portable summary is not “write once, run everywhere.” It is “write once, run where it makes sense.”
+            </p>
+          </section>
+
+          <section>
+            <h2>One concrete before-and-after test</h2>
+            <p>
+              Imagine one product rule that has to appear in a browser experience, a backend authority check, an edge optimization, and a
+              generated workflow. In a typical stack-first system, each surface ends up with its own version of the rule. The system still
+              works, but nobody can point to one durable behavioral source anymore.
+            </p>
+            <p>
+              UMA changes that center of gravity. The goal is to preserve one portable unit of behavior and let the runtime decide where it
+              should execute, what constraints apply, and which path is valid in the current context. That is the practical difference the
+              reference app and the later chapters are trying to prove.
+            </p>
+          </section>
+
+          <section>
+            <h2>What traditional microservices do well</h2>
+            <p>
+              Traditional microservices remain valuable because they make service ownership, deployment independence, and bounded
+              responsibility easier to reason about. They helped teams move away from monolithic stacks by making service boundaries more
+              visible and operationally independent.
+            </p>
+            <p>
+              That architectural move still matters. UMA is not trying to dismiss it. But many organizations now face a second layer of
+              fragmentation that classic microservice diagrams do not explain very well: the same behavior is being repeated across many
+              runtime surfaces that are not captured cleanly by one deployable backend service model.
+            </p>
+          </section>
+
+          <section>
+            <h2>Where the center of gravity changes</h2>
+            <p>
+              The main difference is what each model treats as the durable unit. Traditional microservices emphasize the deployable service.
+              UMA emphasizes the portable service behavior and the runtime layer around it. That means contracts, capability exposure,
+              validation, trust, and execution authority become much more explicit in the architecture.
+            </p>
+            <p>
+              In practical terms, UMA is less interested in whether a team owns one service and more interested in whether one business
+              behavior can stay coherent while execution moves across environments. That is why the runtime becomes so important in UMA:
+              it keeps the portable unit governed as the system grows.
+            </p>
+            <p>
+              Another way to see that shift is the move from stack ownership to behavior ownership. Once the durable concern stops being
+              only the service process or deployment boundary, the architecture needs a stronger answer for how one behavior stays
+              recognizable across several runtime surfaces.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Traditional microservices</h3>
+              <p>Strong at separating deployable backend units and clarifying ownership between services.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>UMA</h3>
+              <p>Strong at preserving one service meaning while runtime, policy, trust, and workflow surfaces evolve around it.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Traditional microservices</h3>
+              <p>Tend to assume the important runtime boundary is the service process or network endpoint.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>UMA</h3>
+              <p>Treats the portable service boundary and the governed runtime around it as the more durable architectural model.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why traditional microservices are no longer enough by themselves</h2>
+            <p>
+              A modern product rarely runs in only one place. Important behavior often appears in frontend validation, edge adaptation,
+              backend authority, workflow automation, and AI-assisted composition. Traditional microservices can still model the backend
+              estate, but they do not automatically solve the problem of duplicated business meaning across those newer execution surfaces.
+            </p>
+            <p>
+              That is the gap UMA tries to close. It preserves one portable expression of the behavior and makes the runtime-specific
+              decisions around it explicit rather than letting each environment quietly redefine the service.
+            </p>
+          </section>
+
+          <section>
+            <h2>What UMA adds to the conversation</h2>
+            <p>
+              UMA adds a stronger story for portability, governed execution, capability discovery, runtime authority, and long-term system
+              coherence. It makes room for workflows that are selected dynamically, capabilities that are surfaced explicitly, and runtime
+              decisions that remain inspectable instead of disappearing into hidden glue.
+            </p>
+            <p>
+              That does not make microservices obsolete. It means the architectural conversation has to evolve when the system itself is no
+              longer defined only by service-to-service backend interactions.
+            </p>
+          </section>
+
+          <section>
+            <h2>How to decide which lens you need</h2>
+            <p>
+              If your main problem is separating backend ownership and deployment responsibility, traditional microservices may be enough.
+              If your main problem is preserving one behavior across client, edge, server, background, and AI-assisted contexts, the
+              microservice lens alone is usually too narrow.
+            </p>
+            <p>
+              In that case, UMA becomes useful because it provides a stronger answer to questions about portability, capability
+              composition, runtime validation, and trust. It gives you a model for what happens after the service boundary is already
+              separated but the architecture is still drifting.
+            </p>
+          </section>
+
+          <section>
+            <h2>What UMA is not trying to do</h2>
+            <ul>
+              <li>It is not trying to erase service ownership or operational boundaries.</li>
+              <li>It is not claiming microservices were a mistake.</li>
+              <li>It is not replacing every architecture term with new branding.</li>
+              <li>It is not saying all services should run everywhere.</li>
+              <li>It is saying that modern systems need a stronger model for portable behavior and governed runtime decisions.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>A practical comparison test</h2>
+            <p>
+              Ask one question: when the same business behavior appears in browser code, edge logic, backend authority, and a generated
+              workflow, what architectural model keeps that behavior coherent? If your answer is only “we have many small services,” you
+              still have an unmodeled problem.
+            </p>
+            <p>
+              UMA becomes relevant exactly there. It extends the conversation from deployable service boundaries to portable behavior,
+              explicit runtime authority, and capability-based composition.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is UMA replacing microservices?</h3>
+            <p>
+              No. UMA is better understood as a later architectural response to problems that traditional microservices do not fully model,
+              especially portability across runtimes and visible runtime governance.
+            </p>
+            <h3>Can UMA and traditional microservices coexist?</h3>
+            <p>
+              Yes. Many organizations will still operate microservice-based systems while using UMA ideas to preserve portable behavior and
+              make runtime decisions more explicit.
+            </p>
+            <h3>Why is this distinction important for the book?</h3>
+            <p>
+              Because a reader should understand that UMA is not “microservices with WebAssembly.” It is a different architectural lens,
+              one designed for systems whose behavior must survive across more varied execution contexts.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Continue the comparison into the model</strong>
+            <p>
+              If this comparison made sense, the next step is to move from the outside view into the core UMA concepts: behavior
+              ownership, capability, runtime, and governed discovery. In the book, I take that shift further and show how those concepts
+              become a usable execution model instead of just a critique of older boundaries.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../from-stack-ownership-to-behavior-ownership/">From stack ownership to behavior ownership</a>
+              <a href="../what-is-uma/">What is UMA?</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../what-is-wasm-mcp/">What is WASM MCP?</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/active-descriptors.md
+++ b/content/pages/core-model/active-descriptors.md
@@ -1,0 +1,59 @@
+---
+ref: active-descriptors
+title: "Active Descriptors in UMA"
+subtitle: "Active descriptors In UMA, a descriptor is not just documentation beside a service. It is metadata the runtime can evaluate to understand the service boundary, validate inputs and outputs, check compatibility, and record why execution was allowed."
+macro_area: core-model
+content_type: explainer
+slug: active-descriptors
+canonical_url: "https://www.universalmicroservices.com/active-descriptors/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "Learn how UMA uses active descriptors as runtime-evaluated constraints for contracts, schemas, latency expectations, compatibility, and execution evidence."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "Active Descriptors in UMA"
+related_refs:
+  - agent-vs-runtime
+  - late-bound-policy-enforcement
+  - what-belongs-in-the-runtime-layer
+  - what-is-a-capability
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Active descriptors</h1>
+          <p>In UMA, a descriptor is not just documentation beside a service. It is metadata the runtime can evaluate to understand the service boundary, validate inputs and outputs, check compatibility, and record why execution was allowed.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The useful idea</h2>
+            <p>An active descriptor describes a capability in terms the runtime can use: schemas, emitted events, required inputs, allowed placements, version constraints, and the evidence expected from a run. It is active because it participates in execution decisions.</p>
+            <p>This does not mean the contract replaces service logic. The contract is an executable constraint model around the logic, while the service still owns the durable behavior.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Boundary</h3><p>Input and output schemas define the shape of the portable behavior.</p></article>
+            <article class="subpage-card"><h3>Compatibility</h3><p>Version and event declarations help the runtime decide whether services can interact.</p></article>
+            <article class="subpage-card"><h3>Expectations</h3><p>Latency, error, and evidence expectations make execution easier to inspect.</p></article>
+            <article class="subpage-card"><h3>Authority</h3><p>The runtime evaluates the descriptor before it treats a proposed path as approved.</p></article>
+          </section>
+          <section>
+            <h2>Concrete proof</h2>
+            <p>The early examples prove the idea in small pieces: Chapter 4 uses a contract around deterministic flag evaluation, Chapter 6 uses a contract to compare native and WASI execution, and Chapter 7 lets contracts and events shape orchestration.</p>
+          </section>
+          <section class="subpage-callout">
+            <strong>Covered in the book</strong>
+            <p>This page gives the preview. Chapters 4, 6, and 7 explain how descriptors become practical runtime inputs without turning the website into the full book.</p>
+            <div class="subpage-inline-links">
+              <a href="../examples/chapter-04-feature-flag-evaluator/">Chapter 4 example</a>
+              <a href="../examples/chapter-06-portability-lab/">Chapter 6 example</a>
+              <a href="../examples/chapter-07-metadata-orchestration/">Chapter 7 example</a>
+              <a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/agent-vs-runtime.md
+++ b/content/pages/core-model/agent-vs-runtime.md
@@ -1,0 +1,220 @@
+---
+ref: agent-vs-runtime
+title: "Agent vs Runtime in UMA"
+subtitle: "Agent vs runtime in UMA One of the easiest ways to misunderstand Universal Microservices Architecture is to assume that once agents enter the picture, they become the real authority of the system. UMA makes the opposite claim. Agents can help discover, rank, and compose capabilities, but the runtime still decides what is valid, safe, and executable."
+macro_area: core-model
+content_type: explainer
+slug: agent-vs-runtime
+canonical_url: "https://www.universalmicroservices.com/agent-vs-runtime/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "Understand the difference between agents and the runtime in Universal Microservices Architecture: agents propose, the runtime validates, and the system stays governed."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "Agent vs Runtime in UMA"
+related_refs:
+  - active-descriptors
+  - late-bound-policy-enforcement
+  - what-belongs-in-the-runtime-layer
+  - what-is-a-capability
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Agent vs runtime in UMA</h1>
+          <p>
+            One of the easiest ways to misunderstand Universal Microservices Architecture is to assume that once agents enter the picture,
+            they become the real authority of the system. UMA makes the opposite claim. Agents can help discover, rank, and compose
+            capabilities, but the runtime still decides what is valid, safe, and executable.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              In UMA, an agent is a reasoning component. It interprets a goal, looks at available capabilities, and proposes a path. The
+              runtime is the execution authority. It validates contracts, checks constraints, enforces trust and placement rules, and
+              decides whether the proposal is acceptable.
+            </p>
+            <p>
+              That distinction matters because modern systems increasingly include components that can generate plans dynamically. If those
+              plans are treated as self-justifying, architecture turns into improvisation. UMA avoids that by keeping a hard boundary
+              between proposing work and authorizing work.
+            </p>
+            <ul>
+              <li><strong>Agent:</strong> proposes what might work.</li>
+              <li><strong>Runtime:</strong> decides what is actually allowed to run.</li>
+              <li><strong>System:</strong> stays governed because planning and authority are not collapsed into one layer.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>What an agent is for</h2>
+            <p>
+              Agents are useful when a system has many capabilities and no single fixed workflow fits every situation. They can help
+              interpret goals, identify candidate capabilities, rank plausible options, and suggest a sequence that might satisfy the
+              request. That is valuable because it lets the system adapt to context instead of relying only on predetermined paths.
+            </p>
+            <p>
+              But adaptability is not the same thing as authority. An agent is good at proposing. It is not, by itself, a stable place to
+              define policy, trust, placement, compatibility, or approval rules. Those concerns need a layer that is more explicit and more
+              governable than a generated plan.
+            </p>
+          </section>
+
+          <section>
+            <h2>What the runtime is for</h2>
+            <p>
+              The runtime exists to turn a capability model into governed execution. It knows what is available, what is compatible, what
+              is allowed in the current environment, and what must be rejected even if a proposal looks plausible. It can also explain what
+              happened, which matters just as much as the execution itself.
+            </p>
+            <p>
+              That means the runtime is the place where architectural rules stay explicit. It is where discovery becomes validation,
+              ranking becomes selection, and a proposed workflow becomes an approved one. Without that layer, an agent can still produce
+              output, but the system becomes harder to audit, reproduce, and trust.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Agent responsibility</h3>
+              <p>Interpret the goal, explore available capabilities, and propose a plausible path.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime responsibility</h3>
+              <p>Validate contracts, enforce constraints, and decide whether the proposal can actually run.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Agent strength</h3>
+              <p>Adaptability, ranking, and dynamic composition when the exact path cannot be fully hardwired in advance.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime strength</h3>
+              <p>Authority, repeatability, evidence, and governance across environments and capability boundaries.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>If you remember one rule</h2>
+            <p>
+              A good UMA system can benefit from an agent without becoming agent-governed. That is the practical test. If the planner goes
+              away, the runtime should still be coherent. If the runtime goes away, the planner should not be trusted to define the system
+              alone.
+            </p>
+            <p>
+              That rule is important because many systems sound flexible only as long as nobody asks who is accountable for the final
+              decision. UMA keeps that answer simple: the runtime is accountable for approval and execution, even when the proposal was
+              generated dynamically.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why this distinction matters more with AI</h2>
+            <p>
+              AI systems make the agent side more powerful, but they also make the boundary more important. As soon as the planning layer is
+              model-driven, it becomes even more dangerous to let the proposal layer silently become the control layer. A strong answer is
+              still needed to the question: who gets to say yes?
+            </p>
+            <p>
+              UMA’s answer is that the runtime says yes or no. The agent can suggest. The runtime can accept, reject, or replace that
+              suggestion according to contracts, placement rules, trust boundaries, and current system conditions. That keeps the system
+              explainable even when planning becomes more fluid.
+            </p>
+          </section>
+
+          <section>
+            <h2>What goes wrong when the distinction disappears</h2>
+            <p>
+              When teams blur the line between agent and runtime, failures start to look intelligent instead of architectural. A proposal is
+              accepted because it seems reasonable, not because it was validated. A capability is invoked because it looked relevant, not
+              because it matched the active constraints. Placement becomes accidental. Trust becomes inferred. Reproducibility collapses
+              because nobody can clearly say which part of the system was merely suggestive and which part was authoritative.
+            </p>
+            <p>
+              That is one reason many “AI-native” system stories still feel thin from an architectural standpoint. They show dynamic plans,
+              but not governed execution. UMA tries to keep that second part visible.
+            </p>
+            <p>
+              Discoverability strengthens that same boundary. Once proposal, validation, revision, and trace become inspectable artifacts,
+              the system can explain not only that authority exists, but how it actually shaped the result.
+            </p>
+          </section>
+
+          <section>
+            <h2>How Chapter 13 makes this visible</h2>
+            <p>
+              The Chapter 13 reference experience is useful because it shows this boundary directly instead of leaving it implicit. The
+              planner can rank capabilities. The runtime still validates the choice. If a proposed path violates the active rules, the
+              runtime can reject it. The resulting workflow is not whatever the planner imagined; it is what the runtime approved.
+            </p>
+            <p>
+              That is the practical version of the architectural claim on this page. The live demo is not just an AI workflow viewer. It is
+              a demonstration of runtime authority in the presence of dynamic planning.
+            </p>
+            <p>
+              That makes the page useful for two kinds of readers. One reader wants the concept: what is the difference between agent and
+              runtime? Another reader wants proof: can I see the proposal accepted or rejected by a governed layer? Chapter 13 is the proof
+              surface for that second question.
+            </p>
+          </section>
+
+          <section>
+            <h2>A useful design test</h2>
+            <p>
+              If you want to know whether your system is treating agents and runtimes clearly, ask a simple question: if the planner proposes
+              a valid-looking but disallowed path, what enforces the rejection? If the answer is unclear, the architecture probably needs a
+              stronger runtime story.
+            </p>
+            <p>
+              A second question helps too: can you explain, after execution, why one capability was approved and another was rejected? If
+              that answer only exists inside the planner’s prompt or hidden reasoning, the system is still missing the governed layer UMA is
+              trying to make explicit.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Does UMA require an agent?</h3>
+            <p>
+              No. UMA does not require an agent in order to be coherent. A system can still use explicit workflows, fixed capability
+              selection, and strong runtime governance. Agents become useful when the system needs dynamic selection or proposal behavior.
+            </p>
+            <h3>Can an agent ever be authoritative?</h3>
+            <p>
+              It can feel authoritative at the product layer, but in a governed UMA system it should still pass through runtime approval.
+              Otherwise the system loses the architectural distinction that keeps dynamic planning from turning into hidden control.
+            </p>
+            <h3>Why not let the agent decide everything if it performs well?</h3>
+            <p>
+              Because performance and authority are different concerns. A planner may often suggest a good path, but a governed system still
+              needs explicit validation, trust enforcement, and reproducible approval. Those are runtime responsibilities, not prompt
+              outcomes.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>See the distinction in practice</strong>
+            <p>
+              If this page makes sense conceptually, the next step is to watch the live reference app. It makes the planner, runtime, and
+              capability flow visible step by step. If you want the deeper architectural argument behind that design, the book is where that
+              fuller model belongs.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../what-makes-a-decision-discoverable/">What makes a decision discoverable?</a>
+              <a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../what-is-uma/">What is UMA?</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/late-bound-policy-enforcement.md
+++ b/content/pages/core-model/late-bound-policy-enforcement.md
@@ -1,0 +1,35 @@
+---
+ref: late-bound-policy-enforcement
+title: "Late-Bound Policy Enforcement in UMA"
+subtitle: "Late-bound policy enforcement UMA treats policy as something evaluated near execution, not as a static diagram note. The runtime can apply placement, trust, compliance, and fail-fast rules without rewriting the portable service."
+macro_area: core-model
+content_type: explainer
+slug: late-bound-policy-enforcement
+canonical_url: "https://www.universalmicroservices.com/late-bound-policy-enforcement/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "A conversion-focused preview of late-bound policy enforcement in UMA: how runtimes apply policy, placement, trust, and compliance rules around portable services."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "Late-Bound Policy Enforcement in UMA"
+related_refs:
+  - active-descriptors
+  - agent-vs-runtime
+  - what-belongs-in-the-runtime-layer
+  - what-is-a-capability
+---
+
+## intro
+
+<section class="subpage-hero"><h1>Late-bound policy enforcement</h1><p>UMA treats policy as something evaluated near execution, not as a static diagram note. The runtime can apply placement, trust, compliance, and fail-fast rules without rewriting the portable service.</p></section>
+
+## main
+
+<div class="subpage-body">
+          <section><h2>Why late-bound policy matters</h2><p>Distributed systems often hardwire policy into deployment scripts, gateway configuration, or application code. That makes the policy hard to audit and hard to move with the behavior it governs.</p><p>UMA keeps the portable behavior separate while letting runtime authority decide whether a specific execution path is allowed under current conditions.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>Local decision</h3><p>The runtime evaluates the metadata it has, instead of relying on hidden centralized coordination for every choice.</p></article><article class="subpage-card"><h3>Fail fast</h3><p>Invalid or disallowed runs should stop before adapter execution and side effects begin.</p></article><article class="subpage-card"><h3>Policy evidence</h3><p>The run should show which policy shaped the outcome.</p></article><article class="subpage-card"><h3>Portable core</h3><p>The service logic remains stable while execution conditions change around it.</p></article></section>
+          <section><h2>What this page does not replace</h2><p>The full book goes deeper into how validation, adapter binding, policy, and lifecycle evidence fit together. This page is the orientation layer: it tells you why the idea matters and where to inspect it in code.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 5 introduces the runtime layer, Chapter 7 applies policy in orchestration, and Chapter 9 turns trust into explicit enforcement.</p><div class="subpage-inline-links"><a href="../examples/chapter-05-post-fetcher-runtime/">Chapter 5 example</a><a href="../examples/chapter-07-metadata-orchestration/">Chapter 7 example</a><a href="../examples/chapter-09-trust-boundaries/">Chapter 9 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/what-belongs-in-the-runtime-layer.md
+++ b/content/pages/core-model/what-belongs-in-the-runtime-layer.md
@@ -1,0 +1,194 @@
+---
+ref: what-belongs-in-the-runtime-layer
+title: "What Belongs in the Runtime Layer?"
+subtitle: "What belongs in the runtime layer? In UMA, the runtime layer owns the governed conditions around execution. The service keeps the durable business behavior. The runtime keeps the decisions that must remain visible when that behavior is validated, adapted, and allowed to run."
+macro_area: core-model
+content_type: explainer
+slug: what-belongs-in-the-runtime-layer
+canonical_url: "https://www.universalmicroservices.com/what-belongs-in-the-runtime-layer/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "Learn what belongs in the runtime layer in UMA: validation, adapter binding, policy, lifecycle evidence, and the governed conditions around execution."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "What Belongs in the Runtime Layer?"
+related_refs:
+  - active-descriptors
+  - agent-vs-runtime
+  - late-bound-policy-enforcement
+  - what-is-a-capability
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What belongs in the runtime layer?</h1>
+          <p>
+            In UMA, the runtime layer owns the governed conditions around execution. The service keeps the durable business behavior. The
+            runtime keeps the decisions that must remain visible when that behavior is validated, adapted, and allowed to run.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              The runtime layer should own validation, adapter selection, policy enforcement, lifecycle evidence, and the execution context
+              around the service. It should not quietly become the place where the service’s core business rule is rewritten.
+            </p>
+            <p>
+              This distinction matters because many systems claim to preserve a portable service while still allowing runtime code to carry
+              the rule that actually determines the outcome. Once that happens, the service boundary stops being the durable center of the
+              architecture.
+            </p>
+          </section>
+
+          <section>
+            <h2>What should stay inside the service</h2>
+            <p>
+              The service should keep the business behavior that must remain semantically stable across hosts. That usually means rules,
+              normalization logic, decision semantics, and the contract-shaped meaning of the result. This is the part of the system that
+              portability is trying to preserve.
+            </p>
+            <p>
+              If the service boundary is clean, the same behavior can be tested, compared, and reasoned about without depending on one
+              transport, one adapter, or one deployment surface.
+            </p>
+          </section>
+
+          <section>
+            <h2>What the runtime should own instead</h2>
+            <p>
+              The runtime should own the questions around the service rather than the rule inside it. Is the request valid? Which adapter
+              is allowed to satisfy the capability? Which policy applies? Should execution fail fast before side effects happen? What
+              evidence should be recorded so the run can be explained afterward?
+            </p>
+            <p>
+              Those concerns are not secondary infrastructure details. They are part of the architecture because they determine how the
+              system turns portable behavior into governed execution.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Validation</h3>
+              <p>Input checks, constraint checks, and fail-fast rules should happen before side effects are allowed to begin.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Adapter binding</h3>
+              <p>The runtime should decide which host capability or adapter implementation satisfies the requested behavior.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Policy and trust</h3>
+              <p>Permissions, placement, trust boundaries, and environment-specific rules belong around the service, not inside it.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Lifecycle evidence</h3>
+              <p>The runtime should keep enough observable evidence to explain what path actually ran and why.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why fail-fast validation belongs there</h2>
+            <p>
+              One of the clearest runtime responsibilities is stopping invalid execution before the system causes side effects. If the
+              runtime has enough context to know that a request is malformed, incompatible, or disallowed, the architecture is stronger
+              when that rejection happens before the adapter path even begins.
+            </p>
+            <p>
+              This is not only about safety. It is about keeping the system honest. A runtime that validates too late often forces cleanup
+              logic to carry architectural meaning that should have stayed visible from the start.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why adapter binding should stay visible</h2>
+            <p>
+              Adapter selection is easy to hide in helper code, but that usually makes the architecture less legible. If a capability can
+              be satisfied through different bindings or wrappers, the system is easier to review when the runtime owns that decision and
+              records it explicitly.
+            </p>
+            <p>
+              That makes the system more explainable to both people and tooling. The service result can stay stable while the runtime still
+              shows which adapter path actually participated.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why lifecycle evidence matters</h2>
+            <p>
+              A runtime layer becomes much more valuable once it can show what happened instead of merely claiming success. Event ordering,
+              binding records, validation failures, and final state markers help the architecture stay auditable instead of turning into an
+              opaque control flow.
+            </p>
+            <p>
+              This does not require a heavy observability platform to matter. Even a small service becomes easier to trust when the runtime
+              leaves behind enough evidence to prove which governed path actually ran.
+            </p>
+          </section>
+
+          <section>
+            <h2>What the runtime layer should not become</h2>
+            <ul>
+              <li>It should not absorb the core business rule because the host code feels more convenient.</li>
+              <li>It should not become a vague utility layer with hidden architectural decisions.</li>
+              <li>It should not hide adapter choice when that choice affects trust, policy, or evidence.</li>
+              <li>It should not wait until after side effects to perform validation it already knows how to do.</li>
+              <li>It should not make the service boundary harder to see.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>A practical design test</h2>
+            <p>
+              Ask whether your system can point to the exact place where validation happens, the exact place where adapter choice is made,
+              and the exact place where execution evidence is recorded. If those answers are scattered across helpers and host-specific
+              code, the runtime layer still exists, but the architecture has not owned it cleanly.
+            </p>
+            <p>
+              Another useful test is this: if the service behavior stays the same, can the runtime change validation rules, adapter
+              wrappers, or lifecycle recording without forcing a rewrite of the core logic? If yes, the separation is probably healthy.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Does the runtime layer replace the service?</h3>
+            <p>
+              No. The service remains the durable behavioral center. The runtime layer exists around it so execution conditions stay
+              explicit instead of leaking back into the service logic.
+            </p>
+            <h3>Why not keep adapter binding inside the host application?</h3>
+            <p>
+              You can, but the architecture becomes harder to inspect. UMA is stronger when adapter choice is treated as a visible runtime
+              concern rather than an implementation accident.
+            </p>
+            <h3>Is lifecycle evidence only useful in large systems?</h3>
+            <p>
+              No. It becomes more valuable at scale, but even a small service is easier to trust when the runtime can explain what it did
+              and what it chose.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Follow the runtime boundary further</strong>
+            <p>
+              This page isolates one practical question the chapter sequence makes important: what the runtime should own once the service
+              itself stays clean. In the book, I push that separation further into execution traces, adapter design, and the evolving
+              responsibilities of the runtime as systems grow. On the site, the best next step is to connect this idea to the UMA runtime
+              and to the runnable examples.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../examples/">Examples</a>
+              <a href="../diagrams/">Diagrams</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/what-is-a-capability.md
+++ b/content/pages/core-model/what-is-a-capability.md
@@ -1,0 +1,237 @@
+---
+ref: what-is-a-capability
+title: "What Is a Capability in UMA?"
+subtitle: "What is a capability in UMA? A capability is the unit the runtime can actually reason about. In Universal Microservices Architecture, a capability is not just code that exists somewhere. It is a named, discoverable, contract-shaped piece of behavior that the runtime can evaluate, approve, reject, and compose into a workflow when compute can happen in many places and the system needs to decide where logic runs."
+macro_area: core-model
+content_type: explainer
+slug: what-is-a-capability
+canonical_url: "https://www.universalmicroservices.com/what-is-a-capability/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "Learn what a capability means in Universal Microservices Architecture, how it differs from a service or workflow, and why it matters for governed composition."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "What Is a Capability in UMA?"
+related_refs:
+  - active-descriptors
+  - agent-vs-runtime
+  - late-bound-policy-enforcement
+  - what-belongs-in-the-runtime-layer
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What is a capability in UMA?</h1>
+          <p>
+            A capability is the unit the runtime can actually reason about. In Universal Microservices Architecture, a capability is not
+            just code that exists somewhere. It is a named, discoverable, contract-shaped piece of behavior that the runtime can evaluate,
+            approve, reject, and compose into a workflow when compute can happen in many places and the system needs to decide where logic runs.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              In UMA, a capability is the actionable shape of a service. It tells the runtime what this piece of the system can do, what
+              it expects, what it produces, and under which conditions it should be considered valid. That makes it more useful than a
+              vague service label and more durable than a one-off function call buried inside a stack-specific implementation.
+            </p>
+            <p>
+              This is why capabilities matter so much once the system becomes dynamic. A runtime cannot compose a workflow out of loosely
+              described code. It needs visible units with clear meaning. Capabilities are those units.
+            </p>
+            <p>
+              The portability goal here is not “write once, run everywhere.” It is “write once, run where it makes sense,” with
+              capabilities giving the runtime concrete units to evaluate.
+            </p>
+            <ul>
+              <li><strong>Capability:</strong> a discoverable unit of behavior the runtime can reason about.</li>
+              <li><strong>Workflow:</strong> a runtime-approved sequence of capabilities used to satisfy a goal.</li>
+              <li><strong>Runtime:</strong> the layer that validates which capabilities can actually participate.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Why UMA uses capabilities instead of only services</h2>
+            <p>
+              The word service is useful, but it can stay too broad. It often tells you that some behavior exists without telling you what
+              the runtime can do with it. A capability is more specific. It expresses the part of the service that is operationally
+              meaningful for discovery, selection, compatibility checking, and composition.
+            </p>
+            <p>
+              That distinction becomes important as soon as the system supports more than one possible path to the same outcome. If the
+              runtime must decide whether to summarize, translate, enrich, format, reject, or adapt, it needs a unit more precise than “we
+              have a service for that.” It needs something it can compare and govern. That is what a capability provides.
+            </p>
+            <p>
+              This also works better when the underlying service is portable in a disciplined way. A runtime can govern a capability much
+              more cleanly when the service behavior is deterministic enough to remain stable across hosts and explicit enough to preserve
+              one visible contract.
+            </p>
+          </section>
+
+          <section>
+            <h2>What makes something a capability</h2>
+            <p>
+              A capability is not defined only by where it runs or which team owns it. It is defined by whether the runtime can treat it
+              as a clear architectural unit. That usually means four things are visible: the behavior it offers, the input it expects, the
+              output it produces, and the conditions under which it is allowed to participate.
+            </p>
+            <p>
+              Without those elements, the runtime is left inferring too much. The system may still work, but it becomes harder to discover,
+              validate, or explain why one path was chosen over another. UMA uses capabilities to keep that ambiguity low.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Named behavior</h3>
+              <p>A capability should express a meaningful action such as enriching, summarizing, translating, validating, or formatting.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Visible contract</h3>
+              <p>The runtime should be able to inspect inputs, outputs, and compatibility expectations without guessing.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime relevance</h3>
+              <p>The capability should be selectable, rejectable, and composable as part of a governed workflow.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Architectural meaning</h3>
+              <p>The capability should explain what value it adds to the workflow, not just where a piece of code happens to live.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Capability versus workflow</h2>
+            <p>
+              A capability is not the same thing as a workflow. A capability is one participant. A workflow is the approved path the
+              runtime builds from one or more capabilities to satisfy a goal. Mixing those two ideas makes dynamic systems harder to
+              understand because the unit of behavior and the unit of orchestration stop being separate.
+            </p>
+            <p>
+              UMA keeps them distinct on purpose. The capability stays reusable and inspectable. The workflow stays explainable as a
+              composition of capabilities rather than a hidden chain of internal calls.
+            </p>
+          </section>
+
+          <section>
+            <h2>Capability versus agent</h2>
+            <p>
+              This is another useful distinction. An agent can help interpret the goal and propose which capabilities might fit. But the
+              capability is still the unit of work the runtime validates and selects. Agents help with reasoning. Capabilities are the
+              architectural units being reasoned about.
+            </p>
+            <p>
+              That is one reason the capability model matters even more in AI-assisted systems. If the planning layer is dynamic, the units
+              being planned must become clearer, not less clear. Otherwise the runtime ends up evaluating suggestions that are too vague to
+              govern properly.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why this matters for runtime authority</h2>
+            <p>
+              The runtime cannot remain authoritative if the units of work are fuzzy. It can only approve or reject what is visible enough
+              to inspect. Capabilities give the runtime something concrete to reason about: what behavior is being requested, what contract
+              it implies, what placement it requires, and whether the current environment should allow it.
+            </p>
+            <p>
+              This is the bridge between the conceptual pages on the site and the reference app. The app is not just showing boxes and
+              arrows. It is showing a runtime making decisions over capabilities rather than blindly following a hardwired script.
+            </p>
+          </section>
+
+          <section>
+            <h2>A concrete proof point</h2>
+            <p>
+              The easiest proof is to watch one workflow in the reference app. You can see which capabilities are available, which one is
+              proposed or selected, and where the runtime keeps authority over the final path. That is much clearer than treating
+              capabilities as another naming convention for services.
+            </p>
+          </section>
+
+          <section>
+            <h2>What a capability is not</h2>
+            <ul>
+              <li>It is not every function or class in the codebase.</li>
+              <li>It is not the same thing as a deployable service boundary.</li>
+              <li>It is not the workflow itself.</li>
+              <li>It is not a synonym for “tool” with no contract or runtime context.</li>
+              <li>It is not just an AI agent prompt with a nice name attached.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>A practical design test</h2>
+            <p>
+              If you are unsure whether something in your system is a capability, ask two questions. First: can the runtime understand
+              what this unit does and when it is valid? Second: can it be selected or rejected as part of a larger workflow without reading
+              hidden implementation details? If both answers are yes, you are probably looking at a capability rather than just an internal
+              implementation detail.
+            </p>
+            <p>
+              If the answers are no, the unit may still be useful code, but it is not yet expressed clearly enough for governed runtime
+              composition.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why capabilities make the architecture easier to learn</h2>
+            <p>
+              Capabilities give the reader a stable mental unit. Instead of thinking in terms of full applications, hidden helpers, or
+              stack-specific modules, the reader can ask simpler questions: what capabilities exist, what goal is being satisfied, which
+              capability was chosen, and why did the runtime approve that path? That makes the system easier to understand without reducing
+              it to simplistic diagrams.
+            </p>
+            <p>
+              It also helps teams talk about architecture with more precision. “This workflow needs translation after summarization” is
+              clearer than “the app calls some translation code after it does the other thing.” The capability model creates that clarity.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is a capability the same as a microservice?</h3>
+            <p>
+              Not necessarily. A microservice is often described as a deployable unit. A capability is the unit the runtime can discover,
+              validate, and compose. Sometimes those ideas overlap. Often they do not.
+            </p>
+            <h3>Can one service expose more than one capability?</h3>
+            <p>
+              Yes. One service boundary can expose multiple meaningful capabilities, especially if the runtime needs to distinguish between
+              different kinds of behavior that should be validated or composed separately.
+            </p>
+            <h3>Do capabilities only matter in dynamic or AI-driven systems?</h3>
+            <p>
+              No. They matter even in simpler systems because they make the service behavior more visible. Dynamic planning just makes the
+              need for them more obvious.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>See capabilities in action</strong>
+            <p>
+              If this page clarified the term, the next useful step is to see capabilities participate in a governed workflow. The live
+              reference app makes that visible, and in the book I go deeper into why capabilities become the durable unit once execution is
+              no longer tied to one stack.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../what-is-wasm-mcp/">What is WASM MCP?</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/what-is-a-uma-runtime.md
+++ b/content/pages/core-model/what-is-a-uma-runtime.md
@@ -1,0 +1,223 @@
+---
+ref: what-is-a-uma-runtime
+title: "What Is a UMA Runtime?"
+subtitle: "What is a UMA runtime? The UMA runtime is the governed layer around portable behavior. It is the part of the system that discovers capabilities, checks compatibility, enforces constraints, decides what is allowed to run, and records enough evidence for the execution to be understandable afterward. In practical terms, it is the layer that decides where logic runs once compute can happen in many places."
+macro_area: core-model
+content_type: explainer
+slug: what-is-a-uma-runtime
+canonical_url: "https://www.universalmicroservices.com/what-is-a-uma-runtime/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "Learn what the UMA runtime is, what it owns, and why runtime authority matters in Universal Microservices Architecture."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "What Is a UMA Runtime?"
+related_refs:
+  - active-descriptors
+  - agent-vs-runtime
+  - late-bound-policy-enforcement
+  - what-belongs-in-the-runtime-layer
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What is a UMA runtime?</h1>
+          <p>
+            The UMA runtime is the governed layer around portable behavior. It is the part of the system that discovers capabilities,
+            checks compatibility, enforces constraints, decides what is allowed to run, and records enough evidence for the execution to be
+            understandable afterward. In practical terms, it is the layer that decides where logic runs once compute can happen in many
+            places.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              In Universal Microservices Architecture, the runtime is not just a host process. It is the architectural authority that turns
+              portable behavior into governed execution. It knows which capabilities exist, which ones match the active goal, which ones
+              fit the current environment, and which proposed paths must be rejected.
+            </p>
+            <p>
+              That is why the runtime matters so much in UMA. Portable logic alone is not enough. A system also needs a visible layer that
+              owns selection, validation, policy, and evidence. Without that layer, portability becomes hard to trust.
+            </p>
+            <p>
+              This is also why UMA is not “write once, run everywhere.” It is “write once, run where it makes sense,” with the runtime
+              making that decision explicit and governable.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why the runtime is not just infrastructure</h2>
+            <p>
+              Many systems treat the runtime as invisible plumbing. It launches code, moves data, and stays mostly out of the
+              architectural conversation. UMA uses the term differently. The runtime is where the architecture keeps its authority once the
+              system becomes dynamic.
+            </p>
+            <p>
+              That means the runtime is not just there to execute. It is there to decide whether a requested path is valid, compatible,
+              allowed, and safe enough to approve. This is one reason UMA can support dynamic workflows without becoming architecturally
+              vague.
+            </p>
+          </section>
+
+          <section>
+            <h2>What the runtime owns</h2>
+            <p>
+              The runtime owns the questions that should stay visible around the portable core: what is available, what matches the active
+              goal, what contracts are compatible, what policy applies, what trust boundary is in effect, and what final path is approved.
+              Those concerns are not distractions from the architecture. They are the parts that keep the system explainable.
+            </p>
+            <p>
+              In a simpler system, some of those decisions may look trivial. In a richer system, they become the difference between a
+              governed platform and a collection of plausible but unaccountable executions.
+            </p>
+            <p>
+              One useful practical version of that question is simply:
+              <a href="../what-belongs-in-the-runtime-layer/">what belongs in the runtime layer?</a>
+              Validation, adapter binding, lifecycle evidence, and policy checks are not side details. They are part of how the runtime
+              keeps portable behavior governed instead of accidental.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Discovery</h3>
+              <p>The runtime can see which capabilities exist and which of them are even candidates for the current goal.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Validation</h3>
+              <p>The runtime checks compatibility, constraints, policies, and trust rules before execution is approved.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Selection</h3>
+              <p>The runtime decides which valid capability or workflow path will actually run, even when planning is dynamic.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Evidence</h3>
+              <p>The runtime preserves enough state and explanation for a person or tool to understand what happened afterward.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Capability and runtime belong together</h2>
+            <p>
+              Capabilities are the units the runtime reasons about. Without capabilities, the runtime has nothing precise to discover or
+              validate. Without the runtime, capabilities remain descriptive rather than governed. That is why these two concepts work as a
+              pair in UMA.
+            </p>
+            <p>
+              This also explains why workflows are not hardcoded in the same way. A workflow is the approved composition the runtime builds
+              from capabilities for a given goal. The runtime is the place where that composition becomes authoritative rather than merely
+              suggested.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why this matters once agents appear</h2>
+            <p>
+              Agents make the need for a strong runtime easier to see. If an agent can interpret goals and propose a path, something still
+              has to decide whether that path should be trusted. In UMA, that answer is the runtime. The agent can help reason. The runtime
+              remains authoritative.
+            </p>
+            <p>
+              This is not anti-agent. It is what keeps an AI-assisted system from quietly turning into a prompt-shaped control plane. The
+              runtime gives the architecture a place where rules stay explicit even when planning becomes fluid.
+            </p>
+          </section>
+
+          <section>
+            <h2>What a UMA runtime is not</h2>
+            <ul>
+              <li>It is not just a process launcher.</li>
+              <li>It is not a synonym for one host, one server, or one deployment environment.</li>
+              <li>It is not the same thing as the service logic itself.</li>
+              <li>It is not a hidden orchestration layer that cannot explain its decisions.</li>
+              <li>It is not an excuse to let policies disappear into infrastructure defaults.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>A practical design test</h2>
+            <p>
+              If you want to know whether your system has a real runtime story, ask a simple question: when two capabilities could satisfy
+              the same goal, who decides which one is allowed to run? If the answer is “whichever one the code happened to call” or “the
+              planner probably chose the right thing,” the runtime layer is still too weak.
+            </p>
+            <p>
+              Another good question is whether the system can explain, after execution, why a path was accepted, rejected, or adapted. If
+              not, the runtime is still being treated as plumbing rather than as an architectural authority.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why the runtime improves learning, not just execution</h2>
+            <p>
+              The runtime also makes UMA easier to teach because it turns vague system behavior into visible steps. Readers can ask what
+              the runtime discovered, why it rejected one path, why it approved another, and what evidence it produced. That is much
+              easier to understand than a system that only exposes the final output.
+            </p>
+            <p>
+              The live reference app is useful for exactly this reason. It makes the runtime visible as a decision layer instead of
+              presenting the workflow as if it simply happened on its own.
+            </p>
+            <p>
+              The next architectural step is making that decision layer queryable. Once proposals, approvals, and trace artifacts become
+              visible too, the runtime stops being understandable only in the moment and becomes understandable afterward as well.
+            </p>
+          </section>
+
+          <section>
+            <h2>A concrete proof point</h2>
+            <p>
+              The simplest proof is not theoretical. Open the reference app and watch one workflow execute. The planner can propose, the
+              runtime can reject or approve, the capability path stays visible, and the result is explained afterward. That is much closer
+              to the real UMA claim than a generic portability slogan.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is the runtime the same thing as the host platform?</h3>
+            <p>
+              No. The host platform matters, but the UMA runtime is the governed layer that sits around portable behavior and owns the
+              architectural decisions required for valid execution.
+            </p>
+            <h3>Can a UMA runtime exist without AI?</h3>
+            <p>
+              Yes. UMA does not require AI to make the runtime meaningful. The runtime still matters in deterministic systems because it
+              owns discovery, validation, policy, and execution authority.
+            </p>
+            <h3>Why not let the workflow decide itself?</h3>
+            <p>
+              Because workflows do not govern themselves. A system still needs a layer that can validate compatibility, enforce rules, and
+              explain why the approved path was valid in the current context.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>See the runtime as a real decision layer</strong>
+            <p>
+              If this page clarified the role of the runtime, the next step is to look at a workflow where the runtime accepts, rejects,
+              and composes capabilities visibly. The live reference app shows the surface; in the book, I go further into why that runtime
+              layer has to stay authoritative as systems grow more dynamic.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+              <a href="../what-belongs-in-the-runtime-layer/">What belongs in the runtime layer?</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../what-makes-a-decision-discoverable/">What makes a decision discoverable?</a>
+              <a href="../what-is-wasm-mcp/">What is WASM MCP?</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/what-is-a-workflow.md
+++ b/content/pages/core-model/what-is-a-workflow.md
@@ -1,0 +1,211 @@
+---
+ref: what-is-a-workflow
+title: "What Is a Workflow in UMA?"
+subtitle: "What is a workflow in UMA? In Universal Microservices Architecture, a workflow is the approved path the runtime builds from capabilities to satisfy a goal. It is not just a sequence of function calls. It is a visible composition of runtime-validated behavior when compute can happen in many places and the runtime must decide where logic runs."
+macro_area: core-model
+content_type: explainer
+slug: what-is-a-workflow
+canonical_url: "https://www.universalmicroservices.com/what-is-a-workflow/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "Learn what a workflow means in Universal Microservices Architecture and how workflows differ from capabilities, agents, and the runtime."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "What Is a Workflow in UMA?"
+related_refs:
+  - active-descriptors
+  - agent-vs-runtime
+  - late-bound-policy-enforcement
+  - what-belongs-in-the-runtime-layer
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What is a workflow in UMA?</h1>
+          <p>
+            In Universal Microservices Architecture, a workflow is the approved path the runtime builds from capabilities to satisfy a
+            goal. It is not just a sequence of function calls. It is a visible composition of runtime-validated behavior when compute can
+            happen in many places and the runtime must decide where logic runs.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              A workflow in UMA is the composition the runtime approves after considering the goal, the available capabilities, the active
+              constraints, and any planning help from agents. That makes a workflow more than an implementation detail. It becomes an
+              architectural object the system can explain.
+            </p>
+            <p>
+              This distinction matters because many systems have workflows without ever making them explicit. The behavior still chains
+              together, but the path is hidden inside glue code, local assumptions, or framework orchestration. UMA makes the workflow
+              visible so the system can justify why that path was valid.
+            </p>
+            <p>
+              The useful portability promise is not “write once, run everywhere.” It is “write once, run where it makes sense,” with the
+              workflow showing how the runtime applied that decision to one goal.
+            </p>
+          </section>
+
+          <section>
+            <h2>Workflow versus capability</h2>
+            <p>
+              A capability is one unit of behavior. A workflow is a composition of capabilities used to reach an outcome. Confusing those
+              two ideas makes systems harder to reason about because the reusable units and the approved path stop being distinct.
+            </p>
+            <p>
+              UMA keeps them separate on purpose. Capabilities stay stable enough to be discovered and validated individually. Workflows
+              remain visible enough to be approved, rejected, adapted, and explained as full paths.
+            </p>
+          </section>
+
+          <section>
+            <h2>Workflow versus agent</h2>
+            <p>
+              An agent can help propose a workflow. It can interpret the goal, rank possible capabilities, and suggest a plausible route.
+              But the workflow itself does not become authoritative just because it was proposed. The runtime still has to approve it.
+            </p>
+            <p>
+              This is why workflows matter so much in the reference app. They show the difference between a suggested path and an approved
+              one. The workflow the user sees is the path the runtime accepted, not simply the first plan that sounded reasonable.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Goal-oriented</h3>
+              <p>A workflow exists to satisfy a goal, not just to reflect implementation structure.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Capability-based</h3>
+              <p>A workflow is built from capabilities that the runtime can inspect and govern.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime-approved</h3>
+              <p>The path becomes real only when the runtime validates it against the current rules and conditions.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Explainable</h3>
+              <p>A useful workflow is one the system can describe after execution, not just one that happened to succeed.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why workflows matter more in modern systems</h2>
+            <p>
+              The more dynamic a system becomes, the more important workflows become as a visible concept. Once there are multiple possible
+              paths to the same outcome, the architecture has to explain not only what capabilities exist, but how they were assembled into
+              a valid route.
+            </p>
+            <p>
+              That is true whether the variability comes from policy, placement, user context, available providers, or AI-assisted
+              planning. A hidden workflow quickly turns into hidden architecture. UMA prevents that by keeping workflows visible and
+              governed.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why the runtime owns the workflow outcome</h2>
+            <p>
+              A workflow is where many architectural concerns meet: compatibility, trust, policy, ordering, and execution authority. Those
+              are not concerns a capability should own alone, and they are not concerns an agent should own by itself either. The runtime
+              is the right place for them because it can evaluate the full path in context.
+            </p>
+            <p>
+              This is also why workflows are so useful in the browser reference app. They make runtime authority legible. You can see which
+              capability was chosen, what the planner proposed, and where the runtime accepted or rejected the path.
+            </p>
+            <p>
+              Once the path is no longer static, discoverability matters as much as approval. Readers and tools should be able to inspect
+              how the workflow moved from projection and proposal into authoritative execution.
+            </p>
+          </section>
+
+          <section>
+            <h2>What a workflow is not</h2>
+            <ul>
+              <li>It is not every internal call chain in the codebase.</li>
+              <li>It is not the same thing as a static pipeline definition.</li>
+              <li>It is not just a planner suggestion.</li>
+              <li>It is not a substitute for capability contracts.</li>
+              <li>It is not useful if the system cannot explain why it was approved.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>A practical design test</h2>
+            <p>
+              If you want to know whether your system has a real workflow model, ask whether it can answer four simple questions after
+              execution: what was the goal, which capabilities were available, which path was approved, and why that path was valid. If the
+              system cannot answer those questions cleanly, the workflow still exists only implicitly.
+            </p>
+            <p>
+              Another useful test is whether the same workflow could be rerun or inspected without reading hidden implementation code. If
+              not, the workflow is still too entangled with the internals of one stack.
+            </p>
+          </section>
+
+          <section>
+            <h2>How the reference app makes workflows useful</h2>
+            <p>
+              The live reference app works because it treats the workflow as a first-class explanation layer. It does not just show the
+              result. It shows the path from discovery to planning to runtime approval to capability execution. That helps readers grasp
+              UMA much faster than a final output alone would.
+            </p>
+            <p>
+              This is one of the biggest teaching advantages of the Chapter 13 experience. It turns workflow composition from a hidden
+              implementation detail into something a reader can inspect step by step.
+            </p>
+          </section>
+
+          <section>
+            <h2>A concrete proof point</h2>
+            <p>
+              The reference app is useful because it shows one workflow as graph, narrative, and runtime state at the same time. That lets
+              you see the difference between a possible path and an approved path instead of guessing what the orchestration layer did.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Does every UMA system need dynamic workflows?</h3>
+            <p>
+              No. A workflow can still be explicit and valuable in a more deterministic system. Dynamic selection simply makes the need for
+              visible workflows more obvious.
+            </p>
+            <h3>Can one goal map to more than one valid workflow?</h3>
+            <p>
+              Yes. That is one of the reasons the runtime matters. It may need to choose between multiple valid paths depending on policy,
+              constraints, trust, or current environment conditions.
+            </p>
+            <h3>Why not just call it orchestration?</h3>
+            <p>
+              Orchestration is part of the story, but workflow is the clearer reader-facing term for the approved path through capabilities
+              that satisfies a goal.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>See the workflow vocabulary together</strong>
+            <p>
+              A reader usually understands UMA faster once capability, runtime, workflow, and discovery surface are seen as one cluster.
+              The reference app and the pages around it are designed to make that cluster legible. In the book, I extend that cluster into
+              a fuller explanation of how workflow approval stays governed as systems become more dynamic.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../what-makes-a-decision-discoverable/">What makes a decision discoverable?</a>
+              <a href="../what-is-wasm-mcp/">What is WASM MCP?</a>
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+              <a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/what-is-wasm-mcp.md
+++ b/content/pages/core-model/what-is-wasm-mcp.md
@@ -1,0 +1,208 @@
+---
+ref: what-is-wasm-mcp
+title: "What Is WASM MCP in UMA?"
+subtitle: "What is WASM MCP in UMA? In the UMA reference experience, WASM MCP is the discovery and invocation surface through which the runtime learns what capabilities are available. It matters because it makes capability availability explicit instead of hiding it inside custom integration code or one-off runtime assumptions when compute can happen in many places and the system needs a visible way to decide where logic runs."
+macro_area: core-model
+content_type: explainer
+slug: what-is-wasm-mcp
+canonical_url: "https://www.universalmicroservices.com/what-is-wasm-mcp/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "Learn what WASM MCP means in Universal Microservices Architecture and why it matters as a discoverable capability surface instead of a hidden integration layer."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "What Is WASM MCP in UMA?"
+related_refs:
+  - active-descriptors
+  - agent-vs-runtime
+  - late-bound-policy-enforcement
+  - what-belongs-in-the-runtime-layer
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What is WASM MCP in UMA?</h1>
+          <p>
+            In the UMA reference experience, <strong>WASM MCP</strong> is the discovery and invocation surface through which the runtime
+            learns what capabilities are available. It matters because it makes capability availability explicit instead of hiding it inside
+            custom integration code or one-off runtime assumptions when compute can happen in many places and the system needs a visible
+            way to decide where logic runs.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              WASM MCP is the capability-facing control surface in the Chapter 13 model. It exposes what capabilities exist, how they can
+              be described, and how the runtime can interact with them. That makes it easier for the runtime to discover, validate, and
+              compose work without hardwiring every path in advance.
+            </p>
+            <p>
+              The important point is not the acronym by itself. The important point is architectural: a modern system needs a visible,
+              inspectable way to surface capabilities if it wants runtime composition to stay governed instead of ad hoc.
+            </p>
+            <p>
+              This fits the same UMA summary as the rest of the site: not “write once, run everywhere,” but “write once, run where it
+              makes sense,” with discovery staying explicit instead of hidden.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why this layer exists</h2>
+            <p>
+              A runtime cannot compose workflows from capabilities it cannot see. In simpler systems, those capabilities are often hidden
+              behind internal calls, framework-specific bindings, or undocumented operational knowledge. That may work for a static path,
+              but it becomes weak as soon as discovery, ranking, or dynamic selection enters the picture.
+            </p>
+            <p>
+              WASM MCP exists in the UMA story to make that surface explicit. It tells the runtime what is available without forcing the
+              runtime to treat every capability as an opaque guess.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why it is not just another protocol page</h2>
+            <p>
+              This page is not trying to turn UMA into a protocol discussion. The key idea is not that one acronym is fashionable. The key
+              idea is that runtime discovery needs a real interface. If a system claims to compose work from capabilities dynamically, it
+              should be able to show how those capabilities are surfaced, described, and made available for runtime governance.
+            </p>
+            <p>
+              In that sense, WASM MCP is valuable because it keeps discovery visible. It gives the runtime a clear place to ask what is
+              available before the planner proposes or the runtime approves a path.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Discovery surface</h3>
+              <p>WASM MCP exposes capabilities so the runtime can inspect what exists before trying to build a workflow.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Invocation bridge</h3>
+              <p>It supports calling into capability providers through a visible, structured boundary instead of hidden glue code.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime support</h3>
+              <p>The runtime can pair capability discovery with compatibility checks, policy evaluation, and final approval.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Architectural evidence</h3>
+              <p>Readers can see where capability availability comes from instead of assuming the workflow path was magically known.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>How it fits with capability, planner, and runtime</h2>
+            <p>
+              The capability is the unit of behavior. The planner can help interpret the goal and rank possible paths. The runtime remains
+              authoritative over what is approved. WASM MCP sits earlier in that chain: it is the surface that makes available capabilities
+              visible to the rest of the system.
+            </p>
+            <p>
+              That is why it matters in the reference app. `WASM MCP` is not just a decorative box in the graph. It marks the point where
+              capability discovery becomes explicit and inspectable.
+            </p>
+          </section>
+
+          <section>
+            <h2>What problem it solves in practice</h2>
+            <p>
+              Without a discovery surface like this, teams often end up with dynamic behavior that is only dynamic inside implementation
+              code. The runtime “knows” about capabilities because somebody programmed a list, a registry, or a service map in one local
+              place. That makes the system harder to understand and harder to audit.
+            </p>
+            <p>
+              WASM MCP improves that by turning availability into something more explicit. The system can expose what exists, then let the
+              planner and runtime reason over that availability instead of operating on hidden assumptions.
+            </p>
+          </section>
+
+          <section>
+            <h2>A concrete proof point</h2>
+            <p>
+              In the reference app, the `WASM MCP` node matters because it shows where discovery begins. The runtime does not simply know
+              what to call. It sees available capabilities through an explicit surface, and that makes the rest of the workflow easier to
+              inspect and trust.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why this matters for SEO and reader understanding too</h2>
+            <p>
+              Readers who see `WASM MCP` in the live app or Chapter 13 CLI output will naturally ask what it means. If the site does not
+              answer that, the reference experience feels more advanced than it really is. This page exists to close that gap: it explains
+              the term at the architectural level instead of forcing the reader to reverse-engineer it from the demo.
+            </p>
+            <p>
+              That also makes the book more valuable, not less. The page explains the concept clearly enough for orientation, while the
+              book can still provide the fuller model and broader implications.
+            </p>
+          </section>
+
+          <section>
+            <h2>What WASM MCP is not</h2>
+            <ul>
+              <li>It is not the runtime itself.</li>
+              <li>It is not the capability itself.</li>
+              <li>It is not the planner.</li>
+              <li>It is not a substitute for runtime validation or trust enforcement.</li>
+              <li>It is not valuable just because it exists; it matters because it makes discovery explicit.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>A practical design test</h2>
+            <p>
+              If your system claims to support runtime composition, ask where the runtime learns what capabilities exist. If that answer is
+              hidden in internal code or tribal knowledge, the architecture still lacks a proper discovery story. A visible discovery
+              surface is one of the signals that the system is becoming more governable.
+            </p>
+            <p>
+              A second good question is whether a reader can point to the discovery layer separately from the planner and the runtime. If
+              those three roles blur together, the system becomes harder to explain.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is WASM MCP required for UMA?</h3>
+            <p>
+              No. UMA as an architectural model is larger than one discovery surface. But Chapter 13 uses WASM MCP because it is a strong
+              way to make capability discovery and invocation visible in a runtime-centered workflow.
+            </p>
+            <h3>Why not let the runtime keep an internal registry instead?</h3>
+            <p>
+              It can, but an explicit discovery surface is easier to inspect, explain, and evolve. It keeps capability availability from
+              becoming a hidden implementation detail.
+            </p>
+            <h3>Does WASM MCP replace runtime authority?</h3>
+            <p>
+              No. It helps expose what exists. The runtime still decides what is valid and what can actually run.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>See the full chain</strong>
+            <p>
+              The easiest way to understand WASM MCP is to place it beside the other UMA roles: capability, planner, runtime, and final
+              workflow. The live reference app and the concept pages around it make that chain visible step by step, while the book takes
+              the same discovery surface into the broader execution model behind it.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+              <a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/core-model/what-makes-a-decision-discoverable.md
+++ b/content/pages/core-model/what-makes-a-decision-discoverable.md
@@ -1,0 +1,170 @@
+---
+ref: what-makes-a-decision-discoverable
+title: "What Makes a Decision Discoverable?"
+subtitle: "What makes a decision discoverable? A decision becomes discoverable when the system can expose how it reached an outcome instead of only reporting that the outcome happened. In UMA, that means intent, authority, revision, execution, and trace all become first-class architectural surfaces."
+macro_area: core-model
+content_type: explainer
+slug: what-makes-a-decision-discoverable
+canonical_url: "https://www.universalmicroservices.com/what-makes-a-decision-discoverable/"
+left_nav_group: core-model
+chapter_ref: null
+seo_description: "Learn what makes a runtime decision discoverable in UMA: visible proposals, authoritative validation, bounded revision, approved execution, and traceable artifacts."
+breadcrumbs:
+  - "Home"
+  - "Core Model"
+  - "What Makes a Decision Discoverable?"
+related_refs:
+  - active-descriptors
+  - agent-vs-runtime
+  - late-bound-policy-enforcement
+  - what-belongs-in-the-runtime-layer
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What makes a decision discoverable?</h1>
+          <p>
+            A decision becomes discoverable when the system can expose how it reached an outcome instead of only reporting that the outcome
+            happened. In UMA, that means intent, authority, revision, execution, and trace all become first-class architectural surfaces.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              A discoverable decision is one a person or tool can inspect before and after execution. The system should be able to show the
+              proposal, the constraints it could not resolve locally, the authoritative validation response, the approved path, and the
+              resulting trace artifacts. Without those surfaces, a runtime may still work, but its decision model remains hidden.
+            </p>
+            <p>
+              This is the step where UMA moves from governed execution into understandable execution. It is not enough for the runtime to
+              know why something happened. The system has to make that reasoning legible.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why execution alone is not enough</h2>
+            <p>
+              Many systems can execute correctly while keeping the actual decision path buried inside code, logs, or implicit behavior. A
+              request succeeds, but no one can tell what alternatives were considered, what assumptions were made at the edge, which
+              constraints forced a revision, or why the final path was approved. The system acts, but it does not explain itself.
+            </p>
+            <p>
+              Discoverability matters because hidden decision paths turn architecture into folklore. Once the reasoning behind a runtime
+              outcome is no longer inspectable, teams have a much harder time reviewing changes, debugging surprising behavior, or safely
+              extending the system.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Projection is useful, not authoritative</h3>
+              <p>A local surface may expose likely capabilities and constraints, but it should not pretend it owns final approval.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Proposals should declare assumptions</h3>
+              <p>The system becomes easier to reason about when unresolved constraints stay explicit instead of being hidden in optimistic planning.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Validation should return guidance</h3>
+              <p>Authority is more useful when it explains why a proposal failed and what would make it valid.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Trace completes the story</h3>
+              <p>A successful execution is not fully discoverable until the approved path can be replayed as evidence afterward.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>What discoverability looks like in practice</h2>
+            <p>
+              A discoverable system usually reveals a ladder of decision surfaces. First it exposes a capability projection or local view of
+              the likely path. Then it emits a proposal that declares assumptions. Next, authority validates that proposal and returns
+              structured feedback. If revision is needed, the revision stays bounded and inspectable. Once approval happens, execution
+              follows the approved intent instead of silently replanning it. Finally, the trace shows enough evidence to explain the outcome
+              after the fact.
+            </p>
+            <p>
+              That ladder matters because it separates useful local reasoning from final authority. Edge planning can still be helpful, but
+              it becomes much safer when it no longer pretends to be the last word.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why bounded revision matters</h2>
+            <p>
+              Many systems become hard to understand because validation and planning collapse into endless negotiation. Each side keeps
+              revising the plan until execution finally happens, but no one can explain where the decisive authority really lived. UMA is
+              stronger when revision stays explicit and bounded.
+            </p>
+            <p>
+              Bounded revision keeps the architectural roles clearer. Proposal stays proposal. Validation stays authority. Execution stays
+              the resolution of approved intent, not a last-minute improvisation.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why trace artifacts matter more than logs</h2>
+            <p>
+              Logs are often chronological but not architectural. A trace artifact is stronger because it tells the decision story in terms
+              the model itself understands: what was proposed, what was rejected, what was revised, what was approved, and what executed.
+              That makes post-execution review much more practical.
+            </p>
+            <p>
+              The difference matters for trust, governance, and change review. Teams can audit logs forever and still miss the actual
+              architectural question. A structured trace turns the decision into something queryable instead of something merely recorded.
+            </p>
+          </section>
+
+          <section>
+            <h2>What makes a discoverable decision stronger than a hidden one</h2>
+            <ul>
+              <li>The system can distinguish proposal from approval.</li>
+              <li>Constraint failures are explicit enough to be acted on.</li>
+              <li>Revision is limited and inspectable instead of endless.</li>
+              <li>Execution resolves approved intent rather than silently changing it.</li>
+              <li>Trace artifacts make the final path understandable after the fact.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is discoverability the same as observability?</h3>
+            <p>
+              No. Observability helps you inspect runtime behavior. Discoverability is narrower and more architectural. It is about whether
+              the system exposes its decision path in a structured, queryable way.
+            </p>
+            <h3>Does every UMA system need the full decision ladder?</h3>
+            <p>
+              Not always. Smaller systems may not need explicit proposal and revision stages yet. The important part is that authority and
+              execution still remain visible once decision complexity starts to grow.
+            </p>
+            <h3>Why not just let the planner decide everything?</h3>
+            <p>
+              Because proposal usefulness and execution authority are not the same architectural role. When they blur together, systems may
+              look smart while becoming harder to govern.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Treat discoverability as an architectural property</strong>
+            <p>
+              This page names the structure. In the book, I take it further into runnable decision ladders so the difference between a
+              hidden execution and a queryable decision path becomes concrete. On the site, the best next move is to connect this page to
+              runtime authority, workflows, and the live reference application.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="../diagrams/">Diagrams</a>
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/discoverability/about-enrico.md
+++ b/content/pages/discoverability/about-enrico.md
@@ -1,0 +1,117 @@
+---
+ref: about-enrico
+title: "About Enrico Piovesan"
+subtitle: "About Enrico Piovesan Enrico Piovesan is a platform software architect with more than two decades of experience building modular, cloud-native, and event-driven systems. His work focuses on architectures that can scale technically without becoming harder for teams to reason about, operate, or evolve."
+macro_area: discoverability
+content_type: resource
+slug: about-enrico
+canonical_url: "https://www.universalmicroservices.com/about-enrico/"
+left_nav_group: discoverability
+chapter_ref: null
+seo_description: "About Enrico Piovesan, platform software architect, writer, and author of Universal Microservices Architecture."
+breadcrumbs:
+  - "Home"
+  - "Discoverability"
+  - "About Enrico Piovesan"
+related_refs:
+  - diagrams
+  - faq
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>About Enrico Piovesan</h1>
+          <p>
+            Enrico Piovesan is a platform software architect with more than two decades of experience building modular, cloud-native, and
+            event-driven systems. His work focuses on architectures that can scale technically without becoming harder for teams to reason
+            about, operate, or evolve.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>Architectural perspective</h2>
+            <p>
+              Universal Microservices Architecture comes from a practical concern: modern systems keep spreading across runtimes faster than
+              their architecture evolves. The result is often duplication, hidden dependencies, and governance that arrives too late. Enrico
+              writes from the perspective of someone trying to preserve architectural clarity under real product pressure rather than from a
+              distance from implementation.
+            </p>
+          </section>
+
+          <section>
+            <h2>Professional background</h2>
+            <p>
+              Enrico’s work spans modular systems, event-driven architecture, platform design, and developer experience. That mix matters
+              because Universal Microservices Architecture is not just a theory about service boundaries. It is also a response to the
+              operational and organizational costs of systems that grow faster than their architectural model.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Platform experience</h3>
+              <p>Long experience with distributed systems, modular design, and developer workflows informs the model behind UMA.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Product reality</h3>
+              <p>The architectural ideas are grounded in systems that must survive scaling pressure, delivery pressure, and team boundaries.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>System thinking</h3>
+              <p>The work is driven by the idea that software architecture should remain understandable as systems become more distributed.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Long-term durability</h3>
+              <p>The aim is not novelty for its own sake, but an architecture that lasts longer under change.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why this site exists</h2>
+            <p>
+              This site is the public hub for the book, the learning path, the examples, and the related writing. Medium remains the main
+              publication channel for long-form posts, while this site acts as the authority and navigation layer around the book and the
+              UMA model.
+            </p>
+            <p>
+              That division is intentional. Medium is where broad topic discovery happens. This site is where readers can connect the book,
+              the learning path, the examples, and the core architectural pages in one place.
+            </p>
+          </section>
+
+          <section>
+            <h2>What readers can expect here</h2>
+            <p>
+              Readers who arrive through the book or Medium should be able to understand what UMA is, why it exists, how the examples map to
+              the ideas, and where to go next. The site is meant to reduce friction, not add another layer of explanation without structure.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked question</h2>
+            <h3>Why separate the site from Medium?</h3>
+            <p>
+              Medium is the ongoing publication channel. The site is the stable authority hub for the book, the learning path, and the
+              examples. Keeping both allows discovery and conversion to support each other instead of competing.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Follow Enrico</strong>
+            <p>
+              You can find the broader writing, publication links, and social channels in the footer below, or continue through the book and
+              examples from here.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../book/">Book</a>
+              <a href="../examples/">Examples</a>
+              <a href="https://medium.com/the-rise-of-device-independent-architecture">Medium publication</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/discoverability/diagrams.md
+++ b/content/pages/discoverability/diagrams.md
@@ -1,0 +1,415 @@
+---
+ref: diagrams
+title: "UMA Diagrams"
+subtitle: "UMA diagrams This page collects reusable diagrams for Universal Microservices Architecture. Each section explains what the diagram is trying to make visible, when to use it, and how to adapt the underlying source for documentation, architecture reviews, and implementation discussions."
+macro_area: discoverability
+content_type: resource
+slug: diagrams
+canonical_url: "https://www.universalmicroservices.com/diagrams/"
+left_nav_group: discoverability
+chapter_ref: null
+seo_description: "Structured UMA diagrams for service boundaries, runtime flow, trust decisions, service graph evolution, governed evolution without fragmentation, and discoverable decision lifecycles."
+breadcrumbs:
+  - "Home"
+  - "Discoverability"
+  - "UMA Diagrams"
+related_refs:
+  - about-enrico
+  - faq
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>UMA diagrams</h1>
+          <p>
+            This page collects reusable diagrams for Universal Microservices Architecture. Each section explains what the diagram is trying
+            to make visible, when to use it, and how to adapt the underlying source for documentation, architecture reviews, and
+            implementation discussions.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>Why diagram curation matters</h2>
+            <p>
+              UMA depends on architectural visibility. The more clearly a team can show service boundaries, runtime transitions, trust
+              decisions, and compatibility relationships, the easier the model is to teach, review, and evolve. These diagrams are designed
+              to clarify one important boundary at a time instead of collapsing the whole architecture into one poster.
+            </p>
+            <p>
+              A useful UMA diagram should answer one concrete question. What is portable and what is runtime-owned? Where is a trust
+              boundary enforced? How does a graph of compatible services emerge over time? When the question is specific, the diagram stays
+              readable and reusable.
+            </p>
+          </section>
+
+          <section>
+            <h2>Diagram conventions</h2>
+            <p>
+              The diagrams on this page reuse the same conventions so readers do not need to learn a new visual language each time. Portable
+              service behavior is highlighted as the part that must remain stable. Runtime-owned elements are shown separately so transport,
+              policy, validation, and adapter decisions do not disappear into the background. Supporting metadata is shown as its own layer
+              whenever it shapes compatibility or governance.
+            </p>
+            <ul>
+              <li>Portable service behavior is the durable center of the model.</li>
+              <li>Runtime shells, adapters, and policy decisions stay explicit.</li>
+              <li>Trust transitions are shown before a protected capability executes.</li>
+              <li>Graphs evolve through visible contracts and metadata, not hidden rewiring.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Diagram 1: Portable service boundary</h2>
+            <p>
+              This diagram shows the core UMA split between pure service behavior and the runtime shell that validates input, binds adapters,
+              and decides where execution happens. The point is to make the portable unit of behavior explicit instead of burying it inside a
+              stack-specific application boundary.
+            </p>
+            <p class="diagram-caption">
+              Caption: The service stays portable and deterministic. The runtime owns validation, transport, policy, and adapter binding.
+            </p>
+            <div class="diagram-render">
+              <pre class="mermaid">flowchart LR
+    Client["Client / Caller"] --> Runtime["Runtime shell"]
+    Runtime --> Contract["Contract validation"]
+    Contract --> Service["Portable UMA service"]
+    Service --> Output["Deterministic result"]
+    Runtime --> Adapters["Adapters / host capabilities"]
+    Adapters --> Output
+
+    classDef portable fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef runtime fill:#0d0d0d,stroke:#4a4a4a,color:#ffffff;
+
+    class Service portable;
+    class Runtime,Contract,Adapters runtime;</pre>
+            </div>
+            <p>
+              Use this diagram when a reader needs to understand the most important UMA boundary first: what belongs inside the portable
+              service and what belongs in the runtime shell around it. It works well on introductory pages, capability documentation, and
+              design reviews where teams are still separating business behavior from environment-specific concerns.
+            </p>
+            <details class="diagram-source">
+              <summary>View diagram source</summary>
+              <pre class="diagram-code"><code>flowchart LR
+    Client["Client / Caller"] --> Runtime["Runtime shell"]
+    Runtime --> Contract["Contract validation"]
+    Contract --> Service["Portable UMA service"]
+    Service --> Output["Deterministic result"]
+    Runtime --> Adapters["Adapters / host capabilities"]
+    Adapters --> Output
+
+    classDef portable fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef runtime fill:#0d0d0d,stroke:#4a4a4a,color:#ffffff;
+
+    class Service portable;
+    class Runtime,Contract,Adapters runtime;</code></pre>
+              <a class="diagram-download" href="./portable-service-boundary.mmd" download>Download source</a>
+            </details>
+          </section>
+
+          <section>
+            <h2>Diagram 2: Runtime execution flow</h2>
+            <p>
+              UMA is not only about where behavior lives. It is also about how the runtime executes that behavior predictably. This sequence
+              shows the flow from request to validation, service execution, adapter access, and final response without hiding the runtime
+              decisions that shape the outcome.
+            </p>
+            <p class="diagram-caption">
+              Caption: The runtime remains visible. Validation and adapter binding are first-class parts of the execution model.
+            </p>
+            <div class="diagram-render">
+              <pre class="mermaid">sequenceDiagram
+    participant Caller
+    participant Runtime
+    participant Service
+    participant Adapter
+
+    Caller->>Runtime: Invoke capability
+    Runtime->>Runtime: Validate against contract
+    Runtime->>Service: Execute portable logic
+    Service->>Adapter: Request host capability
+    Adapter-->>Service: Return external data
+    Service-->>Runtime: Produce result
+    Runtime-->>Caller: Return validated response</pre>
+            </div>
+            <p>
+              Use this diagram when the architectural question is about execution rather than boundaries. It shows that a UMA runtime is not
+              a black box around the service. Validation, adapter access, and response shaping are visible stages that determine whether the
+              system behaves predictably across environments.
+            </p>
+            <details class="diagram-source">
+              <summary>View diagram source</summary>
+              <pre class="diagram-code"><code>sequenceDiagram
+    participant Caller
+    participant Runtime
+    participant Service
+    participant Adapter
+
+    Caller->>Runtime: Invoke capability
+    Runtime->>Runtime: Validate against contract
+    Runtime->>Service: Execute portable logic
+    Service->>Adapter: Request host capability
+    Adapter-->>Service: Return external data
+    Service-->>Runtime: Produce result
+    Runtime-->>Caller: Return validated response</code></pre>
+              <a class="diagram-download" href="./runtime-execution-flow.mmd" download>Download source</a>
+            </details>
+          </section>
+
+          <section>
+            <h2>Diagram 3: Trust boundary decision</h2>
+            <p>
+              Trust decisions in UMA should not be implicit. This diagram shows a simplified runtime trust flow where identity, policy, and
+              capability intent are evaluated before the runtime allows a protected service to execute. It is a useful pattern for pages that
+              explain trust boundaries and governed execution.
+            </p>
+            <p class="diagram-caption">
+              Caption: Access is not assumed. The runtime evaluates identity and policy before crossing a protected boundary.
+            </p>
+            <div class="diagram-render">
+              <pre class="mermaid">flowchart TD
+    Request["Invocation request"] --> Identity["Resolve identity"]
+    Identity --> Policy["Evaluate policy"]
+    Policy -->|allowed| Capability["Protected capability"]
+    Policy -->|denied| Rejected["Denied decision"]
+    Capability --> Audit["Audit / evidence"]
+
+    classDef allow fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef deny fill:#151515,stroke:#666666,color:#ffffff;
+
+    class Capability,Audit allow;
+    class Rejected deny;</pre>
+            </div>
+            <p>
+              Use this diagram when readers need to see where governance happens. UMA is stronger when trust, identity, permissions, and
+              audit evidence stay visible. This pattern works well for security-oriented pages, policy discussions, and runtime trust
+              documentation where the system must explain why a protected capability was allowed or denied.
+            </p>
+            <details class="diagram-source">
+              <summary>View diagram source</summary>
+              <pre class="diagram-code"><code>flowchart TD
+    Request["Invocation request"] --> Identity["Resolve identity"]
+    Identity --> Policy["Evaluate policy"]
+    Policy -->|allowed| Capability["Protected capability"]
+    Policy -->|denied| Rejected["Denied decision"]
+    Capability --> Audit["Audit / evidence"]
+
+    classDef allow fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef deny fill:#151515,stroke:#666666,color:#ffffff;
+
+    class Capability,Audit allow;
+    class Rejected deny;</code></pre>
+              <a class="diagram-download" href="./trust-boundary-decision.mmd" download>Download source</a>
+            </details>
+          </section>
+
+          <section>
+            <h2>Diagram 4: Service graph evolution</h2>
+            <p>
+              Once systems grow beyond one portable service, teams need to visualize how compatible capabilities form a graph. This diagram
+              shows a simple evolution path from a single service to a governed graph, where contracts and metadata keep relationships
+              understandable instead of turning into hidden rewiring.
+            </p>
+            <p class="diagram-caption">
+              Caption: Services evolve into a graph through visible contracts and metadata, not through accidental coupling.
+            </p>
+            <div class="diagram-render">
+              <pre class="mermaid">flowchart LR
+    A["Feature flag evaluator"] --> B["Post fetcher runtime"]
+    B --> C["Metadata orchestration"]
+    C --> D["Service graph"]
+    D --> E["Trust boundaries"]
+    E --> F["System evolution"]
+
+    Meta["Contracts + metadata"] --- C
+    Meta --- D
+    Meta --- E
+
+    classDef main fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef meta fill:#0d0d0d,stroke:#4a4a4a,color:#ffffff;
+
+    class A,B,C,D,E,F main;
+    class Meta meta;</pre>
+            </div>
+            <p>
+              Use this diagram when the conversation moves from one portable service to a broader system. It helps explain how compatible
+              services, metadata, and policy start to form a graph that can change over time without becoming opaque. It is especially
+              useful on pages about growth, compatibility, and runtime-governed evolution.
+            </p>
+            <details class="diagram-source">
+              <summary>View diagram source</summary>
+              <pre class="diagram-code"><code>flowchart LR
+    A["Feature flag evaluator"] --> B["Post fetcher runtime"]
+    B --> C["Metadata orchestration"]
+    C --> D["Service graph"]
+    D --> E["Trust boundaries"]
+    E --> F["System evolution"]
+
+    Meta["Contracts + metadata"] --- C
+    Meta --- D
+    Meta --- E
+
+    classDef main fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef meta fill:#0d0d0d,stroke:#4a4a4a,color:#ffffff;
+
+    class A,B,C,D,E,F main;
+    class Meta meta;</code></pre>
+              <a class="diagram-download" href="./service-graph-evolution.mmd" download>Download source</a>
+            </details>
+          </section>
+
+          <section>
+            <h2>Diagram 5: Evolution without fragmentation</h2>
+            <p>
+              This diagram captures a progression many teams recognize but rarely name clearly. One contract anchor stretches into
+              behavioral drift, drift leads to duplication, duplication hardens into version sprawl, and then the architecture either
+              fragments or learns how to govern coexistence explicitly.
+            </p>
+            <p class="diagram-caption">
+              Caption: Governed evolution is not the absence of change. It is change that remains explainable through contracts and runtime
+              authority.
+            </p>
+            <div class="diagram-render">
+              <pre class="mermaid">flowchart LR
+    A["Contract anchor"] --> B["Behavioral drift"]
+    B --> C["Duplicate implementations"]
+    C --> D["Version sprawl"]
+    D --> E["Runtime-governed coexistence"]
+    E --> F["Hybrid adoption"]
+
+    classDef stable fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef risk fill:#151515,stroke:#ff8a3d,color:#ffffff;
+    classDef governed fill:#151515,stroke:#4bd37b,color:#ffffff;
+
+    class A stable;
+    class B,C,D risk;
+    class E,F governed;</pre>
+            </div>
+            <p>
+              Use this diagram when the architectural question is about long-term change rather than static structure. It helps teams talk
+              about which stage of evolution they are actually in, why versioning alone does not prevent fragmentation, and how
+              runtime-governed coexistence creates room for brownfield improvement.
+            </p>
+            <details class="diagram-source">
+              <summary>View diagram source</summary>
+              <pre class="diagram-code"><code>flowchart LR
+    A["Contract anchor"] --> B["Behavioral drift"]
+    B --> C["Duplicate implementations"]
+    C --> D["Version sprawl"]
+    D --> E["Runtime-governed coexistence"]
+    E --> F["Hybrid adoption"]
+
+    classDef stable fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef risk fill:#151515,stroke:#ff8a3d,color:#ffffff;
+    classDef governed fill:#151515,stroke:#4bd37b,color:#ffffff;
+
+    class A stable;
+    class B,C,D risk;
+    class E,F governed;</code></pre>
+              <a class="diagram-download" href="./evolution-without-fragmentation.mmd" download>Download source</a>
+            </details>
+          </section>
+
+          <section>
+            <h2>Diagram 6: Discoverable decision lifecycle</h2>
+            <p>
+              This diagram shows the decision ladder that becomes a first-class architectural topic in the later UMA examples.
+              Discoverability is not only about surfacing which capabilities exist. It is about surfacing how a projected path became a
+              proposal, how authority validated it, where revision was allowed, and what trace remained afterward.
+            </p>
+            <p class="diagram-caption">
+              Caption: A discoverable system does not only execute. It exposes how an outcome moved from proposal to authoritative trace.
+            </p>
+            <div class="diagram-render">
+              <pre class="mermaid">flowchart LR
+    A["Capability projection"] --> B["Proposal"]
+    B --> C["Authority validation"]
+    C --> D["Bounded revision"]
+    D --> E["Approved execution"]
+    E --> F["Queryable trace"]
+
+    classDef visible fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef authority fill:#151515,stroke:#4bd37b,color:#ffffff;
+
+    class A,B,D,F visible;
+    class C,E authority;</pre>
+            </div>
+            <p>
+              Use this diagram when the conversation is about queryable decisions instead of only runtime control. It works especially well
+              on pages about workflows, runtime authority, and the reference application, where execution alone is not the final
+              architectural product.
+            </p>
+            <details class="diagram-source">
+              <summary>View diagram source</summary>
+              <pre class="diagram-code"><code>flowchart LR
+    A["Capability projection"] --> B["Proposal"]
+    B --> C["Authority validation"]
+    C --> D["Bounded revision"]
+    D --> E["Approved execution"]
+    E --> F["Queryable trace"]
+
+    classDef visible fill:#151515,stroke:#ffc501,color:#ffffff;
+    classDef authority fill:#151515,stroke:#4bd37b,color:#ffffff;
+
+    class A,B,D,F visible;
+    class C,E authority;</code></pre>
+              <a class="diagram-download" href="./discoverable-decision-lifecycle.mmd" download>Download source</a>
+            </details>
+          </section>
+
+          <section>
+            <h2>How to choose the right diagram</h2>
+            <p>
+              Use the service boundary diagram when the question is about separation of concerns. Use the execution flow when the question is
+              about what a runtime actually does. Use the trust diagram when readers need to see where permissions and policy are enforced.
+              Use the graph evolution diagram when the system story is about growth, compatibility, and governed change. Use the evolution
+              without fragmentation diagram when the story is specifically about drift, duplication, version sprawl, and governed
+              coexistence. Use the discoverable decision lifecycle when the story is about how a proposal becomes an approved and traceable
+              outcome.
+            </p>
+            <p>
+              These diagrams should support the prose on this site, not replace it. The right use is to put one of them next to a paragraph
+              that answers a specific question in plain language. That makes the visual reinforce the explanation instead of competing with
+              it.
+            </p>
+          </section>
+
+          <section>
+            <h2>Download the current diagram set</h2>
+            <p>
+              Every diagram on this page has a downloadable source file so the same visual models can move into repository documentation,
+              issue discussions, architecture notes, and future chapter pages. That keeps the diagrams reusable and versionable instead of
+              trapped inside static screenshots.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="./portable-service-boundary.mmd" download>Portable service boundary</a>
+              <a href="./runtime-execution-flow.mmd" download>Runtime execution flow</a>
+              <a href="./trust-boundary-decision.mmd" download>Trust boundary decision</a>
+              <a href="./service-graph-evolution.mmd" download>Service graph evolution</a>
+              <a href="./evolution-without-fragmentation.mmd" download>Evolution without fragmentation</a>
+              <a href="./discoverable-decision-lifecycle.mmd" download>Discoverable decision lifecycle</a>
+            </div>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Where these diagrams connect next</strong>
+            <p>
+              The strongest next uses for these diagrams are the pages that explain service graphs, runtime trust decisions, portability,
+              and the learning path from one portable service to governed system evolution.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../service-graph-evolution/">Service graph evolution</a>
+              <a href="../how-systems-evolve-without-fragmentation/">How systems evolve without fragmentation</a>
+              <a href="../what-makes-a-decision-discoverable/">What makes a decision discoverable?</a>
+              <a href="../trust-boundaries/">Trust boundaries</a>
+              <a href="../learning-path/">Learning path</a>
+              <a href="../portable-business-logic/">Portable business logic</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/discoverability/faq.md
+++ b/content/pages/discoverability/faq.md
@@ -1,0 +1,307 @@
+---
+ref: faq
+title: "UMA FAQ"
+subtitle: "Universal Microservices Architecture FAQ This FAQ is meant to be maintained over time as the site, examples, and book evolve. It collects short, direct answers to the questions that come up most often when people first encounter UMA and want to understand how the model behaves in practice. The shortest framing to keep in mind is this: UMA is an execution model for distributed systems where compute can happen in many places and the system decides where logic runs."
+macro_area: discoverability
+content_type: resource
+slug: faq
+canonical_url: "https://www.universalmicroservices.com/faq/"
+left_nav_group: discoverability
+chapter_ref: null
+seo_description: "Frequently asked questions about Universal Microservices Architecture, including portability, WebAssembly, runtime governance, trust boundaries, and examples."
+breadcrumbs:
+  - "Home"
+  - "Discoverability"
+  - "UMA FAQ"
+related_refs:
+  - about-enrico
+  - diagrams
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Universal Microservices Architecture FAQ</h1>
+          <p>
+            This FAQ is meant to be maintained over time as the site, examples, and book evolve. It collects short, direct answers to the
+            questions that come up most often when people first encounter UMA and want to understand how the model behaves in practice.
+          </p>
+          <p>
+            The shortest framing to keep in mind is this: UMA is an execution model for distributed systems where compute can happen in
+            many places and the system decides where logic runs.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>Foundations</h2>
+            <h3>What is Universal Microservices Architecture?</h3>
+            <p>
+              Universal Microservices Architecture is an execution model for distributed systems where compute can happen in many places
+              and the system decides where logic runs. It keeps service behavior portable while making contracts, runtime policy, trust,
+              and execution boundaries explicit.
+            </p>
+            <h3>Why does UMA exist?</h3>
+            <p>
+              UMA exists because modern systems increasingly duplicate the same business logic across many runtime surfaces. That duplication
+              creates drift, inconsistent outcomes, and hidden architecture. UMA addresses that by preserving one portable expression of the
+              behavior and surrounding it with explicit runtime governance.
+            </p>
+            <h3>What problem does UMA solve that good platform tooling still leaves behind?</h3>
+            <p>
+              UMA solves a different problem from deployment tooling alone. Platforms can schedule, route, and observe workloads well, but
+              they do not automatically keep one business behavior coherent across browser, edge, backend, workflow, and AI-assisted
+              execution surfaces. UMA is meant to close that architectural gap.
+            </p>
+            <p>
+              The dedicated <a href="../what-problem-does-uma-solve/">what problem does UMA solve?</a> page is the fastest entry point if
+              you want the direct version of that argument before the wider concept cluster.
+            </p>
+            <h3>What is the difference between stack ownership and behavior ownership?</h3>
+            <p>
+              Stack ownership organizes software around runtime or team boundaries. Behavior ownership organizes it around the durable rule
+              or domain meaning that must survive across those boundaries. UMA pushes toward the second view.
+            </p>
+            <h3>What does runtime-agnostic architecture actually mean?</h3>
+            <p>
+              It means the service behavior can stay semantically stable while the runtime around it changes. Validation, transport,
+              placement, identity, permissions, and trust still matter, but they stop being the place where the business meaning of the
+              service is quietly rewritten.
+            </p>
+            <p>
+              The useful shorthand is not “write once, run everywhere.” It is “write once, run where it makes sense.”
+            </p>
+            <p>
+              The dedicated <a href="../runtime-agnostic-architecture/">runtime-agnostic architecture</a> page goes deeper into that
+              distinction and why it matters for modern systems that span browser, edge, backend, and workflow execution surfaces.
+            </p>
+            <h3>How is UMA different from traditional microservices?</h3>
+            <p>
+              Traditional microservices usually focus on deployable units, service ownership, and networked boundaries. UMA focuses on a
+              different question: can the same business behavior remain stable while the execution context changes? That leads to a stronger
+              emphasis on portability, contracts, runtime visibility, and long-term system coherence.
+            </p>
+            <p>
+              If you want the longer version of that comparison, the dedicated
+              <a href="../uma-vs-traditional-microservices/">UMA vs traditional microservices</a> page goes deeper without flattening the
+              distinction into a slogan.
+            </p>
+            <h3>Does UMA replace frontend and backend architecture?</h3>
+            <p>
+              No. UMA does not erase frontend, backend, edge, or cloud concerns. It gives teams a different way to place business behavior
+              inside those environments. The important shift is that service meaning is no longer tightly bound to one stack.
+            </p>
+          </section>
+
+          <section>
+            <h2>Runtime and execution</h2>
+            <h3>Is UMA only about WebAssembly?</h3>
+            <p>
+              No. WebAssembly is a strong fit because it gives portable behavior a practical execution boundary, but the larger subject is
+              architectural coherence across runtimes. UMA is about service meaning, contracts, runtime visibility, and system evolution.
+            </p>
+            <h3>Why does WebAssembly matter here?</h3>
+            <p>
+              WebAssembly matters because it gives portable service behavior a compact, sandboxed execution target that is easier to move
+              between environments. It does not define the whole model by itself, but it makes runtime portability more practical.
+            </p>
+            <h3>What belongs in the runtime layer?</h3>
+            <p>
+              The runtime layer owns the concerns around the service rather than the core behavior inside it. Validation, policy decisions,
+              adapter binding, host capability access, transport, observability, and trust enforcement belong in the runtime because they
+              vary by environment.
+            </p>
+            <h3>How do I prove portability instead of assuming it?</h3>
+            <p>
+              Portability should be validated with evidence. Run the same service behavior in more than one runtime target, compare the
+              outputs, and inspect the surrounding runtime behavior that shapes the result. The examples on this site are designed to make
+              that proof visible instead of leaving it implicit.
+            </p>
+            <p>
+              The <a href="../how-to-prove-portability/">how to prove portability</a> page turns that answer into a more concrete checklist
+              based on observable parity and explicit runtime differences.
+            </p>
+            <h3>Do the UMA examples publish any benchmark or footprint data?</h3>
+            <p>
+              Yes. The site now includes benchmark and footprint notes for selected early chapters so readers can inspect artifact size,
+              repeated timing data, and the exact local environment used to generate them. The point is not to claim one universal winner.
+              It is to show the tradeoff honestly and make the portability claim inspectable.
+            </p>
+            <p>
+              The <a href="../benchmark-and-footprint/">benchmark and footprint notes</a> page is the best place to start if you want
+              measured proof before reading deeper into the model.
+            </p>
+            <h3>What should happen when compatibility breaks in a UMA service graph?</h3>
+            <p>
+              The break should remain visible. Missing edges, waiting consumers, or failed compatibility checks are healthier than a system
+              that quietly hides the problem, because they make graph drift inspectable and easier to repair.
+            </p>
+            <p>
+              The <a href="../service-graph-evolution/">service graph evolution</a> page now covers that failure-and-recovery angle more
+              directly.
+            </p>
+            <h3>Can a UMA system work and still be architecturally incoherent?</h3>
+            <p>
+              Yes. A system can still produce the expected result while degrading through over-granular boundaries, vague event semantics,
+              runtime ambiguity, or orchestration that makes the architecture harder to explain than the output suggests.
+            </p>
+            <p>
+              The <a href="../what-makes-a-system-coherent/">what makes a system coherent?</a> page isolates that distinction directly.
+            </p>
+            <h3>How can a system evolve without fragmentation?</h3>
+            <p>
+              By keeping change anchored to explicit behavior, visible compatibility, and governed coexistence. Drift does not always mean
+              a rewrite is next, but it does mean the system needs a clear authority for deciding which behavior is still valid.
+            </p>
+            <p>
+              The <a href="../how-systems-evolve-without-fragmentation/">how systems evolve without fragmentation</a> page follows that
+              progression from contract anchor through drift, duplication, version sprawl, and runtime-governed recovery.
+            </p>
+          </section>
+
+          <section>
+            <h2>Governance and trust</h2>
+            <h3>Where do trust boundaries live in UMA?</h3>
+            <p>
+              Trust boundaries live in the runtime and governance layer around the portable service. Identity resolution, permissions,
+              provenance, policy evaluation, and audit evidence should stay visible there rather than being hidden inside business logic.
+            </p>
+            <h3>Can a service be valid and still be denied in UMA?</h3>
+            <p>
+              Yes. A service can be syntactically valid and still be denied because it requested undeclared permissions, carries untrusted
+              dependency provenance, or attempts communication the runtime trust policy does not allow.
+            </p>
+            <p>
+              The <a href="../trust-boundaries/">trust boundaries</a> page now covers that distinction more directly, including why
+              compatibility alone is not the same thing as authorization.
+            </p>
+            <h3>What is the difference between an agent and the runtime in UMA?</h3>
+            <p>
+              The agent is the reasoning side of the system. It can interpret a goal, inspect available capabilities, and propose a path.
+              The runtime is the authority side of the system. It validates contracts, enforces constraints, and decides what is actually
+              allowed to execute.
+            </p>
+            <h3>What is a capability in UMA?</h3>
+            <p>
+              A capability is the unit the runtime can discover and reason about. It represents a named piece of behavior with a visible
+              contract and enough meaning for the runtime to validate, select, reject, or compose into a workflow.
+            </p>
+            <h3>What makes a service portable in UMA?</h3>
+            <p>
+              A service becomes portable when its business behavior stays stable, its contract remains explicit, its outputs stay
+              comparable across runtimes, and the runtime-specific concerns around it do not quietly redefine the rule itself.
+            </p>
+            <p>
+              The <a href="../what-makes-a-service-portable/">what makes a service portable?</a> page turns that into a practical design
+              test instead of leaving portability as a vague promise.
+            </p>
+            <h3>What is a workflow in UMA?</h3>
+            <p>
+              A workflow is the path the runtime approves from one or more capabilities in order to satisfy a goal. It is visible enough
+              for the system to explain why that path was chosen.
+            </p>
+            <h3>What is contract-driven orchestration?</h3>
+            <p>
+              Contract-driven orchestration means the runtime creates the execution path from declared events, subscriptions, metadata, and
+              policy instead of burying the flow inside handwritten workflow glue. That makes orchestration much easier to govern and audit.
+            </p>
+            <p>
+              The <a href="../contract-driven-orchestration/">contract-driven orchestration</a> page goes deeper into why that distinction
+              matters once systems start emitting events and binding subscribers dynamically.
+            </p>
+            <h3>What is a UMA runtime?</h3>
+            <p>
+              A UMA runtime is the governed layer around portable behavior. It discovers capabilities, checks compatibility and
+              constraints, approves the valid execution path, and keeps enough evidence for the result to remain explainable afterward.
+            </p>
+            <h3>What makes a decision discoverable in UMA?</h3>
+            <p>
+              A decision becomes discoverable when proposal, validation, revision, approved execution, and trace remain inspectable as
+              artifacts instead of collapsing into one opaque runtime result.
+            </p>
+            <p>
+              The <a href="../what-makes-a-decision-discoverable/">what makes a decision discoverable?</a> page turns that into a concrete
+              lifecycle.
+            </p>
+            <h3>What belongs in the runtime layer?</h3>
+            <p>
+              The runtime layer should own validation, adapter binding, policy, trust, lifecycle evidence, and the conditions around
+              execution that vary by environment. The service should keep the durable rule; the runtime should keep the governed execution
+              context around it.
+            </p>
+            <p>
+              The dedicated <a href="../what-belongs-in-the-runtime-layer/">what belongs in the runtime layer?</a> page turns that split
+              into a practical design question instead of leaving it as a slogan.
+            </p>
+            <h3>What is WASM MCP in UMA?</h3>
+            <p>
+              WASM MCP is the discovery and invocation surface the runtime can use to understand which capabilities are available. It makes
+              capability availability more explicit instead of leaving it buried inside implementation code.
+            </p>
+            <h3>What does governed execution mean?</h3>
+            <p>
+              Governed execution means that the runtime can explain why a capability was allowed, denied, routed, or adapted in a specific
+              way. The point is not only to run code, but to keep the decisions around that execution understandable and reviewable.
+            </p>
+            <h3>Can UMA support enterprise systems?</h3>
+            <p>
+              Yes. In fact, UMA is most relevant when systems have to survive scale, multiple runtimes, organizational boundaries, and long
+              product lifecycles. That is where hidden drift and runtime ambiguity become expensive, and where clearer contracts and
+              boundaries matter most.
+            </p>
+          </section>
+
+          <section>
+            <h2>Adoption and learning path</h2>
+            <h3>Do I need to adopt UMA all at once?</h3>
+            <p>
+              No. The model can start with a single portable service and then expand as runtime, orchestration, trust, and governance
+              concerns become more important. That is also how the book and examples are structured.
+            </p>
+            <h3>Who is UMA for?</h3>
+            <p>
+              UMA is most useful for architects, senior engineers, platform engineers, and technical leads who need a more durable way to
+              reason about systems that cross runtime boundaries and long product lifecycles.
+            </p>
+            <h3>Where should I start?</h3>
+            <p>
+              Start with the <a href="../what-is-uma/">What is UMA?</a> page if you want the conceptual definition. Start with the
+              <a href="../learning-path/">Learning Path</a> if you want the chapter sequence. Start with the
+              <a href="../examples/">Examples</a> page if you want runnable proof immediately.
+            </p>
+            <h3>Do I need to move away from Medium to use this site?</h3>
+            <p>
+              No. Medium can remain the publishing channel while this site acts as the authority hub for the book, examples, topic pages,
+              and the reader journey. The two properties can support each other instead of competing.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>This page will keep growing</strong>
+            <p>
+              This FAQ is meant to be maintained over time. As the site grows and new chapter pages are added, the recurring questions from
+              readers, Medium posts, and the repository should feed back into this page so it stays useful as a quick-reference layer.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-is-uma/">What is UMA?</a>
+              <a href="../what-problem-does-uma-solve/">What problem does UMA solve?</a>
+              <a href="../from-stack-ownership-to-behavior-ownership/">From stack ownership to behavior ownership</a>
+              <a href="../uma-vs-traditional-microservices/">UMA vs traditional microservices</a>
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../contract-driven-orchestration/">Contract-driven orchestration</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../what-belongs-in-the-runtime-layer/">What belongs in the runtime layer?</a>
+              <a href="../what-is-wasm-mcp/">What is WASM MCP?</a>
+              <a href="../learning-path/">Learning Path</a>
+              <a href="../examples/">Examples</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="../diagrams/">Diagrams</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/evolve-uma/ai-native-runtime-governance.md
+++ b/content/pages/evolve-uma/ai-native-runtime-governance.md
@@ -1,0 +1,35 @@
+---
+ref: ai-native-runtime-governance
+title: "AI-Native Runtime Governance in UMA"
+subtitle: "AI-native runtime governance UMA does not make the agent the authority. It lets AI propose, summarize, rank, or assist, while the runtime validates what is allowed and leaves an inspectable trail."
+macro_area: evolve-uma
+content_type: walkthrough
+slug: ai-native-runtime-governance
+canonical_url: "https://www.universalmicroservices.com/ai-native-runtime-governance/"
+left_nav_group: evolve-uma
+chapter_ref: null
+seo_description: "Learn how UMA lets AI participate in workflow proposals while the runtime remains authoritative, explainable, and traceable."
+breadcrumbs:
+  - "Home"
+  - "Evolve Uma"
+  - "AI-Native Runtime Governance in UMA"
+related_refs:
+  - contract-driven-orchestration
+  - how-systems-evolve-without-fragmentation
+  - runtime-provenance-and-trust
+  - service-graph-evolution
+---
+
+## intro
+
+<section class="subpage-hero"><h1>AI-native runtime governance</h1><p>UMA does not make the agent the authority. It lets AI propose, summarize, rank, or assist, while the runtime validates what is allowed and leaves an inspectable trail.</p></section>
+
+## main
+
+<div class="subpage-body">
+          <section><h2>The boundary that matters</h2><p>AI-native systems become risky when proposals, validation, execution, and authority collapse into one opaque step. UMA keeps those stages visible: a planner can propose, but runtime policy still decides what can run.</p><p>That is the difference between an AI-assisted workflow and an AI-owned architecture.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>Proposal</h3><p>The agent can suggest a path or choose among candidates.</p></article><article class="subpage-card"><h3>Validation</h3><p>The runtime checks constraints, authority, placement, and capability compatibility.</p></article><article class="subpage-card"><h3>Execution</h3><p>Approved intent resolves into concrete runtime steps.</p></article><article class="subpage-card"><h3>Trace</h3><p>The final result should explain the path, not hide it.</p></article></section>
+          <section><h2>Why this supports book conversion</h2><p>This page gives enough to understand the distinction. The complete argument lives in Chapters 12 and 13, where discoverable decisions and the portable MCP runtime turn the boundary into runnable behavior.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 12 explains the proposal, validation, revision, execution, and trace ladder. Chapter 13 shows AI participation inside the portable MCP runtime.</p><div class="subpage-inline-links"><a href="../agent-vs-runtime/">Agent vs runtime</a><a href="../examples/chapter-12-discoverable-decisions/">Chapter 12 example</a><a href="../examples/chapter-13-portable-mcp-runtime/">Chapter 13 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/evolve-uma/contract-driven-orchestration.md
+++ b/content/pages/evolve-uma/contract-driven-orchestration.md
@@ -1,0 +1,181 @@
+---
+ref: contract-driven-orchestration
+title: "Contract-Driven Orchestration"
+subtitle: "Contract-driven orchestration In UMA, orchestration becomes more durable when it emerges from contracts, events, metadata, and policy instead of being embedded as hidden workflow glue. That makes the system easier to govern and much easier to explain."
+macro_area: evolve-uma
+content_type: walkthrough
+slug: contract-driven-orchestration
+canonical_url: "https://www.universalmicroservices.com/contract-driven-orchestration/"
+left_nav_group: evolve-uma
+chapter_ref: null
+seo_description: "Learn how contract-driven orchestration works in UMA, where events, policies, and metadata shape execution without hardcoded workflow glue."
+breadcrumbs:
+  - "Home"
+  - "Evolve Uma"
+  - "Contract-Driven Orchestration"
+related_refs:
+  - ai-native-runtime-governance
+  - how-systems-evolve-without-fragmentation
+  - runtime-provenance-and-trust
+  - service-graph-evolution
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Contract-driven orchestration</h1>
+          <p>
+            In UMA, orchestration becomes more durable when it emerges from contracts, events, metadata, and policy instead of being
+            embedded as hidden workflow glue. That makes the system easier to govern and much easier to explain.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              Contract-driven orchestration means the runtime uses declared event and capability relationships to create the execution path,
+              rather than relying on a hand-wired chain of process calls. The contracts describe what can emit, what can subscribe, and
+              what conditions apply. The runtime turns that into governed behavior.
+            </p>
+            <p>
+              This matters because orchestration is where systems often become opaque. The moment the flow is buried in custom glue,
+              teams lose visibility into why one subscriber ran, why policy changed the path, or how the runtime decided that a binding was
+              valid.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why contracts matter more than glue code</h2>
+            <p>
+              A hardcoded workflow can still work, but it tends to make orchestration fragile and stack-bound. The orchestration logic
+              becomes a private implementation detail rather than a visible architectural fact. Contracts change that. They make the
+              possible bindings legible before the flow executes.
+            </p>
+            <p>
+              Once those relationships are explicit, the runtime can validate them, policies can shape them, and telemetry can prove what
+              actually happened. That is much stronger than simply trusting that one coordinator service stitched the right steps together.
+            </p>
+          </section>
+
+          <section>
+            <h2>How events and subscriptions create the path</h2>
+            <p>
+              In a contract-driven model, emitted events are not just messages flying around the system. They are declared architectural
+              signals that other capabilities can subscribe to under known conditions. That makes orchestration feel less like a hidden
+              process graph and more like a governed relationship model.
+            </p>
+            <p>
+              The runtime can then create bindings from those contracts rather than inventing the flow from scratch. That is what makes the
+              orchestration model explainable instead of accidental.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Contracts define possibilities</h3>
+              <p>The system can see what may emit, what may subscribe, and what compatibility rules shape the flow.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Policies shape execution</h3>
+              <p>Execution mode can change without rewriting the services themselves because policy stays in the runtime path.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Telemetry proves behavior</h3>
+              <p>Evidence about bindings, validation, and subscriber execution keeps orchestration auditable.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Determinism still matters</h3>
+              <p>A governed orchestration path should remain repeatable enough to inspect and verify under the same conditions.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why policy belongs inside the orchestration path</h2>
+            <p>
+              Policy is most useful when it shapes execution at the moment orchestration becomes real. If policy is only an external
+              review step, the system can still drift toward undocumented local behavior. When policy stays in the path, the runtime can
+              visibly alter or stop execution under governed rules.
+            </p>
+            <p>
+              That is one reason Chapter 7 adds real value to the site’s concept cluster. It shows that orchestration is not only about
+              who runs after whom. It is about how declared bindings, validation, and policy produce a runtime path that remains legible.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why telemetry matters here</h2>
+            <p>
+              Telemetry is often treated as a later operational concern. In contract-driven orchestration, it becomes architectural
+              evidence. If the runtime creates a binding, validates an event, dispatches a subscriber, or changes behavior because of
+              policy, the system is stronger when those steps remain visible.
+            </p>
+            <p>
+              That visibility is what keeps orchestration reviewable. It lets a reader or operator move from “the system ran” to “the
+              system ran this governed path for these declared reasons.”
+            </p>
+          </section>
+
+          <section>
+            <h2>What this is not</h2>
+            <ul>
+              <li>It is not a claim that every workflow should be fully dynamic.</li>
+              <li>It is not an argument against simple deterministic flows.</li>
+              <li>It is not “event-driven” as a slogan with no runtime governance behind it.</li>
+              <li>It is not an excuse to let subscribers appear without declared compatibility.</li>
+              <li>It is not a substitute for a real runtime authority layer.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>A practical design test</h2>
+            <p>
+              Ask whether your system can explain why a particular binding existed. Was it declared through contracts and metadata? Was it
+              allowed by policy? Can the runtime show evidence that it validated and dispatched the path intentionally? If not, the system
+              may still be orchestrated, but the orchestration is not yet very governable.
+            </p>
+            <p>
+              Another useful test is whether a policy change can alter orchestration behavior without forcing a rewrite of the participating
+              services. If the answer is yes, the runtime is doing more of the architectural work in the right place.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is contract-driven orchestration the same as event-driven architecture?</h3>
+            <p>
+              Not exactly. Events are part of it, but the important UMA distinction is that contracts, policies, and runtime validation
+              keep the event relationships governed instead of implicit.
+            </p>
+            <h3>Does this remove the need for a workflow model?</h3>
+            <p>
+              No. It changes how the workflow becomes real. The path is no longer just a handwritten chain; it is something the runtime can
+              justify from the declared relationships.
+            </p>
+            <h3>Why is telemetry part of the concept instead of a later operational topic?</h3>
+            <p>
+              Because telemetry is what turns orchestration into evidence. Without it, teams are left trusting the flow rather than being
+              able to inspect it.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Follow orchestration into graph evolution</strong>
+            <p>
+              This page isolates the orchestration idea before it becomes a larger graph topic. In the book, I push that line further into
+              how contracts, policies, and runtime evidence change the way systems grow over time. On the site, the next useful move is to
+              connect this orchestration model to service graph evolution and the diagrams that make it visible.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../service-graph-evolution/">Service graph evolution</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../diagrams/">Diagrams</a>
+              <a href="../examples/">Examples</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/evolve-uma/how-systems-evolve-without-fragmentation.md
+++ b/content/pages/evolve-uma/how-systems-evolve-without-fragmentation.md
@@ -1,0 +1,188 @@
+---
+ref: how-systems-evolve-without-fragmentation
+title: "How Do Systems Evolve Without Fragmentation?"
+subtitle: "How do systems evolve without fragmentation? Systems rarely fragment because one team chooses chaos on purpose. They fragment because small, locally sensible changes keep accumulating until the architecture can no longer explain one coherent behavior. UMA treats that as an evolution problem, not only as a refactoring problem."
+macro_area: evolve-uma
+content_type: walkthrough
+slug: how-systems-evolve-without-fragmentation
+canonical_url: "https://www.universalmicroservices.com/how-systems-evolve-without-fragmentation/"
+left_nav_group: evolve-uma
+chapter_ref: null
+seo_description: "Learn how UMA keeps systems evolving without fragmentation by making drift, duplication, version coexistence, and runtime governance explicit."
+breadcrumbs:
+  - "Home"
+  - "Evolve Uma"
+  - "How Do Systems Evolve Without Fragmentation?"
+related_refs:
+  - ai-native-runtime-governance
+  - contract-driven-orchestration
+  - runtime-provenance-and-trust
+  - service-graph-evolution
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>How do systems evolve without fragmentation?</h1>
+          <p>
+            Systems rarely fragment because one team chooses chaos on purpose. They fragment because small, locally sensible changes keep
+            accumulating until the architecture can no longer explain one coherent behavior. UMA treats that as an evolution problem, not
+            only as a refactoring problem.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              A system evolves without fragmentation when change stays anchored to explicit behavior, visible compatibility, and governed
+              coexistence. The architecture needs a way to absorb drift, versioning, and brownfield constraints without letting each local
+              workaround become a new permanent truth.
+            </p>
+            <p>
+              That is why UMA puts so much weight on contracts and runtime authority. The system needs a stable place where change can be
+              judged, limited, and explained before it becomes another branch of hidden behavior.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why fragmentation happens gradually</h2>
+            <p>
+              Most systems do not jump from coherence to fragmentation in one release. They slide there through a sequence that looks
+              reasonable up close: one consumer interprets behavior differently, one team duplicates an implementation to move faster, one
+              version stays alive longer than expected, one migration remains half-complete. Each step can look justified. Together they
+              produce a system that no longer has one reliable meaning.
+            </p>
+            <p>
+              This is why architecture needs a vocabulary for drift, duplication, and coexistence. If every problem is treated as a purely
+              local delivery issue, the larger evolution pattern stays invisible until the repair cost is much higher.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Drift starts with meaning</h3>
+              <p>Two components can still look compatible in shape while quietly diverging in what they mean by the same behavior.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Duplication multiplies drift</h3>
+              <p>Copying behavior into parallel implementations often solves a short-term problem while creating two futures to govern.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Versioning needs rules</h3>
+              <p>Multiple versions can coexist safely only when the runtime can explain who may use what and under which conditions.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Recovery should be governed</h3>
+              <p>Healthy recovery does not always mean a rewrite. It often means clearer contracts and stronger runtime approval.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>What drift looks like before a system is obviously broken</h2>
+            <p>
+              Drift usually appears before any full outage. A report still renders, but one region uses different semantics. A workflow
+              still completes, but only because several compatibility assumptions remain tribal knowledge. A service still answers, but the
+              runtime can no longer explain why a specific version or implementation was chosen.
+            </p>
+            <p>
+              Those are the moments when teams still have room to recover cleanly. Once drift has already hardened into duplicated services,
+              uncontrolled version sprawl, and policy exceptions, the conversation becomes much more expensive.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why contracts matter more during change than at launch</h2>
+            <p>
+              Contracts are often treated as launch-time artifacts. In practice, they become more valuable after the system has been in the
+              wild for a while. They give the architecture a reference point for deciding whether behavior is still the same behavior, or
+              whether evolution has crossed into a new incompatible branch.
+            </p>
+            <p>
+              That is one reason UMA keeps returning to contract clarity. A contract does not remove change. It makes change legible enough
+              for the runtime and the team to govern it.
+            </p>
+          </section>
+
+          <section>
+            <h2>When versioning helps and when it makes things worse</h2>
+            <p>
+              Versioning is not the enemy. Ungoverned versioning is. Keeping two versions alive for a while can be entirely reasonable if
+              the system knows which consumers are compatible, which policies apply, and how coexistence will eventually narrow back toward
+              one cleaner shape.
+            </p>
+            <p>
+              Versioning becomes fragmentation when new versions accumulate faster than the architecture can explain them. Once teams stop
+              knowing why a version still exists, it has usually stopped being a compatibility tool and started becoming structural debt.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why runtime-governed coexistence matters</h2>
+            <p>
+              The strongest recovery pattern is often not “replace everything now.” It is “make coexistence explicit and govern it.” That
+              means the runtime can resolve which implementation is valid for which consumer, which rules still hold, and what evidence
+              supports the decision. This keeps the system changing without pretending all change must be synchronized.
+            </p>
+            <p>
+              Brownfield architecture especially benefits from this. Many real systems cannot stop and rewrite around a cleaner model. They
+              need a way to improve under load, with legacy pieces still present. Governed coexistence gives them that path without making
+              fragmentation the permanent default.
+            </p>
+          </section>
+
+          <section>
+            <h2>A practical progression to watch for</h2>
+            <ol>
+              <li>One contract clearly anchors the behavior.</li>
+              <li>Different consumers start stretching that meaning.</li>
+              <li>Teams duplicate the behavior to keep moving.</li>
+              <li>Multiple versions accumulate without a clear coexistence rule.</li>
+              <li>The runtime becomes the place where coexistence is made explicit.</li>
+              <li>The system improves without demanding a full rewrite first.</li>
+            </ol>
+            <p>
+              That progression is useful because it gives teams a way to name where they are. Not every system is fully fragmented, and not
+              every recovery story starts from a clean slate.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Does evolving without fragmentation mean avoiding change?</h3>
+            <p>
+              No. It means avoiding change that multiplies hidden meanings faster than the architecture can govern them. Healthy evolution is
+              still active change, not stasis.
+            </p>
+            <h3>Is duplication always wrong?</h3>
+            <p>
+              Not automatically. The issue is whether duplication is temporary, visible, and governed, or whether it becomes a quiet second
+              source of truth that keeps drifting.
+            </p>
+            <h3>Do I need a rewrite to recover coherence?</h3>
+            <p>
+              Not always. Many systems recover by clarifying contracts, making coexistence explicit, and moving final authority into the
+              runtime instead of leaving it in informal coordination.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Follow the evolution pattern, not only the final state</strong>
+            <p>
+              This page names the pattern. In the book, I walk through how that pattern becomes inspectable through runnable examples, so
+              drift, duplication, sprawl, and governed recovery stop feeling like abstract architecture language. On the site, the best next
+              move is to pair this with graph evolution, system coherence, and the diagrams that make change legible.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../service-graph-evolution/">Service graph evolution</a>
+              <a href="../what-makes-a-system-coherent/">What makes a system coherent?</a>
+              <a href="../contract-driven-orchestration/">Contract-driven orchestration</a>
+              <a href="../diagrams/">Diagrams</a>
+              <a href="../examples/">Examples</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/evolve-uma/runtime-provenance-and-trust.md
+++ b/content/pages/evolve-uma/runtime-provenance-and-trust.md
@@ -1,0 +1,35 @@
+---
+ref: runtime-provenance-and-trust
+title: "Runtime Provenance and Trust in UMA"
+subtitle: "Runtime provenance and trust Portable behavior does not automatically become trusted behavior. UMA makes publisher identity, declared permissions, dependency provenance, placement, and communication rules visible to the runtime."
+macro_area: evolve-uma
+content_type: walkthrough
+slug: runtime-provenance-and-trust
+canonical_url: "https://www.universalmicroservices.com/runtime-provenance-and-trust/"
+left_nav_group: evolve-uma
+chapter_ref: null
+seo_description: "Learn how UMA makes provenance, permissions, dependencies, and trust boundaries explicit in runtime decisions instead of hiding them in perimeter infrastructure."
+breadcrumbs:
+  - "Home"
+  - "Evolve Uma"
+  - "Runtime Provenance and Trust in UMA"
+related_refs:
+  - ai-native-runtime-governance
+  - contract-driven-orchestration
+  - how-systems-evolve-without-fragmentation
+  - service-graph-evolution
+---
+
+## intro
+
+<section class="subpage-hero"><h1>Runtime provenance and trust</h1><p>Portable behavior does not automatically become trusted behavior. UMA makes publisher identity, declared permissions, dependency provenance, placement, and communication rules visible to the runtime.</p></section>
+
+## main
+
+<div class="subpage-body">
+          <section><h2>The architectural shift</h2><p>Traditional systems often inherit trust from location: inside the network, inside the cluster, inside the gateway. UMA asks a different question: what does this module declare, who published it, what does it depend on, and what is it allowed to communicate with?</p><p>That makes trust part of the system model instead of a perimeter assumption.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>Publisher</h3><p>Who produced the service matters to runtime approval.</p></article><article class="subpage-card"><h3>Permissions</h3><p>Requested capability access must match declared permissions.</p></article><article class="subpage-card"><h3>Dependencies</h3><p>Provenance and checksums can affect whether a service is trusted.</p></article><article class="subpage-card"><h3>Communication</h3><p>Event compatibility is not enough if trust policy rejects the path.</p></article></section>
+          <section><h2>What readers should inspect</h2><p>The Chapter 9 example is the proof layer: trusted services are allowed, undeclared permissions are denied, untrusted dependencies fail, forbidden communication is blocked, and restored compliance brings the system back to allow.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapter 9 expands this into a full trust-boundary sequence. The site gives the map; the book explains why this model changes how portable systems should be governed.</p><div class="subpage-inline-links"><a href="../trust-boundaries/">Trust boundaries</a><a href="../examples/chapter-09-trust-boundaries/">Chapter 9 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/evolve-uma/service-graph-evolution.md
+++ b/content/pages/evolve-uma/service-graph-evolution.md
@@ -1,0 +1,229 @@
+---
+ref: service-graph-evolution
+title: "Service Graph Evolution"
+subtitle: "Service graph evolution One of the most useful ideas in Universal Microservices Architecture is that systems do not need to be hardwired into shape. Services can evolve into a graph through compatibility, contracts, and runtime discovery. That changes how architects think about system growth and how they reason about change over time."
+macro_area: evolve-uma
+content_type: walkthrough
+slug: service-graph-evolution
+canonical_url: "https://www.universalmicroservices.com/service-graph-evolution/"
+left_nav_group: evolve-uma
+chapter_ref: null
+seo_description: "Understand service graph evolution in Universal Microservices Architecture and why compatibility, contracts, and visibility matter more than hidden rewiring."
+breadcrumbs:
+  - "Home"
+  - "Evolve Uma"
+  - "Service Graph Evolution"
+related_refs:
+  - ai-native-runtime-governance
+  - contract-driven-orchestration
+  - how-systems-evolve-without-fragmentation
+  - runtime-provenance-and-trust
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Service graph evolution</h1>
+          <p>
+            One of the most useful ideas in Universal Microservices Architecture is that systems do not need to be hardwired into shape.
+            Services can evolve into a graph through compatibility, contracts, and runtime discovery. That changes how architects think
+            about system growth and how they reason about change over time.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>What a service graph really shows</h2>
+            <p>
+              A service graph is more than a diagram. It is a visible expression of which services can emit, consume, and compose behavior
+              together at runtime. The more that graph depends on declared compatibility rather than hidden rewiring, the more durable the
+              architecture becomes.
+            </p>
+            <p>
+              In UMA, the graph matters because it reveals how the system actually evolves. It shows which capabilities can participate,
+              which relationships are supported by contracts and metadata, and where growth is happening through governed compatibility
+              rather than accidental coupling.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why graph evolution matters more than static structure</h2>
+            <p>
+              Many architectures look coherent when drawn as a static picture. The harder question is whether they stay coherent as new
+              services, policies, and runtime environments are added. Service graph evolution is the point where the true quality of the
+              system becomes visible, because that is where hidden rewiring, duplicated orchestration, and ambiguous compatibility start to
+              accumulate.
+            </p>
+            <p>
+              A system that grows well is not just one that adds more nodes. It is one that remains interpretable while it changes. Teams
+              should be able to explain why a service participates in the graph, what relationships are allowed, and which runtime and trust
+              conditions shape that participation.
+            </p>
+          </section>
+
+          <section>
+            <h2>How graphs evolve in a healthy system</h2>
+            <p>
+              A healthy service graph grows through explicit compatibility. Services can emit events, subscribe to behavior, and be selected
+              for runtime participation because the contracts and metadata support those relationships. That is very different from a system
+              that evolves through ad hoc rewiring or duplicated orchestration logic.
+            </p>
+            <p>
+              UMA treats the graph as something that should remain interpretable over time. If teams can no longer explain how a service
+              becomes part of the graph, the architecture is already drifting. Growth should happen through visible relationships, not
+              through increasingly fragile knowledge hidden inside a few coordinating components.
+            </p>
+            <p>
+              This is also where
+              <a href="../contract-driven-orchestration/">contract-driven orchestration</a>
+              becomes a useful intermediate idea. Before a system looks like a graph, it often first becomes a governed set of bindings
+              between emitted events, subscribers, policy checks, and runtime evidence.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Compatibility matters first</h3>
+              <p>Healthy growth depends on services being able to connect through declared contracts instead of incidental implementation details.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Discovery must stay visible</h3>
+              <p>The system should be able to explain how compatible services become part of the same graph.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Evolution is where drift appears</h3>
+              <p>Architectures rarely fail on day one; they fail when repeated changes make the graph harder to reason about.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Governance keeps growth healthy</h3>
+              <p>Runtime policy, trust, and compatibility help distinguish healthy extension from architectural fragmentation.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>What makes a graph governable</h2>
+            <p>
+              A governable graph is one where compatibility is explicit, metadata is trustworthy, and runtime selection can be explained.
+              It should be possible to understand why a service is compatible, why it was selected, and what policies shape its role in the
+              broader system. Without that visibility, a graph becomes just another hidden layer of system behavior.
+            </p>
+            <p>
+              This is also where service graph evolution connects directly to trust boundaries. A graph that grows without explicit runtime
+              trust and policy tends to become ambiguous. A graph that grows with visible compatibility and governed selection remains much
+              easier to reason about.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why compatibility should fail visibly</h2>
+            <p>
+              Healthy graph evolution is not only about adding new relationships. It is also about what happens when compatibility breaks.
+              A mature system should fail in a way that is legible. If an event shape changes, a version drifts, or a subscriber no longer
+              matches the declared contract, the graph should show that break clearly instead of silently degrading into partial behavior.
+            </p>
+            <p>
+              That kind of visible failure is a strength, not a weakness. It tells the team where the architecture has actually become
+              incompatible, and it prevents downstream services from pretending the graph is still intact when it is not.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why inspectable change matters</h2>
+            <p>
+              A graph becomes much more useful when change can be inspected at the level that created it. If a service joins the graph
+              because of a new event contract, a changed consumer declaration, or a repaired metadata relationship, teams should be able to
+              see that transition directly instead of inferring it from surprising runtime behavior.
+            </p>
+            <p>
+              This is one of the most practical ideas behind Chapter 8. Graph evolution should be readable as declared change, not only as
+              a final state. That keeps system growth reviewable in a way static diagrams alone cannot.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why this topic matters</h2>
+            <p>
+              Service graph evolution is where the real architectural cost of change becomes visible. If the graph can grow through explicit
+              compatibility, the system remains teachable and governable. If growth depends on hidden rewiring, teams inherit fragility even
+              when each local change seemed reasonable.
+            </p>
+            <p>
+              That is why service graph evolution is a useful SEO and teaching topic for UMA. It exposes the difference between architecture
+              that merely scales in size and architecture that remains intelligible under change.
+            </p>
+          </section>
+
+          <section>
+            <h2>Signals of unhealthy evolution</h2>
+            <ul>
+              <li>New services only work after undocumented rewiring.</li>
+              <li>Compatibility is inferred from implementation detail instead of declared contracts.</li>
+              <li>Runtime placement and trust decisions stay hidden from the graph model.</li>
+              <li>Teams cannot explain why one service participates and another does not.</li>
+              <li>Policy and metadata drift faster than the system can document them.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>What healthy graph growth looks like in practice</h2>
+            <p>
+              Healthy graph growth usually starts small. One service becomes compatible with another through a contract or event boundary.
+              Metadata makes that compatibility visible. Runtime policy determines whether and where that relationship is allowed. Over time,
+              new services can join the graph without requiring the old ones to be rewritten around them.
+            </p>
+            <p>
+              That kind of growth is slower to design up front, but cheaper to sustain. It keeps change visible, which is exactly what a
+              long-lived architecture needs.
+            </p>
+            <p>
+              Just as important, healthy growth includes recovery. If a change breaks compatibility, the architecture should support a clear
+              repair path that restores the graph without forcing upstream services to be rewritten around the break. That is a much better
+              sign than a system that only looks stable because incompatibilities stay hidden.
+            </p>
+            <p>
+              That recovery path becomes even more important once graph growth turns into broader system evolution. Drift, duplication, and
+              unmanaged coexistence are all signs that graph change is no longer fully governed.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is a service graph just another architecture diagram?</h3>
+            <p>
+              No. In UMA, the graph is valuable because it reflects runtime-visible compatibility and composition, not just a static drawing
+              made after the fact.
+            </p>
+            <h3>Does every UMA system need a large service graph?</h3>
+            <p>
+              No. Some systems remain small and should stay small. The point is not to maximize graph complexity. The point is to make
+              system growth legible and governed when it does happen.
+            </p>
+            <h3>What should happen when compatibility breaks?</h3>
+            <p>
+              The break should be visible. A waiting consumer, a missing edge, or a failed compatibility check is more honest and much more
+              useful than a system that quietly routes around the problem. Healthy graph evolution depends on visible breakage and visible
+              repair.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Follow the practical path</strong>
+            <p>
+              This page gives the shape of graph evolution. In the book, I take that shape further into inspectable change, compatibility
+              failure, and recovery so the architectural consequences feel concrete instead of abstract. On the site, the best next move is
+              to pair this page with orchestration, trust, and the diagrams that make graph change visible.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../contract-driven-orchestration/">Contract-driven orchestration</a>
+              <a href="../examples/">Examples</a>
+              <a href="../how-systems-evolve-without-fragmentation/">How systems evolve without fragmentation</a>
+              <a href="../learning-path/">Learning Path</a>
+              <a href="../trust-boundaries/">Trust boundaries</a>
+              <a href="../diagrams/">Diagrams</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/evolve-uma/trust-boundaries.md
+++ b/content/pages/evolve-uma/trust-boundaries.md
@@ -1,0 +1,230 @@
+---
+ref: trust-boundaries
+title: "Trust Boundaries in UMA"
+subtitle: "Trust boundaries in UMA Portability only works in production if trust remains explicit. Universal Microservices Architecture treats identity, permissions, provenance, and runtime policy as part of the architecture rather than as controls bolted on after the service has already spread across environments."
+macro_area: evolve-uma
+content_type: walkthrough
+slug: trust-boundaries
+canonical_url: "https://www.universalmicroservices.com/trust-boundaries/"
+left_nav_group: evolve-uma
+chapter_ref: null
+seo_description: "Learn why trust boundaries matter in Universal Microservices Architecture and how identity, permissions, provenance, and runtime policy shape safe execution."
+breadcrumbs:
+  - "Home"
+  - "Evolve Uma"
+  - "Trust Boundaries in UMA"
+related_refs:
+  - ai-native-runtime-governance
+  - contract-driven-orchestration
+  - how-systems-evolve-without-fragmentation
+  - runtime-provenance-and-trust
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Trust boundaries in UMA</h1>
+          <p>
+            Portability only works in production if trust remains explicit. Universal Microservices Architecture treats identity,
+            permissions, provenance, and runtime policy as part of the architecture rather than as controls bolted on after the service has
+            already spread across environments.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>Why trust cannot be added later</h2>
+            <p>
+              When a service moves between hosts, runtimes, and execution contexts, the questions change quickly. What is allowed to run?
+              What is allowed to call what? Which capabilities can be used, and under which policy? If those answers do not live in the
+              architecture, portability becomes a liability instead of a strength.
+            </p>
+            <p>
+              Portable systems expand faster than many teams expect. A service that is safe in one environment can become risky in another
+              if the trust story is left implicit. That is why UMA treats trust boundaries as part of the design model rather than as a late
+              layer of operational hardening.
+            </p>
+          </section>
+
+          <section>
+            <h2>What a trust boundary means in UMA</h2>
+            <p>
+              A trust boundary is the point where the system decides what a portable service is allowed to do, what it is allowed to access,
+              and under which identity it is allowed to execute. In UMA, that boundary is not assumed from the deployment environment. It is
+              expressed as part of the runtime model so the architecture can explain it before production incidents do.
+            </p>
+            <p>
+              That makes the trust boundary a design surface. It is where identity, policy, capability access, provenance, and auditability
+              come together around the service. The runtime is responsible for enforcing those decisions, but the architecture has to say
+              clearly what the decisions are.
+            </p>
+            <p>
+              This is why Chapter 9 matters so much in the learning path. It turns trust from a generic security concern into a concrete
+              runtime question: what metadata, permissions, dependencies, and communication paths are actually allowed to participate?
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Identity</h3>
+              <p>Each portable unit needs a stable identity so the system can reason about what is being executed.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Permissions</h3>
+              <p>Capabilities should be declared and enforced deliberately instead of being inherited from the host by accident.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Provenance</h3>
+              <p>The architecture needs a story for where the executable unit came from and why it is trusted.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime enforcement</h3>
+              <p>Trust boundaries only matter when the runtime can explain, apply, and audit the policy consistently.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why this is architectural, not operational</h2>
+            <p>
+              Teams often treat trust as a platform concern that appears after the software already exists. UMA makes the opposite choice.
+              It treats trust as part of the design of the system itself, because portability without governance creates invisible risk.
+            </p>
+            <p>
+              That is what makes trust boundaries an architectural topic. They change how services can compose, what they can consume, and
+              which environments they can safely inhabit. Those are system design questions, not just platform configuration choices.
+            </p>
+          </section>
+
+          <section>
+            <h2>What governed execution means</h2>
+            <p>
+              Governed execution means the runtime can explain why a capability was allowed, denied, or adapted in a particular way. The
+              important part is not only that the policy exists, but that it remains visible and reviewable as part of the system model.
+            </p>
+            <p>
+              In a portable system, governed execution is what keeps the same service from turning into a different risk profile every time
+              it moves. Identity, provenance, and permissions have to travel with the service boundary strongly enough that the runtime can
+              make consistent decisions across environments.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why undeclared permissions should fail early</h2>
+            <p>
+              A portable service should not gain new powers just because it arrived in a more permissive environment. If the service needs
+              access to a capability, that need should be declared clearly enough that the runtime can validate it before execution begins.
+              Otherwise portability quietly becomes permission drift.
+            </p>
+            <p>
+              Early denial is the healthier architectural outcome. It keeps the boundary explicit and prevents the system from discovering
+              only after side effects occur that a service was relying on access it never declared honestly.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why dependency provenance is architectural</h2>
+            <p>
+              Dependency provenance is often treated as compliance paperwork or supply-chain hygiene outside the architecture itself. UMA
+              treats it differently. If the runtime cannot explain where a service or one of its critical dependencies came from, trust is
+              already incomplete.
+            </p>
+            <p>
+              That makes provenance part of the runtime decision, not an afterthought. A service can be syntactically valid and still be
+              denied because its dependency story is not trustworthy enough for the current boundary.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why compatibility is not the same as authorization</h2>
+            <p>
+              Two services can look compatible in shape and still be forbidden to communicate. Matching contracts do not automatically grant
+              trust. Communication also depends on policy, identity, placement, and the trust model of the system.
+            </p>
+            <p>
+              This is one of the most important ways trust boundaries correct a common architectural blind spot. Teams often stop once the
+              technical shapes line up. UMA says that compatible shape and authorized communication are related, but not identical.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why trust becomes harder in portable systems</h2>
+            <p>
+              The more places a service can run, the more important it becomes to define who it is, what it can do, and what evidence the
+              runtime needs before it allows execution. Portability increases freedom, but it also increases the need for precise
+              governance. Without a clear trust model, a portable architecture can scale its blast radius faster than it scales confidence.
+            </p>
+            <p>
+              This is one reason trust boundaries connect so directly to service graph evolution. A graph of compatible services only remains
+              safe when the runtime can explain which relationships are permitted and why.
+            </p>
+          </section>
+
+          <section>
+            <h2>Where teams usually go wrong</h2>
+            <ul>
+              <li>They assume the host environment will imply the right permissions.</li>
+              <li>They treat provenance as an operational concern instead of a runtime input.</li>
+              <li>They let identity emerge from deployment shape instead of from the service model.</li>
+              <li>They add policy after portability has already expanded the blast radius.</li>
+              <li>They document trust informally instead of making it part of the runtime model.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>What good trust design looks like</h2>
+            <p>
+              Good trust design starts by naming the executable unit clearly, defining its contracts, and deciding which capabilities it is
+              allowed to use. The runtime then enforces those decisions consistently, with identity and provenance visible enough that the
+              system can audit what happened later.
+            </p>
+            <p>
+              This does not make the system rigid. It makes change safer. New services and new runtime contexts can still be introduced, but
+              only through a model that can explain what was permitted and why.
+            </p>
+            <p>
+              Good trust design also makes denial legible. When a service is blocked because of undeclared permissions, untrusted
+              provenance, or forbidden communication, the system should be able to point to the exact rule or metadata decision that caused
+              it. That is what turns enforcement into architecture instead of guesswork.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Why are trust boundaries more important in portable systems?</h3>
+            <p>
+              Because portable systems cross more execution contexts. The more places a service can run, the more important it becomes to
+              define who it is, what it can do, and how the runtime enforces those decisions consistently.
+            </p>
+            <h3>Can trust be delegated entirely to the platform team?</h3>
+            <p>
+              The platform team can implement and operate enforcement, but the architecture still has to define what should be trusted, what
+              is allowed, and which runtime inputs matter. Otherwise the platform only enforces an incomplete model.
+            </p>
+            <h3>Can a service be valid and still be denied?</h3>
+            <p>
+              Yes. A service can match the expected shape and still be denied because it requested undeclared permissions, carries
+              untrusted provenance, or attempts communication the trust policy does not allow.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Related topics</strong>
+            <p>
+              Trust boundaries connect directly to runtime-agnostic architecture and to service graph evolution, because safe composition is
+              impossible when the system cannot explain who is allowed to do what. In the book, I push this further into the operational
+              consequences of deny decisions, metadata integrity, and communication policy without reducing the topic to generic security
+              advice.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../what-belongs-in-the-runtime-layer/">What belongs in the runtime layer?</a>
+              <a href="../service-graph-evolution/">Service graph evolution</a>
+              <a href="../examples/">Examples</a>
+              <a href="../diagrams/">Diagrams</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/evolve-uma/what-makes-a-system-coherent.md
+++ b/content/pages/evolve-uma/what-makes-a-system-coherent.md
@@ -1,0 +1,170 @@
+---
+ref: what-makes-a-system-coherent
+title: "What Makes a System Coherent?"
+subtitle: "What makes a system coherent? A UMA system is coherent when its runtime behavior still reflects the architectural model it claims to have. That is a higher standard than simple functionality. A system can work and still be architecturally unclear, fragile, or misleading."
+macro_area: evolve-uma
+content_type: walkthrough
+slug: what-makes-a-system-coherent
+canonical_url: "https://www.universalmicroservices.com/what-makes-a-system-coherent/"
+left_nav_group: evolve-uma
+chapter_ref: null
+seo_description: "Learn what makes a UMA system coherent instead of merely functional, and how metadata, capability boundaries, event semantics, and runtime decisions shape that outcome."
+breadcrumbs:
+  - "Home"
+  - "Evolve Uma"
+  - "What Makes a System Coherent?"
+related_refs:
+  - ai-native-runtime-governance
+  - contract-driven-orchestration
+  - how-systems-evolve-without-fragmentation
+  - runtime-provenance-and-trust
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What makes a system coherent?</h1>
+          <p>
+            A UMA system is coherent when its runtime behavior still reflects the architectural model it claims to have. That is a higher
+            standard than simple functionality. A system can work and still be architecturally unclear, fragile, or misleading.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              Coherence means the system’s boundaries, events, metadata, capability choices, and runtime decisions reinforce one another
+              instead of fighting each other. The architecture stays easier to explain because the runtime outcomes still match the declared
+              model.
+            </p>
+            <p>
+              That is why Chapter 10 matters. It pushes the conversation beyond “did the workflow finish?” and toward “what kind of system
+              did these decisions create?” In UMA, that difference is where architectural quality becomes visible.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why functionality is not enough</h2>
+            <p>
+              A system can produce the expected output while still accumulating architectural damage. It may split behavior into too many
+              capability fragments, hide meaning inside vague events, let runtime selection become ambiguous, or pile orchestration logic
+              into metadata that no longer clarifies anything. None of those problems necessarily causes an immediate failure.
+            </p>
+            <p>
+              That is exactly why coherence matters as its own topic. It gives teams a way to talk about whether the architecture is
+              staying healthy, not only whether the current scenario happened to complete.
+            </p>
+          </section>
+
+          <section>
+            <h2>Where coherence becomes visible</h2>
+            <p>
+              In UMA, coherence becomes visible in runtime behavior. Which capability was selected? Why was it selected? Do the event
+              names still reflect stable domain meaning? Is metadata clarifying the flow or bloating it? Can the system explain the path in
+              a way that still matches the intended architecture?
+            </p>
+            <p>
+              Those questions matter because diagrams alone can hide degradation. The runtime outcome is often where the real architectural
+              tradeoff finally becomes obvious.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Focused capability boundaries</h3>
+              <p>Capabilities should be meaningful enough to govern without being split into tiny steps that add more complexity than value.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Stable event semantics</h3>
+              <p>Events should describe durable domain facts, not vague workflow hints that only local code can interpret.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Deterministic runtime choices</h3>
+              <p>When multiple paths exist, the system should still explain why one was chosen and under which declared conditions.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Metadata with purpose</h3>
+              <p>Metadata should clarify compatibility and governance, not become a dumping ground for hidden orchestration detail.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>What makes a system drift away from coherence</h2>
+            <p>
+              Several patterns create drift quickly: over-granular capability splits, hidden event coupling, runtime ambiguity, and
+              over-orchestrated flows that try to control every step centrally. Each one can still look justified locally. Together they
+              make the architecture harder to reason about and harder to repair.
+            </p>
+            <p>
+              Coherence is often lost gradually. That is why runtime-visible tradeoffs are so useful. They show where the system stopped
+              matching its own architectural story before the damage becomes too expensive to reverse.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why recovery matters as much as diagnosis</h2>
+            <p>
+              A good architecture page should not only help a reader spot what is wrong. It should also help them see what recovery looks
+              like. In UMA, recovery usually comes from clearer constraints, sharper capability boundaries, more stable event meaning, and
+              runtime rules that reduce ambiguity instead of layering on more complexity.
+            </p>
+            <p>
+              That is a healthier model than assuming every problem can be solved by adding more orchestration or more services. Sometimes
+              architectural repair is really about removing noise until the runtime can be authoritative again.
+            </p>
+          </section>
+
+          <section>
+            <h2>A practical coherence test</h2>
+            <p>
+              Ask whether the system can explain a runtime outcome in the same terms the architecture uses to describe itself. If the
+              runtime says one thing and the architecture slides say another, coherence is already weakening.
+            </p>
+            <p>
+              Another useful test is whether the recovery path becomes simpler or more complicated. If every fix adds more indirection,
+              more orchestration, and more metadata without restoring clarity, the system is probably becoming merely functional rather than
+              more coherent.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Can a system be functional but not coherent?</h3>
+            <p>
+              Yes. That is exactly the point of this concept. A system may still produce the right output while becoming harder to explain,
+              govern, and evolve safely.
+            </p>
+            <h3>Does coherence mean fewer services?</h3>
+            <p>
+              Not automatically. The issue is not service count by itself. The issue is whether boundaries, events, metadata, and runtime
+              choices are still making the architecture clearer or only more fragmented.
+            </p>
+            <h3>Why is this a runtime question and not only a design question?</h3>
+            <p>
+              Because runtime outcomes expose tradeoffs that static structure can hide. Coherence becomes easiest to judge when the system
+              has to act, select, emit, and explain itself.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Use coherence as a design filter</strong>
+            <p>
+              This page gives the standard, not every tradeoff that can challenge it. In the book, I take the idea further through concrete
+              degraded and recovered designs so the difference between “working” and “coherent” becomes much more practical. On the site,
+              the next useful move is to connect coherence to orchestration, graph evolution, and runtime authority.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../contract-driven-orchestration/">Contract-driven orchestration</a>
+              <a href="../how-systems-evolve-without-fragmentation/">How systems evolve without fragmentation</a>
+              <a href="../service-graph-evolution/">Service graph evolution</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../examples/">Examples</a>
+              <a href="../learning-path/">Learning Path</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-04-feature-flag-evaluator.md
+++ b/content/pages/examples/chapter-04-feature-flag-evaluator.md
@@ -1,0 +1,80 @@
+---
+ref: chapter-04-feature-flag-evaluator
+title: "Chapter 4 Feature Flag Evaluator Tutorial"
+subtitle: "Chapter 4 UMA code example Feature flag evaluator tutorial This tutorial walks through the first hands-on UMA example: a deterministic feature flag evaluator with one contract, one portable Rust core, a WASI executable, and a TypeScript parity implementation."
+macro_area: examples
+content_type: tutorial
+slug: chapter-04-feature-flag-evaluator
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-04-feature-flag-evaluator/"
+left_nav_group: examples
+chapter_ref: "Chapter 4"
+seo_description: "Run the Chapter 4 UMA feature flag evaluator tutorial and learn how one Rust-first portable service keeps deterministic rule behavior aligned with TypeScript parity."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 4: Chapter 4 Feature Flag Evaluator Tutorial"
+related_refs:
+  - examples
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+  - chapter-07-metadata-orchestration
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 4 UMA code example</p>
+          <h1>Feature flag evaluator tutorial</h1>
+          <p>This tutorial walks through the first hands-on UMA example: a deterministic feature flag evaluator with one contract, one portable Rust core, a WASI executable, and a TypeScript parity implementation.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Keep the navigation close to the tutorial itself. Use the links below to move between the source folder, the examples index, and the next chapter without hunting through the footer.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-04-feature-flag-evaluator">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-05-post-fetcher-runtime/">Next: Post Fetcher Runtime</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>what belongs in the evaluator contract instead of the host adapter</li><li>how first-match rule evaluation and sticky rollout decisions stay deterministic</li><li>how Rust and TypeScript parity is proven from observable output</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust with the wasm32-wasip1 target</li><li>Wasmtime on your PATH</li><li>Node.js 20 or newer for parity checks</li><li>npm for TypeScript parity and optional adapters</li></ul>
+            <p>Run this setup command before the lab if your machine does not already have the target installed.</p><pre class="tutorial-code"><code>rustup target add wasm32-wasip1</code></pre>
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-04-feature-flag-evaluator</code></pre></li><li><strong>List the guided labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Run the country match lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab1-country-match</code></pre></li><li><strong>Run the sticky rollout lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab2-rollout-match</code></pre></li><li><strong>Run the default fallback lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab3-default-fallback</code></pre></li><li><strong>Run the rule language lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab4-rule-language</code></pre></li><li><strong>Compare Rust and TypeScript behavior</strong><pre class="tutorial-code"><code>./scripts/compare_impls.sh</code></pre></li><li><strong>Run the chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_flag_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>enabled</li><li>matchedRule</li><li>the same lab returning the same decision in Rust and TypeScript</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_flag_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 5 introduces the runtime layer around a pure service.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-04-feature-flag-evaluator">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              
+              <a href="../chapter-05-post-fetcher-runtime/">Next: Post Fetcher Runtime</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-05-post-fetcher-runtime.md
+++ b/content/pages/examples/chapter-05-post-fetcher-runtime.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-05-post-fetcher-runtime
+title: "Chapter 5 Post Fetcher Runtime Tutorial"
+subtitle: "Chapter 5 UMA code example Post fetcher runtime tutorial This tutorial shows what the UMA runtime layer owns around a pure service: validation, adapter selection, deterministic event ordering, and lifecycle evidence."
+macro_area: examples
+content_type: tutorial
+slug: chapter-05-post-fetcher-runtime
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-05-post-fetcher-runtime/"
+left_nav_group: examples
+chapter_ref: "Chapter 5"
+seo_description: "Follow the Chapter 5 UMA post fetcher runtime tutorial to see validation, adapter binding, event ordering, and lifecycle metadata around a pure Rust service."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 5: Chapter 5 Post Fetcher Runtime Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-06-portability-lab
+  - chapter-07-metadata-orchestration
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 5 UMA code example</p>
+          <h1>Post fetcher runtime tutorial</h1>
+          <p>This tutorial shows what the UMA runtime layer owns around a pure service: validation, adapter selection, deterministic event ordering, and lifecycle evidence.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Use the links below to move through the tutorial sequence without dropping to the footer first.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-05-post-fetcher-runtime">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-04-feature-flag-evaluator/">Previous: Feature Flag Evaluator</a>
+              <a href="../chapter-06-portability-lab/">Next: UMA Portability Lab</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>what belongs in service logic versus runtime logic</li><li>why validation should stop execution before side effects happen</li><li>how lifecycle metadata records the network.fetch adapter binding</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.77 or newer</li><li>cargo</li><li>jq</li><li>Node.js and npm for TypeScript parity</li></ul>
+            
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-05-post-fetcher-runtime</code></pre></li><li><strong>List the guided labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Run the golden cloud host path</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab1-cloud-golden-path</code></pre></li><li><strong>Run fail-fast header validation</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab2-header-validation-fail-fast</code></pre></li><li><strong>Inspect adapter binding and wrappers</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab3-adapter-binding-and-wrappers</code></pre></li><li><strong>Verify Rust and TypeScript parity</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab4-rust-ts-parity</code></pre></li><li><strong>Run the chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_runtime_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>output.events</li><li>lifecycle.bindings</li><li>final lifecycle.state</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_runtime_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 6 proves portability across native and WASI targets.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-05-post-fetcher-runtime">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-04-feature-flag-evaluator/">Previous: Feature Flag Evaluator</a>
+              <a href="../chapter-06-portability-lab/">Next: UMA Portability Lab</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-06-portability-lab.md
+++ b/content/pages/examples/chapter-06-portability-lab.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-06-portability-lab
+title: "Chapter 6 UMA Portability Lab Tutorial"
+subtitle: "Chapter 6 UMA code example UMA portability lab tutorial This tutorial proves portability through observable behavior. The native runner and WASI runner emit the same image.analyzed payload while target-specific telemetry remains explicit."
+macro_area: examples
+content_type: tutorial
+slug: chapter-06-portability-lab
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-06-portability-lab/"
+left_nav_group: examples
+chapter_ref: "Chapter 6"
+seo_description: "Run the Chapter 6 UMA portability tutorial and compare the same image analyzer behavior across native Rust and WASI with shared event payloads."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 6: Chapter 6 UMA Portability Lab Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-07-metadata-orchestration
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 6 UMA code example</p>
+          <h1>UMA portability lab tutorial</h1>
+          <p>This tutorial proves portability through observable behavior. The native runner and WASI runner emit the same image.analyzed payload while target-specific telemetry remains explicit.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Use the links up front so the portability path feels like a guided sequence instead of a footer scavenger hunt.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-06-portability-lab">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-05-post-fetcher-runtime/">Previous: Post Fetcher Runtime</a>
+              <a href="../chapter-07-metadata-orchestration/">Next: Metadata Orchestration</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>how one contract drives native and WASI execution</li><li>why parity should be checked through emitted events</li><li>how native-only capabilities stay outside the portable path</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.77 or newer</li><li>rustup target add wasm32-wasip1</li><li>Wasmtime 20 or newer</li><li>jq</li></ul>
+            <p>Run this setup command before the lab if your machine does not already have the target installed.</p><pre class="tutorial-code"><code>rustup target add wasm32-wasip1</code></pre>
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-06-portability-lab</code></pre></li><li><strong>List the guided labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Compare native and WASI events</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab1-native-wasm-parity</code></pre></li><li><strong>Compute shared payload digests</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab2-shared-payload-digest</code></pre></li><li><strong>Exercise failure paths and capability gates</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab3-failure-paths-and-capability-gates</code></pre></li><li><strong>Check Rust and TypeScript reference parity</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab4-rust-ts-reference-parity</code></pre></li><li><strong>Run the chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_portability_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>identical image.analyzed payloads</li><li>matching shared payload digests</li><li>gpu.telemetry.reported only on the native path</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_portability_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 7 uses contracts and events to create orchestration.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-06-portability-lab">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-05-post-fetcher-runtime/">Previous: Post Fetcher Runtime</a>
+              <a href="../chapter-07-metadata-orchestration/">Next: Metadata Orchestration</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-07-metadata-orchestration.md
+++ b/content/pages/examples/chapter-07-metadata-orchestration.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-07-metadata-orchestration
+title: "Chapter 7 Metadata Orchestration Tutorial"
+subtitle: "Chapter 7 UMA code example Metadata orchestration tutorial This tutorial shows orchestration emerging from contracts and events instead of hardcoded workflow steps. The Rust cloud runner is the validated path, with TypeScript kept in parity."
+macro_area: examples
+content_type: tutorial
+slug: chapter-07-metadata-orchestration
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-07-metadata-orchestration/"
+left_nav_group: examples
+chapter_ref: "Chapter 7"
+seo_description: "Use the Chapter 7 UMA metadata orchestration tutorial to run a contract-driven flow where bindings, policy, validation, and telemetry are visible."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 7: Chapter 7 Metadata Orchestration Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 7 UMA code example</p>
+          <h1>Metadata orchestration tutorial</h1>
+          <p>This tutorial shows orchestration emerging from contracts and events instead of hardcoded workflow steps. The Rust cloud runner is the validated path, with TypeScript kept in parity.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Keep the primary navigation alongside the lesson so the contract and policy links are visible before you reach the footer.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-07-metadata-orchestration">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-06-portability-lab/">Previous: Portability Lab</a>
+              <a href="../chapter-08-service-graph/">Next: Service Graph Evolution</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>how emits and subscribes create runtime bindings</li><li>how policy fail-open and fail-closed modes affect execution</li><li>how CloudEvents and telemetry prove orchestration behavior</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.76 or newer</li><li>Wasmtime 20 or newer</li><li>Node.js 20 or newer</li><li>jq and yq are optional</li></ul>
+            
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-07-metadata-orchestration</code></pre></li><li><strong>List the guided labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Run the baseline cloud flow</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab1-baseline-cloud-flow</code></pre></li><li><strong>Verify Rust and TypeScript parity</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab2-rust-ts-parity</code></pre></li><li><strong>Run the fail-closed policy lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab3-policy-fail-closed</code></pre></li><li><strong>Run the telemetry audit lab</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh lab4-telemetry-audit</code></pre></li><li><strong>Run the chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_orchestration_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>binding.created</li><li>policy.violation</li><li>validation.passed</li><li>telemetry.ok</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_orchestration_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 8 makes service graph evolution inspectable.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-07-metadata-orchestration">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-06-portability-lab/">Previous: UMA Portability Lab</a>
+              <a href="../chapter-08-service-graph/">Next: Service Graph Evolution</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-08-service-graph.md
+++ b/content/pages/examples/chapter-08-service-graph.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-08-service-graph
+title: "Chapter 8 Service Graph Evolution Tutorial"
+subtitle: "Chapter 8 UMA code example Service graph evolution tutorial This tutorial turns system growth into something inspectable. You will run graph scenarios, compare contract changes, and see how compatible services join the graph without upstream rewrites."
+macro_area: examples
+content_type: tutorial
+slug: chapter-08-service-graph
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-08-service-graph/"
+left_nav_group: examples
+chapter_ref: "Chapter 8"
+seo_description: "Follow the Chapter 8 UMA service graph tutorial to inspect graph growth, compatibility breaks, and recovery using Rust-first scenario snapshots and diffs."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 8: Chapter 8 Service Graph Evolution Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 8 UMA code example</p>
+          <h1>Service graph evolution tutorial</h1>
+          <p>This tutorial turns system growth into something inspectable. You will run graph scenarios, compare contract changes, and see how compatible services join the graph without upstream rewrites.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Use the in-page route block to move through the graph progression without relying on footer links for the main sequence.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-08-service-graph">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-07-metadata-orchestration/">Previous: Metadata Orchestration</a>
+              <a href="../chapter-09-trust-boundaries/">Next: Trust Boundaries</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>how service graphs emerge from contracts and event compatibility</li><li>how Git-style diffs expose architecture changes</li><li>how broken compatibility fails visibly and recovers predictably</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
+            
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-08-service-graph</code></pre></li><li><strong>List the graph labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the first scenario contracts</strong><pre class="tutorial-code"><code>./scripts/validate_graph_contracts.sh lab1-upload-only</code></pre></li><li><strong>Run the upload-only graph</strong><pre class="tutorial-code"><code>./scripts/run_graph_demo.sh lab1-upload-only</code></pre></li><li><strong>Inspect the contract change to image tagging</strong><pre class="tutorial-code"><code>./scripts/contract_diff.sh lab1-upload-only lab2-image-tagger</code></pre></li><li><strong>Run the indexer graph</strong><pre class="tutorial-code"><code>./scripts/run_graph_demo.sh lab3-indexer</code></pre></li><li><strong>Compare a compatibility break</strong><pre class="tutorial-code"><code>./scripts/graph_diff.sh lab3-indexer lab4-broken-compat</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_graph_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>capability lines</li><li>consumes and emits lines</li><li>Edges</li><li>Waiting Consumers</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_graph_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 9 adds explicit trust and runtime enforcement.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-08-service-graph">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-07-metadata-orchestration/">Previous: Metadata Orchestration</a>
+              <a href="../chapter-09-trust-boundaries/">Next: Trust Boundaries</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-09-trust-boundaries.md
+++ b/content/pages/examples/chapter-09-trust-boundaries.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-09-trust-boundaries
+title: "Chapter 9 Trust Boundaries Tutorial"
+subtitle: "Chapter 9 UMA code example Trust boundaries tutorial This tutorial makes trust decisions visible. The runtime evaluates metadata, permissions, dependency provenance, placement, and communication rules before allowing execution."
+macro_area: examples
+content_type: tutorial
+slug: chapter-09-trust-boundaries
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-09-trust-boundaries/"
+left_nav_group: examples
+chapter_ref: "Chapter 9"
+seo_description: "Run the Chapter 9 UMA trust boundaries tutorial to see publisher trust, permissions, provenance, and communication policy produce allow and deny decisions."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 9: Chapter 9 Trust Boundaries Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 9 UMA code example</p>
+          <h1>Trust boundaries tutorial</h1>
+          <p>This tutorial makes trust decisions visible. The runtime evaluates metadata, permissions, dependency provenance, placement, and communication rules before allowing execution.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Keep the path visible beside the tutorial so the trust rules, source folder, and neighboring chapters are easy to jump to.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-09-trust-boundaries">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-08-service-graph/">Previous: Service Graph Evolution</a>
+              <a href="../chapter-10-architectural-tradeoffs/">Next: Architectural Tradeoffs</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>why portable systems cannot inherit trust from location alone</li><li>how undeclared permissions and untrusted dependencies fail before execution</li><li>how trust policy governs communication across services</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
+            
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-09-trust-boundaries</code></pre></li><li><strong>List the trust labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the trusted scenario</strong><pre class="tutorial-code"><code>./scripts/validate_trust.sh lab1-trusted-service</code></pre></li><li><strong>Run the trusted service scenario</strong><pre class="tutorial-code"><code>./scripts/run_trust_demo.sh lab1-trusted-service</code></pre></li><li><strong>Inspect an undeclared permission change</strong><pre class="tutorial-code"><code>./scripts/trust_diff.sh lab1-trusted-service lab2-undeclared-permission</code></pre></li><li><strong>Run the untrusted dependency scenario</strong><pre class="tutorial-code"><code>./scripts/run_trust_demo.sh lab3-untrusted-dependency</code></pre></li><li><strong>Run the restored compliance scenario</strong><pre class="tutorial-code"><code>./scripts/run_trust_demo.sh lab5-restored-compliance</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_trust_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>Outcome: allow or deny</li><li>permission.undeclared</li><li>dependency.provenance.untrusted</li><li>communication.forbidden</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_trust_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 10 compares architectural tradeoffs through runtime behavior.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-09-trust-boundaries">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-08-service-graph/">Previous: Service Graph Evolution</a>
+              <a href="../chapter-10-architectural-tradeoffs/">Next: Architectural Tradeoffs</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-10-architectural-tradeoffs.md
+++ b/content/pages/examples/chapter-10-architectural-tradeoffs.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-10-architectural-tradeoffs
+title: "Chapter 10 Architectural Tradeoffs Tutorial"
+subtitle: "Chapter 10 UMA code example Architectural tradeoffs tutorial This tutorial shows architecture as runtime behavior. You will compare scenarios where service granularity, event semantics, placement rules, and orchestration choices either preserve or degrade coherence."
+macro_area: examples
+content_type: tutorial
+slug: chapter-10-architectural-tradeoffs
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-10-architectural-tradeoffs/"
+left_nav_group: examples
+chapter_ref: "Chapter 10"
+seo_description: "Use the Chapter 10 UMA architectural tradeoffs tutorial to compare coherent and degraded designs through runtime-visible warnings and decision axes."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 10: Chapter 10 Architectural Tradeoffs Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 10 UMA code example</p>
+          <h1>Architectural tradeoffs tutorial</h1>
+          <p>This tutorial shows architecture as runtime behavior. You will compare scenarios where service granularity, event semantics, placement rules, and orchestration choices either preserve or degrade coherence.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Keep the chapter sequence in view so the comparison path stays obvious while you read the tradeoff scenarios.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-10-architectural-tradeoffs">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-09-trust-boundaries/">Previous: Trust Boundaries</a>
+              <a href="../chapter-11-evolution-without-fragmentation/">Next: Evolution Without Fragmentation</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>why more services are not automatically better architecture</li><li>how metadata works as a control plane</li><li>how clearer constraints recover coherence after ambiguity or over-orchestration</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
+            
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-10-architectural-tradeoffs</code></pre></li><li><strong>List the architecture labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the baseline</strong><pre class="tutorial-code"><code>./scripts/validate_architecture.sh lab1-baseline</code></pre></li><li><strong>Run the coherent baseline</strong><pre class="tutorial-code"><code>./scripts/run_arch_demo.sh lab1-baseline</code></pre></li><li><strong>Compare over-granular decomposition</strong><pre class="tutorial-code"><code>./scripts/diff_architecture.sh lab1-baseline lab2-over-granular</code></pre></li><li><strong>Run the runtime ambiguity lab</strong><pre class="tutorial-code"><code>./scripts/run_arch_demo.sh lab4-runtime-ambiguity</code></pre></li><li><strong>Run the recovered architecture lab</strong><pre class="tutorial-code"><code>./scripts/run_arch_demo.sh lab6-recovered-architecture</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_arch_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>Verdict</li><li>architectural decision axes</li><li>over_granular</li><li>hidden_event_coupling</li><li>runtime_ambiguity</li><li>over_orchestrated</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_arch_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 11 focuses on evolution without fragmentation.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-10-architectural-tradeoffs">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-09-trust-boundaries/">Previous: Trust Boundaries</a>
+              <a href="../chapter-11-evolution-without-fragmentation/">Next: Evolution Without Fragmentation</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-11-evolution-without-fragmentation.md
+++ b/content/pages/examples/chapter-11-evolution-without-fragmentation.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-11-evolution-without-fragmentation
+title: "Chapter 11 Evolution Without Fragmentation Tutorial"
+subtitle: "Chapter 11 UMA code example Evolution without fragmentation tutorial This tutorial shows what happens after deployment. You will follow drift, duplicated behavior, version sprawl, and runtime-governed recovery without pretending every system can be rewritten."
+macro_area: examples
+content_type: tutorial
+slug: chapter-11-evolution-without-fragmentation
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-11-evolution-without-fragmentation/"
+left_nav_group: examples
+chapter_ref: "Chapter 11"
+seo_description: "Follow the Chapter 11 UMA evolution tutorial to watch drift, duplication, version sprawl, governed coexistence, and hybrid adoption unfold through runnable labs."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 11: Chapter 11 Evolution Without Fragmentation Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 11 UMA code example</p>
+          <h1>Evolution without fragmentation tutorial</h1>
+          <p>This tutorial shows what happens after deployment. You will follow drift, duplicated behavior, version sprawl, and runtime-governed recovery without pretending every system can be rewritten.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Use the links here to move between the evolution chapters without burying the learning path in the footer.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-11-evolution-without-fragmentation">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-10-architectural-tradeoffs/">Previous: Architectural Tradeoffs</a>
+              <a href="../chapter-12-discoverable-decisions/">Next: Discoverable Decisions</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>how locally valid changes create fragmentation over time</li><li>why versioning needs explicit coexistence rules</li><li>how runtime governance supports brownfield adoption</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
+            
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-11-evolution-without-fragmentation</code></pre></li><li><strong>List the evolution labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the contract anchor</strong><pre class="tutorial-code"><code>./scripts/validate_evolution.sh lab1-contract-anchor</code></pre></li><li><strong>Run the coherent baseline</strong><pre class="tutorial-code"><code>./scripts/run_evolution_demo.sh lab1-contract-anchor</code></pre></li><li><strong>Inspect behavioral drift</strong><pre class="tutorial-code"><code>./scripts/diff_evolution.sh lab1-contract-anchor lab2-behavioral-drift</code></pre></li><li><strong>Run duplicate implementations</strong><pre class="tutorial-code"><code>./scripts/run_evolution_demo.sh lab3-duplicate-implementations</code></pre></li><li><strong>Run governed coexistence</strong><pre class="tutorial-code"><code>./scripts/run_evolution_demo.sh lab5-runtime-governed-coexistence</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_evolution_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>Verdict</li><li>behavioral_drift</li><li>duplicate_behavior</li><li>version_fragmentation</li><li>Runtime Decisions</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_evolution_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 12 turns runtime decisions into discoverable artifacts.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-11-evolution-without-fragmentation">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-10-architectural-tradeoffs/">Previous: Architectural Tradeoffs</a>
+              <a href="../chapter-12-discoverable-decisions/">Next: Discoverable Decisions</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-12-discoverable-decisions.md
+++ b/content/pages/examples/chapter-12-discoverable-decisions.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-12-discoverable-decisions
+title: "Chapter 12 Discoverable Decisions Tutorial"
+subtitle: "Chapter 12 UMA code example Discoverable decisions tutorial This tutorial moves from systems that merely execute to systems that can explain. Each lab exposes more of the proposal, validation, revision, execution, and trace lifecycle."
+macro_area: examples
+content_type: tutorial
+slug: chapter-12-discoverable-decisions
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-12-discoverable-decisions/"
+left_nav_group: examples
+chapter_ref: "Chapter 12"
+seo_description: "Run the Chapter 12 UMA discoverable decisions tutorial to expose proposal, validation, revision, execution, and trace artifacts as inspectable runtime evidence."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 12: Chapter 12 Discoverable Decisions Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 12 UMA code example</p>
+          <h1>Discoverable decisions tutorial</h1>
+          <p>This tutorial moves from systems that merely execute to systems that can explain. Each lab exposes more of the proposal, validation, revision, execution, and trace lifecycle.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Keep the decision path in front of the reader so the queryable proof is visible while the tutorial is still on screen.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-12-discoverable-decisions">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-11-evolution-without-fragmentation/">Previous: Evolution Without Fragmentation</a>
+              <a href="../chapter-13-portable-mcp-runtime/">Next: Portable MCP Runtime</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>why discoverability is different from execution</li><li>how edge proposals and cloud authority cooperate</li><li>how trace artifacts make final decisions auditable</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.76 or newer</li><li>Node.js 20 or newer</li><li>a checkout of the repository</li></ul>
+            
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-12-discoverable-decisions</code></pre></li><li><strong>List the decision labs</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Validate the first decision scenario</strong><pre class="tutorial-code"><code>./scripts/validate_decisions.sh lab1-capability-projection</code></pre></li><li><strong>Run capability projection</strong><pre class="tutorial-code"><code>./scripts/run_decision_demo.sh lab1-capability-projection</code></pre></li><li><strong>Compare the edge proposal step</strong><pre class="tutorial-code"><code>./scripts/diff_decisions.sh lab1-capability-projection lab2-edge-proposal</code></pre></li><li><strong>Run authority feedback</strong><pre class="tutorial-code"><code>./scripts/run_decision_demo.sh lab3-authority-feedback</code></pre></li><li><strong>Run queryable trace</strong><pre class="tutorial-code"><code>./scripts/run_decision_demo.sh lab6-queryable-trace</code></pre></li><li><strong>Run the full smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_discoverability_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>Verdict</li><li>proposal_hidden</li><li>authority_gap</li><li>Discoverable Surfaces</li><li>Trace</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_discoverability_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>Chapter 13 applies the model to a portable MCP runtime.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-12-discoverable-decisions">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-11-evolution-without-fragmentation/">Previous: Evolution Without Fragmentation</a>
+              <a href="../chapter-13-portable-mcp-runtime/">Next: Portable MCP Runtime</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/chapter-13-portable-mcp-runtime.md
+++ b/content/pages/examples/chapter-13-portable-mcp-runtime.md
@@ -1,0 +1,81 @@
+---
+ref: chapter-13-portable-mcp-runtime
+title: "Chapter 13 Portable MCP Runtime Tutorial"
+subtitle: "Chapter 13 UMA code example Portable MCP runtime tutorial This tutorial is the repo reference application. It composes discoverable capabilities into workflows, lets AI propose without becoming authoritative, and explains the execution through CLI, JSON, MCP, and a browser app."
+macro_area: examples
+content_type: tutorial
+slug: chapter-13-portable-mcp-runtime
+canonical_url: "https://www.universalmicroservices.com/examples/chapter-13-portable-mcp-runtime/"
+left_nav_group: examples
+chapter_ref: "Chapter 13"
+seo_description: "Use the Chapter 13 portable MCP runtime tutorial to build WASI AI capabilities, run an UMA workflow, inspect JSON reports, and start the MCP server."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "Chapter 13: Chapter 13 Portable MCP Runtime Tutorial"
+related_refs:
+  - examples
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+---
+
+## intro
+
+<section class="subpage-hero tutorial-hero">
+          <p class="tutorial-kicker">Chapter 13 UMA code example</p>
+          <h1>Portable MCP runtime tutorial</h1>
+          <p>This tutorial is the repo reference application. It composes discoverable capabilities into workflows, lets AI propose without becoming authoritative, and explains the execution through CLI, JSON, MCP, and a browser app.</p>
+        </section>
+
+## main
+
+<div class="subpage-body tutorial-body">
+          <section class="subpage-callout">
+            <strong>Tutorial route</strong>
+            <p>Keep the final chapter’s navigation close to the lesson so the source, the examples index, and the previous step remain visible up front.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-13-portable-mcp-runtime">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-12-discoverable-decisions/">Previous: Discoverable Decisions</a>
+              <a href="../../reference-application/">Live reference application</a>
+            </div>
+          </section>
+          <section>
+            <h2>What you will learn</h2>
+            <ul><li>how WASM MCP exposes discovery and invocation surfaces</li><li>how the UMA runtime validates and executes selected capabilities</li><li>how AI-backed capabilities participate with explicit fallback reporting</li></ul>
+          </section>
+          <section>
+            <h2>Prerequisites</h2>
+            <ul><li>Rust 1.76 or newer</li><li>wasm32-wasip1 target</li><li>Node.js 20 or newer</li><li>npm</li><li>Wasmtime on your PATH</li></ul>
+            <p>Run this setup command before the lab if your machine does not already have the target installed.</p><pre class="tutorial-code"><code>rustup target add wasm32-wasip1</code></pre>
+          </section>
+          <section>
+            <h2>Full tutorial</h2>
+            <ol class="tutorial-steps"><li><strong>Enter the example</strong><pre class="tutorial-code"><code>cd chapter-13-portable-mcp-runtime</code></pre></li><li><strong>Set up pinned model artifacts</strong><pre class="tutorial-code"><code>./scripts/setup_models.sh</code></pre></li><li><strong>Build the PlannerAI WASI module</strong><pre class="tutorial-code"><code>./scripts/build_planner_ai_wasi.sh</code></pre></li><li><strong>Build the SummarizerAI WASI module</strong><pre class="tutorial-code"><code>./scripts/build_summarizer_ai_wasi.sh</code></pre></li><li><strong>Build the TranslatorFr WASI module</strong><pre class="tutorial-code"><code>./scripts/build_translator_ai_wasi.sh</code></pre></li><li><strong>List workflows</strong><pre class="tutorial-code"><code>./scripts/list_labs.sh</code></pre></li><li><strong>Run the French AI report workflow</strong><pre class="tutorial-code"><code>./scripts/run_lab.sh use-case-2-ai-report</code></pre></li><li><strong>Render the workflow as JSON</strong><pre class="tutorial-code"><code>cargo run --manifest-path rust/Cargo.toml -- render use-case-2-ai-report json</code></pre></li><li><strong>Run the MCP server smoke check</strong><pre class="tutorial-code"><code>./scripts/smoke_mcp_server.sh</code></pre></li><li><strong>Run the full chapter smoke path</strong><pre class="tutorial-code"><code>./scripts/smoke_portable_mcp_labs.sh</code></pre></li></ol>
+          </section>
+          <section>
+            <h2>What to inspect</h2>
+            <p>After each command, look for these proof points. They are the signals that connect the code example back to the UMA architecture claim.</p>
+            <ul><li>capability selection</li><li>runtime validation result</li><li>structured report JSON</li><li>explicit provider fallback reporting when used</li></ul>
+          </section>
+          <section>
+            <h2>Acceptance check</h2>
+            <p>The chapter-level validation path is:</p>
+            <pre class="tutorial-code"><code>./scripts/smoke_portable_mcp_labs.sh</code></pre>
+            <p>Return to the repository root for the final acceptance gate:</p>
+            <pre class="tutorial-code"><code>cd ..
+./scripts/smoke_reader_paths.sh</code></pre>
+          </section>
+          <section>
+            <h2>Where to go next</h2>
+            <p>This chapter closes the validated learning path and links to the live reference application.</p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/tree/main/chapter-13-portable-mcp-runtime">Open source folder</a>
+              <a href="../">All UMA examples</a>
+              <a href="../chapter-12-discoverable-decisions/">Previous: Discoverable Decisions</a>
+              <a href="../../reference-application/">Live reference application</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/examples/examples.md
+++ b/content/pages/examples/examples.md
@@ -1,0 +1,287 @@
+---
+ref: examples
+title: "UMA Examples"
+subtitle: "UMA examples The examples are the practical proof layer of Universal Microservices Architecture. They let readers inspect how a portable service is defined, how a runtime wraps it, how orchestration emerges from metadata, and how system evolution and trust decisions become visible rather than hidden inside operational glue. They are the fastest way to evaluate UMA as an execution model instead of treating it as another architectural slogan."
+macro_area: examples
+content_type: hub
+slug: examples
+canonical_url: "https://www.universalmicroservices.com/examples/"
+left_nav_group: examples
+chapter_ref: null
+seo_description: "Explore the practical Universal Microservices Architecture examples, including chapter-aligned Rust-first labs, portable MCP runtime composition, and runnable tutorials."
+breadcrumbs:
+  - "Home"
+  - "Examples"
+  - "UMA Examples"
+related_refs:
+  - chapter-04-feature-flag-evaluator
+  - chapter-05-post-fetcher-runtime
+  - chapter-06-portability-lab
+  - chapter-07-metadata-orchestration
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>UMA examples</h1>
+          <p>
+            The examples are the practical proof layer of Universal Microservices Architecture. They let readers inspect how a portable
+            service is defined, how a runtime wraps it, how orchestration emerges from metadata, and how system evolution and trust
+            decisions become visible rather than hidden inside operational glue. They are the fastest way to evaluate UMA as an execution
+            model instead of treating it as another architectural slogan.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section class="subpage-callout">
+            <strong>How to navigate the examples</strong>
+            <p>
+              Start with Chapter 4 and move forward in order if you want the cleanest learning path. Each tutorial page keeps the source
+              folder, the examples index, and the sibling chapter links near the top so the navigation is part of the page instead of
+              hidden in the footer.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="chapter-04-feature-flag-evaluator/">Start with Chapter 4</a>
+              <a href="chapter-07-metadata-orchestration/">Jump to orchestration</a>
+              <a href="chapter-12-discoverable-decisions/">See discoverable decisions</a>
+            </div>
+          </section>
+
+          <section id="why-the-examples-matter">
+            <h2>Why the examples matter</h2>
+            <p>
+              Architecture claims are easy to make and hard to validate. The examples exist to close that gap. They give the reader a way
+              to compare intention against output, contracts against runtime decisions, and design coherence against the real drift that
+              appears once a system grows.
+            </p>
+            <p>
+              The key thing to evaluate is not “can this code run somewhere else?” It is whether one behavior stays coherent while compute
+              can happen in many places and the runtime decides where logic runs.
+            </p>
+          </section>
+
+          <section id="before-and-after-repo-reading">
+            <h2>A before-and-after way to read the repo</h2>
+            <p>
+              Before UMA, a team often ends up with the same business rule scattered across browser logic, edge handling, backend checks,
+              and workflow glue. After UMA, the question becomes whether one portable behavioral unit can stay intact while the runtime
+              takes responsibility for placement, validation, trust, and workflow approval.
+            </p>
+            <p>
+              That is the lens to use when reading the examples. Do not ask only whether the lab runs. Ask whether the architecture still
+              knows what the durable behavior is and why the runtime approved the path that produced the result.
+            </p>
+          </section>
+
+          <section id="what-makes-these-examples-different">
+            <h2>What makes these examples different</h2>
+            <p>
+              These examples are not generic demos attached to a book launch. Each one exists to make a specific architectural question
+              visible. What does a portable service boundary look like? What belongs in the runtime layer? How does metadata shape
+              orchestration? When do trust and compatibility become part of the architecture rather than operational cleanup?
+            </p>
+            <p>
+              That makes the examples valuable even outside the book flow. A reader can inspect one example in isolation and still learn
+              something important about portability, runtime governance, or long-term system design. Used in sequence, they become a
+              practical walk through the model.
+            </p>
+          </section>
+
+          <section id="example-props" class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Chapter-aligned</h3>
+              <p>The examples map directly to the later chapters so the learning path continues from explanation into runnable material.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Rust-first</h3>
+              <p>The primary validated path uses Rust for the core runtime and architecture examples.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>TypeScript parity</h3>
+              <p>Selected chapters include TypeScript parity paths to make comparison easier for readers coming from different stacks.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Reader-tested flows</h3>
+              <p>Scripts, smoke checks, and learning-path validation make the examples easier to follow chapter by chapter.</p>
+            </article>
+          </section>
+
+          <section id="tutorials">
+            <h2>Runnable tutorials for every code example</h2>
+            <p>
+              Each chapter example now has a dedicated tutorial page with its own canonical URL, metadata, source link, validation
+              command, and repository-level acceptance check. The pages are grouped below so the learning path is easier to scan and
+              easier to follow.
+            </p>
+          </section>
+
+          <section id="foundations">
+            <h2>Foundations</h2>
+            <div class="subpage-grid tutorial-link-grid">
+              <article class="subpage-card">
+                <h3><a href="chapter-04-feature-flag-evaluator/">Chapter 4: Feature Flag Evaluator</a></h3>
+                <p>Build and run the deterministic Rust-first evaluator, then prove TypeScript parity from output.</p>
+              </article>
+              <article class="subpage-card">
+                <h3><a href="chapter-05-post-fetcher-runtime/">Chapter 5: Post Fetcher Runtime</a></h3>
+                <p>Inspect validation, adapter binding, event ordering, and lifecycle evidence around a pure service.</p>
+              </article>
+              <article class="subpage-card">
+                <h3><a href="chapter-06-portability-lab/">Chapter 6: Portability Lab</a></h3>
+                <p>Compare native and WASI execution through the same emitted image analysis payload.</p>
+              </article>
+            </div>
+          </section>
+
+          <section id="orchestration-and-trust">
+            <h2>Orchestration and trust</h2>
+            <div class="subpage-grid tutorial-link-grid">
+              <article class="subpage-card">
+                <h3><a href="chapter-07-metadata-orchestration/">Chapter 7: Metadata Orchestration</a></h3>
+                <p>Run the contract-driven orchestration flow and inspect binding, policy, schema, and telemetry signals.</p>
+              </article>
+              <article class="subpage-card">
+                <h3><a href="chapter-08-service-graph/">Chapter 8: Service Graph Evolution</a></h3>
+                <p>Use graph snapshots and diffs to watch compatible services join, break, and recover.</p>
+              </article>
+              <article class="subpage-card">
+                <h3><a href="chapter-09-trust-boundaries/">Chapter 9: Trust Boundaries</a></h3>
+                <p>See trust metadata, permissions, dependency provenance, and communication policy produce runtime decisions.</p>
+              </article>
+            </div>
+          </section>
+
+          <section id="evolution-and-discoverability">
+            <h2>Evolution and discoverability</h2>
+            <div class="subpage-grid tutorial-link-grid">
+              <article class="subpage-card">
+                <h3><a href="chapter-10-architectural-tradeoffs/">Chapter 10: Architectural Tradeoffs</a></h3>
+                <p>Compare coherent and degraded designs using runtime-visible warnings and architectural decision axes.</p>
+              </article>
+              <article class="subpage-card">
+                <h3><a href="chapter-11-evolution-without-fragmentation/">Chapter 11: Evolution Without Fragmentation</a></h3>
+                <p>Follow drift, duplication, version sprawl, coexistence, and hybrid adoption through runnable scenarios.</p>
+              </article>
+              <article class="subpage-card">
+                <h3><a href="chapter-12-discoverable-decisions/">Chapter 12: Discoverable Decisions</a></h3>
+                <p>Expose proposal, authority feedback, revision, execution, and trace artifacts as queryable proof.</p>
+              </article>
+              <article class="subpage-card">
+                <h3><a href="chapter-13-portable-mcp-runtime/">Chapter 13: Portable MCP Runtime</a></h3>
+                <p>Build WASI AI capabilities, run the UMA workflow, inspect JSON reports, and smoke the MCP server.</p>
+              </article>
+            </div>
+          </section>
+
+          <section id="what-each-tutorial-page-includes">
+            <h2>What each tutorial page includes</h2>
+            <p>
+              Every tutorial page now keeps the navigation close to the content: an in-page route block, the validation commands, the
+              source folder link, and the next step in the sequence. That makes the structure easier to scan without sending readers to
+              the footer first.
+            </p>
+          </section>
+
+          <section id="what-you-can-do">
+            <h2>What you can do with them</h2>
+            <p>
+              Use the examples to test the book’s architectural claims against concrete behavior. You can run a minimal service, trace a
+              runtime wrapper, compare implementations, follow orchestration decisions, and see where trust and compatibility start to
+              matter.
+            </p>
+            <p>
+              They also give teams a way to discuss architecture with evidence. Instead of debating portability or coherence in abstract
+              terms, readers can point to actual contracts, runtime outputs, and learning-path transitions.
+            </p>
+            <p>
+              That proof should include measurable tradeoffs, not just screenshots. The benchmark notes now publish local artifact sizes
+              and repeated execution timings for the early portability chapters so readers can evaluate UMA with numbers as well as
+              examples.
+            </p>
+          </section>
+
+          <section id="how-the-repository-is-organized">
+            <h2>How the repository is organized</h2>
+            <p>
+              The repository follows the same broad progression as the learning path. Earlier chapters keep the system intentionally small.
+              Later chapters introduce orchestration, service graphs, trust boundaries, and governed evolution. That organization helps the
+              reader understand not just individual samples, but the architectural consequences of adding more runtime responsibility over
+              time.
+            </p>
+            <p>
+              The latest steps in that progression are the Chapter 12 lab on discoverable decisions and the Chapter 13 portable MCP runtime,
+              where projections, proposals, validation feedback, approved execution, MCP discovery, and event-driven composition become
+              first-class outputs instead of hidden runtime behavior.
+            </p>
+            <p>
+              By then, the examples are proving something stronger than execution. They are proving that a governed system can expose its
+              own reasoning surfaces as reusable architectural artifacts.
+            </p>
+          </section>
+
+          <section id="why-rust-first-matters">
+            <h2>Why Rust-first matters here</h2>
+            <p>
+              The validated default path uses Rust because it makes the portable runtime story concrete and rigorous. TypeScript parity is
+              included where it adds value for comparison, but the repository stays centered on one primary validated path so the learning
+              experience remains consistent and defensible.
+            </p>
+          </section>
+
+          <section id="what-the-closing-examples-prove">
+            <h2>What the closing examples prove</h2>
+            <p>
+              The Chapter 12 example matters because it demonstrates a final architectural shift: a system should not only execute correctly,
+              it should expose why it acted. That lab makes decision stages queryable so readers can inspect capability projection, proposal
+              shape, authority feedback, bounded revision, approved execution, and full traceability in one sequence.
+            </p>
+            <p>
+              Chapter 13 then carries that idea into a richer reference experience. The runtime discovers distributed capabilities through
+              MCP-style descriptors, evaluates compatibility and constraints, accepts or rejects agent proposals, coordinates event-driven
+              execution, and produces a structured French report without collapsing back into a hardwired workflow.
+            </p>
+            <p>
+              If you want one conceptual lens that makes the Chapter 13 behavior easier to read, focus on the distinction between planning
+              and authority. The agent can help propose a workflow, but the runtime still governs what is approved and executed.
+            </p>
+            <p>
+              That is also the cleanest demonstration of the UMA promise: not write once, run everywhere, but write once, run where it
+              makes sense under visible runtime authority.
+            </p>
+          </section>
+
+          <section id="frequently-asked-question">
+            <h2>Frequently asked question</h2>
+            <h3>Do I need to run every example to understand UMA?</h3>
+            <p>
+              No, but the examples are where the architectural claims become easiest to verify. Even running a few of the core chapters
+              gives much more confidence in the model than reading about it alone.
+            </p>
+          </section>
+
+          <section id="repository-entry-point" class="subpage-callout">
+            <strong>Repository entry point</strong>
+            <p>
+              The examples live in the public repository and follow the same story arc as the site and the book. That makes the repository
+              the right place to continue after this overview. If you want the full design reasoning behind that progression, the book takes
+              the same examples and connects them into one architectural sequence rather than a set of isolated labs.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">GitHub repository</a>
+              <a href="../benchmark-and-footprint/">Benchmark and footprint notes</a>
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../how-to-prove-portability/">How to prove portability</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-makes-a-decision-discoverable/">What makes a decision discoverable?</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../what-is-wasm-mcp/">What is WASM MCP?</a>
+              <a href="../learning-path/">Learning Path</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="../#hands-on">Hands-on</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/how-uma-works/architecture-drift-and-portable-business-logic.md
+++ b/content/pages/how-uma-works/architecture-drift-and-portable-business-logic.md
@@ -1,0 +1,35 @@
+---
+ref: architecture-drift-and-portable-business-logic
+title: "Architecture Drift and Portable Business Logic"
+subtitle: "Architecture drift and portable business logic Architecture drift often begins when the same business behavior is copied into browser code, mobile code, backend code, edge functions, workflow glue, and AI-adjacent automation. UMA attacks that drift by making the durable behavior portable and governed."
+macro_area: how-uma-works
+content_type: walkthrough
+slug: architecture-drift-and-portable-business-logic
+canonical_url: "https://www.universalmicroservices.com/architecture-drift-and-portable-business-logic/"
+left_nav_group: how-uma-works
+chapter_ref: null
+seo_description: "Learn how UMA reduces architecture drift by keeping business behavior portable, contract-shaped, and governed across browser, edge, backend, and AI-assisted runtime paths."
+breadcrumbs:
+  - "Home"
+  - "How Uma Works"
+  - "Architecture Drift and Portable Business Logic"
+related_refs:
+  - incremental-uma-adoption
+  - migrating-to-uma-incrementally
+  - portable-business-logic
+  - runtime-agnostic-architecture
+---
+
+## intro
+
+<section class="subpage-hero"><h1>Architecture drift and portable business logic</h1><p>Architecture drift often begins when the same business behavior is copied into browser code, mobile code, backend code, edge functions, workflow glue, and AI-adjacent automation. UMA attacks that drift by making the durable behavior portable and governed.</p></section>
+
+## main
+
+<div class="subpage-body">
+          <section><h2>The problem</h2><p>A duplicated rule can start as a harmless optimization. Over time, each copy adapts to local pressures. The web client handles one edge case, the backend handles another, the edge function adds a shortcut, and nobody can point to one authoritative behavior anymore.</p><p>UMA does not promise magic elimination of drift. It gives teams a model for reducing drift by keeping business behavior behind explicit contracts and visible runtime authority.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>Portable core</h3><p>Keep the durable behavior testable outside one host.</p></article><article class="subpage-card"><h3>Runtime wrapper</h3><p>Let validation, adapters, and policy live around the core.</p></article><article class="subpage-card"><h3>Observable parity</h3><p>Compare behavior from outputs and events, not wishful code similarity.</p></article><article class="subpage-card"><h3>Governed evolution</h3><p>Use contracts and runtime decisions to manage version growth.</p></article></section>
+          <section><h2>The conversion point</h2><p>This is the pressure that makes the book worth reading. The website can name the pattern, but the book walks through how a system moves from one portable behavior to runtime governance, trust, discoverability, and long-term evolution.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapters 4, 6, 10, and 11 show the drift problem from different angles: portable behavior, proof of parity, coherence tradeoffs, and evolution without fragmentation.</p><div class="subpage-inline-links"><a href="../portable-business-logic/">Portable business logic</a><a href="../examples/chapter-04-feature-flag-evaluator/">Chapter 4 example</a><a href="../examples/chapter-10-architectural-tradeoffs/">Chapter 10 example</a><a href="../examples/chapter-11-evolution-without-fragmentation/">Chapter 11 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/how-uma-works/incremental-uma-adoption.md
+++ b/content/pages/how-uma-works/incremental-uma-adoption.md
@@ -1,0 +1,35 @@
+---
+ref: incremental-uma-adoption
+title: "Incremental UMA Adoption"
+subtitle: "Incremental UMA adoption UMA does not require a rewrite. It can start with one portable behavior, one contract, or one runtime-governed boundary inside a system that still has legacy services and ordinary deployment infrastructure."
+macro_area: how-uma-works
+content_type: walkthrough
+slug: incremental-uma-adoption
+canonical_url: "https://www.universalmicroservices.com/incremental-uma-adoption/"
+left_nav_group: how-uma-works
+chapter_ref: null
+seo_description: "Learn how UMA can begin with one portable capability and coexist with legacy systems through adapters, governed boundaries, and gradual runtime adoption."
+breadcrumbs:
+  - "Home"
+  - "How Uma Works"
+  - "Incremental UMA Adoption"
+related_refs:
+  - architecture-drift-and-portable-business-logic
+  - migrating-to-uma-incrementally
+  - portable-business-logic
+  - runtime-agnostic-architecture
+---
+
+## intro
+
+<section class="subpage-hero"><h1>Incremental UMA adoption</h1><p>UMA does not require a rewrite. It can start with one portable behavior, one contract, or one runtime-governed boundary inside a system that still has legacy services and ordinary deployment infrastructure.</p></section>
+
+## main
+
+<div class="subpage-body">
+          <section><h2>Start with the boundary</h2><p>The practical first step is not replacing your platform. It is finding a duplicated behavior or fragile runtime decision and moving that behavior behind an explicit contract and runtime-evaluated boundary.</p><p>Adapters let existing hosts participate while the portable core stays visible.</p></section>
+          <section class="subpage-grid"><article class="subpage-card"><h3>One behavior</h3><p>Choose a rule or normalization path that is repeated across environments.</p></article><article class="subpage-card"><h3>One contract</h3><p>Define what the behavior accepts, returns, emits, and depends on.</p></article><article class="subpage-card"><h3>One runtime wrapper</h3><p>Add validation, adapter binding, and lifecycle evidence around it.</p></article><article class="subpage-card"><h3>One migration path</h3><p>Keep legacy internals where needed while governing the boundary.</p></article></section>
+          <section><h2>Where the book goes further</h2><p>The full adoption story is not only about starting. It is about avoiding fragmentation as more versions, consumers, and runtime surfaces appear. That is why Chapter 11 matters so much.</p></section>
+          <section class="subpage-callout"><strong>Covered in the book</strong><p>Chapters 5 and 6 show the first runtime and portability steps. Chapter 11 explains hybrid adoption without forcing a rewrite.</p><div class="subpage-inline-links"><a href="../examples/chapter-05-post-fetcher-runtime/">Chapter 5 example</a><a href="../examples/chapter-06-portability-lab/">Chapter 6 example</a><a href="../examples/chapter-11-evolution-without-fragmentation/">Chapter 11 example</a><a href="https://www.amazon.com/Universal-Microservices-Architecture-Device-Independent-Modelling/dp/B0GTTTTQH4">Buy the book</a></div></section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/how-uma-works/migrating-to-uma-incrementally.md
+++ b/content/pages/how-uma-works/migrating-to-uma-incrementally.md
@@ -1,0 +1,80 @@
+---
+ref: migrating-to-uma-incrementally
+title: "Migrating to UMA Incrementally"
+subtitle: "Migrating to UMA incrementally UMA does not require a full-platform rewrite. A practical migration begins with one behavior that is duplicated, hard to govern, or forced to run in more than one place. From there, the team extracts a capability, defines its contract, proves portability, and expands only when the result is useful."
+macro_area: how-uma-works
+content_type: walkthrough
+slug: migrating-to-uma-incrementally
+canonical_url: "https://www.universalmicroservices.com/migrating-to-uma-incrementally/"
+left_nav_group: how-uma-works
+chapter_ref: null
+seo_description: "A practical conceptual guide to incremental UMA migration for greenfield and brownfield systems without requiring a full rewrite."
+breadcrumbs:
+  - "Home"
+  - "How Uma Works"
+  - "Migrating to UMA Incrementally"
+related_refs:
+  - architecture-drift-and-portable-business-logic
+  - incremental-uma-adoption
+  - portable-business-logic
+  - runtime-agnostic-architecture
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Migrating to UMA incrementally</h1>
+          <p>UMA does not require a full-platform rewrite. A practical migration begins with one behavior that is duplicated, hard to govern, or forced to run in more than one place. From there, the team extracts a capability, defines its contract, proves portability, and expands only when the result is useful.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>Start with one capability</h2>
+            <p>The best first candidate is a rule or decision that already appears in multiple places. Feature flags, eligibility checks, routing decisions, and policy evaluations are common starting points.</p>
+            <p>The goal is not to universalize everything. The goal is to find one behavior where portability reduces drift.</p>
+          </section>
+
+          <section>
+            <h2>Greenfield adoption</h2>
+            <p>In a greenfield system, UMA can start as a design discipline. Define the capability, contract, runtime expectations, and validation path before choosing all host-specific details.</p>
+            <p>That keeps the first service small enough to understand while still teaching the team the model.</p>
+          </section>
+
+          <section>
+            <h2>Brownfield adoption</h2>
+            <p>In an existing system, begin beside the current implementation. Keep the old path alive, extract the behavior into a portable service, and compare outputs before moving traffic or workflow authority.</p>
+            <p>This makes migration observable rather than ideological.</p>
+          </section>
+
+          <section>
+            <h2>Use a strangler path</h2>
+            <p>A strangler path works well when one capability can be routed gradually to the UMA implementation. The surrounding system keeps operating while the runtime earns authority through tests, telemetry, and controlled rollout.</p>
+            <p>This approach also helps teams avoid creating a second architecture that nobody trusts.</p>
+          </section>
+
+          <section>
+            <h2>Incremental rollout</h2>
+            <p>Roll out by capability, not by layer. A team can adopt one portable service, one runtime wrapper, one validation flow, and one chapter-aligned proof point before expanding the approach to other parts of the system.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Find drift</h3><p>Look for behavior copied across client, edge, backend, and workflow paths.</p></article>
+            <article class="subpage-card"><h3>Extract capability</h3><p>Name the durable behavior before choosing the new runtime shape.</p></article>
+            <article class="subpage-card"><h3>Prove parity</h3><p>Compare outputs across the old path and the portable implementation.</p></article>
+            <article class="subpage-card"><h3>Expand carefully</h3><p>Move the next behavior only after the runtime path is understandable and governed.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page keeps migration at a conceptual level. The migration material in the book goes deeper into sequencing, risk, governance, and production patterns. The repository gives concrete labs for proving one step at a time.</p>
+            <div class="subpage-inline-links">
+              <a href="../how-to-prove-portability/">How to prove portability</a>
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../trust-boundaries/">Trust boundaries</a>
+              <a href="../examples/chapter-06-portability-lab/">Portability lab example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/how-uma-works/portable-business-logic.md
+++ b/content/pages/how-uma-works/portable-business-logic.md
@@ -1,0 +1,174 @@
+---
+ref: portable-business-logic
+title: "Portable Business Logic"
+subtitle: "Portable business logic Portable business logic is the part of the system that should outlast frameworks, hosts, and deployment patterns. In UMA, that logic is treated as a durable service boundary with explicit inputs, outputs, and contracts, rather than as code trapped inside one application layer."
+macro_area: how-uma-works
+content_type: walkthrough
+slug: portable-business-logic
+canonical_url: "https://www.universalmicroservices.com/portable-business-logic/"
+left_nav_group: how-uma-works
+chapter_ref: null
+seo_description: "Understand portable business logic through the UMA model: what should stay durable, what should stay explicit, and how to avoid stack-bound rewrites."
+breadcrumbs:
+  - "Home"
+  - "How Uma Works"
+  - "Portable Business Logic"
+related_refs:
+  - architecture-drift-and-portable-business-logic
+  - incremental-uma-adoption
+  - migrating-to-uma-incrementally
+  - runtime-agnostic-architecture
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Portable business logic</h1>
+          <p>
+            Portable business logic is the part of the system that should outlast frameworks, hosts, and deployment patterns. In UMA, that
+            logic is treated as a durable service boundary with explicit inputs, outputs, and contracts, rather than as code trapped inside
+            one application layer.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>What portable business logic actually means</h2>
+            <p>
+              Portable business logic is not just shared code or a convenience library. It is the part of the system that preserves rules,
+              decisions, and domain meaning even when the surrounding runtime changes. In UMA, that logic is treated as a durable service
+              boundary with explicit contracts, instead of being trapped inside one frontend, backend, or middleware layer.
+            </p>
+            <p>
+              This distinction matters because software teams often say they want reuse while continuing to let each stack reinterpret the
+              same behavior in its own way. A portable service model is stricter than that. It requires the meaning of the service to stay
+              stable while the runtime around it adapts.
+            </p>
+            <p>
+              Another way to frame it is that portable business logic is one practical expression of
+              <a href="../from-stack-ownership-to-behavior-ownership/">behavior ownership</a>. The architecture stops treating each stack
+              as the natural owner of the rule and starts treating the rule itself as the thing that deserves a durable center.
+            </p>
+          </section>
+
+          <section>
+            <h2>What should be portable</h2>
+            <p>
+              The most valuable behavior in a product is the part that encodes rules, decisions, and domain meaning. That is the behavior
+              worth preserving. User-interface concerns, infrastructure integration, transport details, and host capabilities still matter,
+              but they should not own the domain logic that makes the service useful.
+            </p>
+            <p>
+              If the core business behavior is allowed to drift between browser code, backend code, and edge logic, the system eventually
+              stops having one truth. Portable business logic is the answer to that problem. It gives the team one durable expression of the
+              service, while still allowing runtime-specific adaptation around it.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why contracts matter so much</h2>
+            <p>
+              Contracts are what make portability governable instead of aspirational. They give the service a visible shape: inputs,
+              outputs, constraints, and expectations. Without them, “shared logic” tends to become a soft promise that each runtime
+              interprets differently.
+            </p>
+            <p>
+              With explicit contracts, the logic can be preserved, versioned, compared, validated, and tested across environments. That is
+              one of the biggest differences between portable business logic and a loosely shared utility package.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Keep the core stable</h3>
+              <p>Portable logic should not change just because the system moved from browser to edge or from edge to cloud.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Make bindings visible</h3>
+              <p>Capabilities, adapters, and runtime bindings should surround the logic instead of being fused into it.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Version the behavior</h3>
+              <p>A portable service boundary is easier to test, compare, evolve, and reason about than duplicated stack-owned logic.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Reduce stack ownership</h3>
+              <p>The architecture becomes more coherent when rules belong to the service model rather than to the frontend or backend toolchain.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why teams benefit</h2>
+            <p>
+              When the logic stays portable, teams spend less time reconciling behavior across implementations and more time improving the
+              product. It also becomes easier to reason about change because the durable business meaning of the service stops moving every
+              time the surrounding runtime changes.
+            </p>
+            <p>
+              That benefit compounds over time. The longer a product lives, the more expensive behavioral duplication becomes. Portable
+              business logic reduces that future cost by making the rules of the system easier to preserve and easier to govern.
+            </p>
+            <p>
+              It also improves cross-team clarity. Instead of one team owning the “real” rule in one stack and another team recreating it
+              elsewhere, the service boundary itself becomes the common reference point.
+            </p>
+          </section>
+
+          <section>
+            <h2>What portability does not mean</h2>
+            <ul>
+              <li>It does not mean every service should execute in every environment.</li>
+              <li>It does not mean UI concerns disappear into the service layer.</li>
+              <li>It does not mean runtime bindings can be ignored.</li>
+              <li>It does not mean data access, trust, and policy stop mattering.</li>
+              <li>It means the core business behavior is no longer owned by one stack.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Where teams usually go wrong</h2>
+            <p>
+              A common failure mode is to preserve only part of the logic while letting runtime code fill in the rest through implicit
+              assumptions. Another is to call something portable while it still depends on local framework state, hidden host bindings, or
+              unspoken data-shape assumptions.
+            </p>
+            <p>
+              Portable business logic works only when the service boundary is explicit enough that the runtime can surround it without
+              rewriting it. That means teams need to be honest about what belongs inside the service and what belongs outside it.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is portable business logic the same as shared code?</h3>
+            <p>
+              Not exactly. Shared code can still be vague, under-governed, or tied to local assumptions. Portable business logic is shared
+              through a clear service boundary with explicit contracts and a runtime story around it.
+            </p>
+            <h3>Does portable business logic remove the need for runtime-specific code?</h3>
+            <p>
+              No. Runtime-specific code still matters for validation, transport, trust, adaptation, and integration. The point is that this
+              code should stay around the service instead of silently becoming the place where the business behavior is redefined.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Continue</strong>
+            <p>
+              Portable business logic becomes much clearer once you connect it to behavior ownership and the runtime model around it. The
+              book goes deeper into that progression by showing where the portable core stops and the governed system begins.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../from-stack-ownership-to-behavior-ownership/">From stack ownership to behavior ownership</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../webassembly-architecture/">WebAssembly architecture</a>
+              <a href="../examples/">Examples</a>
+              <a href="../diagrams/">Diagrams</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/how-uma-works/runtime-agnostic-architecture.md
+++ b/content/pages/how-uma-works/runtime-agnostic-architecture.md
@@ -1,0 +1,238 @@
+---
+ref: runtime-agnostic-architecture
+title: "Runtime-agnostic Architecture"
+subtitle: "Runtime-agnostic architecture Runtime-agnostic architecture does not mean that runtimes stop mattering. It means the business behavior of the system no longer depends on being permanently fused to a single runtime choice. UMA treats that separation as an architectural discipline, not a marketing slogan, in a system where compute can happen in many places and the runtime decides where logic runs."
+macro_area: how-uma-works
+content_type: walkthrough
+slug: runtime-agnostic-architecture
+canonical_url: "https://www.universalmicroservices.com/runtime-agnostic-architecture/"
+left_nav_group: how-uma-works
+chapter_ref: null
+seo_description: "Understand runtime-agnostic architecture through the UMA lens: portable behavior, explicit runtime responsibilities, and more coherent software systems."
+breadcrumbs:
+  - "Home"
+  - "How Uma Works"
+  - "Runtime-agnostic Architecture"
+related_refs:
+  - architecture-drift-and-portable-business-logic
+  - incremental-uma-adoption
+  - migrating-to-uma-incrementally
+  - portable-business-logic
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Runtime-agnostic architecture</h1>
+          <p>
+            Runtime-agnostic architecture does not mean that runtimes stop mattering. It means the business behavior of the system no
+            longer depends on being permanently fused to a single runtime choice. UMA treats that separation as an architectural discipline,
+            not a marketing slogan, in a system where compute can happen in many places and the runtime decides where logic runs.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>What runtime-agnostic architecture actually means</h2>
+            <p>
+              Runtime-agnostic architecture is often described too loosely, as if it only means code that can execute in more than one
+              place. That is not enough. The harder and more useful question is whether the business meaning of a service can stay stable
+              while the runtime around it changes. In UMA, the portable unit is the service behavior itself, while validation, transport,
+              policy, trust, placement, and host capability access stay visible around it.
+            </p>
+            <p>
+              This makes runtime-agnostic architecture a discipline of separation rather than a vague portability claim. The goal is not to
+              pretend every environment is the same. The goal is to stop every environment from quietly redefining what the service means.
+            </p>
+            <p>
+              That is why runtime-agnostic architecture is not mainly about technical portability. It is about protecting semantic
+              continuity. If the same behavior changes meaning every time it crosses into a new runtime surface, the architecture is still
+              stack-shaped even if some code happens to be reusable.
+            </p>
+            <p>
+              The more useful shorthand is not “write once, run everywhere.” It is “write once, run where it makes sense.”
+            </p>
+          </section>
+
+          <section>
+            <h2>What this looks like in practice</h2>
+            <p>
+              A runtime-agnostic system does not ask every environment to host the same logic in the same way. It asks the architecture to
+              preserve one behavioral meaning while letting the runtime decide whether that logic belongs closer to the user, deeper in a
+              governed backend, or inside a workflow or edge path.
+            </p>
+            <p>
+              That distinction matters because many systems already execute in several places. The hard part is not moving compute. The hard
+              part is moving it without letting each surface rewrite the rule for itself.
+            </p>
+          </section>
+
+          <section>
+            <h2>What should remain portable</h2>
+            <p>
+              The most valuable behavior in a system is usually the part that expresses rules, decisions, and domain meaning. That is the
+              behavior that should remain portable. Storage choices, transport layers, host permissions, and placement strategies still
+              matter, but they should not own the meaning of the service itself.
+            </p>
+            <p>
+              When this boundary is explicit, the same service behavior can move between client, edge, and cloud contexts without forcing a
+              fresh rewrite of the underlying business model. The runtime can still adapt how the service is hosted and executed, but it no
+              longer becomes the place where domain logic is silently reauthored.
+            </p>
+            <p>
+              In that sense, runtime-agnostic architecture depends on the same shift described in
+              <a href="../from-stack-ownership-to-behavior-ownership/">behavior ownership</a>. The thing being protected is not only code
+              reuse. It is the durability of one business behavior across several execution surfaces.
+            </p>
+          </section>
+
+          <section>
+            <h2>What should remain explicit</h2>
+            <p>
+              A runtime-agnostic model does not hide the runtime. It keeps runtime-specific decisions visible and governable. Validation,
+              hosting, transport, permissions, identity, and placement still matter. The difference is that they stop silently redefining
+              the service behavior.
+            </p>
+            <p>
+              That makes the architecture easier to reason about because teams can separate “what this service means” from “how this
+              environment allows it to run.” A portable service is not an abstract idea floating above the system. It is a stable behavior
+              with a visible runtime story around it.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Portable behavior</h3>
+              <p>Service logic can move between execution environments without forcing a full rewrite of the business model.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Explicit runtime rules</h3>
+              <p>Validation, transport, trust, and capabilities stay outside the portable core and remain visible to the architect.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Stable reasoning</h3>
+              <p>Teams can reason about one service model instead of translating behavior between many platform-specific forms.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Safer system growth</h3>
+              <p>When runtime decisions are explicit, portability is less likely to collapse into accidental duplication and drift.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why teams struggle without it</h2>
+            <p>
+              Most organizations already support many runtime surfaces whether they planned to or not. A browser client may contain decision
+              logic for speed, an edge worker may enforce a variation of the same rule for latency, and a backend service may reimplement
+              the logic again for final authority. Over time, these copies drift because each environment accumulates its own assumptions,
+              shortcuts, and local optimizations.
+            </p>
+            <p>
+              Runtime-agnostic architecture matters because it interrupts that pattern. It gives teams a more durable answer to the question
+              of what should be preserved as shared service behavior and what should remain visible as runtime-specific execution policy.
+            </p>
+          </section>
+
+          <section>
+            <h2>A practical test for runtime-agnostic design</h2>
+            <p>
+              Ask whether one important behavior can be described once, validated once, and then adapted by several runtimes without
+              rewriting the rule itself. If the answer is no, the architecture is still runtime-dependent in the place that matters most.
+            </p>
+            <p>
+              A second test is organizational: when a business rule changes, does the system have one durable reference point for that
+              change, or does every runtime surface need its own reinterpretation? The more often the second pattern appears, the less
+              runtime-agnostic the architecture really is.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why it matters now</h2>
+            <p>
+              Modern systems are already spread across web, mobile, server, edge, and AI-driven execution contexts. The question is no
+              longer whether behavior moves. The question is whether the architecture can survive that movement without fragmenting.
+            </p>
+            <p>
+              That matters because modern software organizations rarely own just one runtime surface anymore. They own many. Without a
+              runtime-agnostic architectural model, every new surface becomes another place where business logic can drift.
+            </p>
+          </section>
+
+          <section>
+            <h2>How UMA frames the problem differently</h2>
+            <p>
+              UMA treats runtime-agnostic architecture as a boundary problem. It asks which part of the system should remain stable enough to
+              survive movement, and which part must remain explicit because it changes with the environment. That is different from a
+              conventional framework conversation, which often begins by asking which stack or deployment model should own the logic.
+            </p>
+            <p>
+              In practice, this means contracts matter more, runtime responsibilities stay visible, and trust and policy stop being
+              afterthoughts. The architecture becomes easier to review because the model itself tells you where a decision belongs.
+            </p>
+          </section>
+
+          <section>
+            <h2>Common misunderstandings</h2>
+            <p>
+              Runtime-agnostic does not mean runtime-neutral in the sense of treating all environments as interchangeable. Some services
+              belong closer to users. Some belong in controlled backend environments. Some require more policy or trust than others. UMA is
+              not trying to erase those differences. It is trying to stop them from owning the business model.
+            </p>
+            <p>
+              Another common misunderstanding is that runtime-agnostic architecture removes the need for optimization. It does not. Teams
+              can still optimize for latency, placement, caching, security, and cost. The difference is that those optimizations happen
+              around a visible service boundary instead of forcing a new implementation of the service behavior itself.
+            </p>
+          </section>
+
+          <section>
+            <h2>What a good adoption path looks like</h2>
+            <p>
+              The best adoption path is usually small and evidence-driven. Start with one service whose behavior is clearly defined, preserve
+              that behavior through an explicit contract, and let the runtime own validation and adaptation around it. Once that pattern is
+              visible, it becomes easier to extend it into orchestration, trust decisions, and graph evolution.
+            </p>
+            <p>
+              This is also why the learning path on the site starts with a small portable service and only later moves into governance and
+              system evolution. Runtime-agnostic architecture is easier to understand when the first boundary is small and explicit.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Can a runtime-agnostic architecture still be optimized for one runtime?</h3>
+            <p>
+              Yes. The architecture can preserve one portable service model while still optimizing deployment, placement, caching, or
+              transport around the runtime that matters most for a given use case.
+            </p>
+            <h3>Does runtime-agnostic architecture mean every service should run everywhere?</h3>
+            <p>
+              No. A runtime-agnostic service model is about preserving meaning, not forcing universal placement. Some services should stay
+              close to users, some should stay inside governed backend environments, and some should move between both. The important point
+              is that the service behavior is not rewritten every time placement changes.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Where to go next</strong>
+            <p>
+              This page gives the architectural shape of the idea. In the book, I explore the pressure behind that shape in more detail:
+              why teams drift back toward runtime-owned behavior, where that drift becomes expensive, and how a governed runtime model
+              changes the tradeoffs. On the site, the next useful move is to connect runtime-agnostic design to portable business logic,
+              runtime authority, and a concrete proof surface.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../from-stack-ownership-to-behavior-ownership/">From stack ownership to behavior ownership</a>
+              <a href="../portable-business-logic/">Portable business logic</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../examples/">Examples</a>
+              <a href="../webassembly-architecture/">WebAssembly architecture</a>
+              <a href="../trust-boundaries/">Trust boundaries</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/how-uma-works/uma-production-readiness.md
+++ b/content/pages/how-uma-works/uma-production-readiness.md
@@ -1,0 +1,80 @@
+---
+ref: uma-production-readiness
+title: "UMA Production Readiness"
+subtitle: "UMA production readiness Production readiness in UMA is not just the question of whether portable code can run. The stronger question is whether the runtime can govern that code under real trust, versioning, observability, and deployment constraints."
+macro_area: how-uma-works
+content_type: walkthrough
+slug: uma-production-readiness
+canonical_url: "https://www.universalmicroservices.com/uma-production-readiness/"
+left_nav_group: how-uma-works
+chapter_ref: null
+seo_description: "Understand what production readiness means in UMA across security, versioning, governance, observability, deployment, and runtime authority."
+breadcrumbs:
+  - "Home"
+  - "How Uma Works"
+  - "UMA Production Readiness"
+related_refs:
+  - architecture-drift-and-portable-business-logic
+  - incremental-uma-adoption
+  - migrating-to-uma-incrementally
+  - portable-business-logic
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>UMA production readiness</h1>
+          <p>Production readiness in UMA is not just the question of whether portable code can run. The stronger question is whether the runtime can govern that code under real trust, versioning, observability, and deployment constraints.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>Security and trust</h2>
+            <p>A portable service can create new security pressure because the same behavior may run in different contexts. UMA treats trust boundaries, permissions, provenance, and authority as part of the runtime model.</p>
+            <p>The runtime must know what is allowed before it executes.</p>
+          </section>
+
+          <section>
+            <h2>Versioning and compatibility</h2>
+            <p>A production UMA system needs clear contracts, compatibility checks, and versioned evolution. Without that discipline, portability can turn into version sprawl.</p>
+            <p>The service graph should make change visible rather than leaving teams to discover drift through incidents.</p>
+          </section>
+
+          <section>
+            <h2>Governance</h2>
+            <p>Governance means deciding who can expose a capability, who can call it, what evidence is required, and which runtime path is authoritative. UMA makes those questions architecture questions, not only operations questions.</p>
+            <p>This is especially important when AI-assisted workflows participate in discovery or proposal.</p>
+          </section>
+
+          <section>
+            <h2>Observability</h2>
+            <p>Observability should show more than whether a process is alive. A UMA runtime should expose capability selection, validation decisions, approvals, rejections, execution paths, and relevant traces.</p>
+            <p>That evidence is what makes runtime decisions explainable.</p>
+          </section>
+
+          <section>
+            <h2>Deployment</h2>
+            <p>Deployment readiness depends on the hosts involved. Browser, edge, cloud, WASI, and workflow execution each introduce different constraints. UMA does not erase those differences. It gives teams a model for deciding where a capability should run and why.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Security</h3><p>Trust, permissions, and provenance must travel with the runtime decision.</p></article>
+            <article class="subpage-card"><h3>Versioning</h3><p>Contracts and compatibility need to be visible as the system evolves.</p></article>
+            <article class="subpage-card"><h3>Governance</h3><p>Capability exposure and execution authority need explicit ownership.</p></article>
+            <article class="subpage-card"><h3>Observability</h3><p>The runtime should explain decisions, not only report activity.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page answers the production question at a conceptual level. The book goes further into governance, deployment patterns, runtime controls, and implementation guidance. The repository shows the proof artifacts that make those discussions concrete.</p>
+            <div class="subpage-inline-links">
+              <a href="../trust-boundaries/">Trust boundaries</a>
+              <a href="../what-makes-a-system-coherent/">What makes a system coherent?</a>
+              <a href="../what-makes-a-decision-discoverable/">What makes a decision discoverable?</a>
+              <a href="../examples/chapter-09-trust-boundaries/">Trust boundaries example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/how-uma-works/webassembly-architecture.md
+++ b/content/pages/how-uma-works/webassembly-architecture.md
@@ -1,0 +1,176 @@
+---
+ref: webassembly-architecture
+title: "WebAssembly Architecture and UMA"
+subtitle: "WebAssembly architecture in UMA WebAssembly matters to Universal Microservices Architecture because it gives portable service behavior a stable execution boundary. But the architecture is not “just use WebAssembly.” UMA depends on contracts, runtime governance, and explicit system composition as much as it depends on a portable binary target."
+macro_area: how-uma-works
+content_type: walkthrough
+slug: webassembly-architecture
+canonical_url: "https://www.universalmicroservices.com/webassembly-architecture/"
+left_nav_group: how-uma-works
+chapter_ref: null
+seo_description: "Learn how WebAssembly architecture supports Universal Microservices Architecture and why portable execution still needs contracts, policy, and runtime governance."
+breadcrumbs:
+  - "Home"
+  - "How Uma Works"
+  - "WebAssembly Architecture and UMA"
+related_refs:
+  - architecture-drift-and-portable-business-logic
+  - incremental-uma-adoption
+  - migrating-to-uma-incrementally
+  - portable-business-logic
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>WebAssembly architecture in UMA</h1>
+          <p>
+            WebAssembly matters to Universal Microservices Architecture because it gives portable service behavior a stable execution
+            boundary. But the architecture is not “just use WebAssembly.” UMA depends on contracts, runtime governance, and explicit system
+            composition as much as it depends on a portable binary target.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>What WebAssembly contributes</h2>
+            <p>
+              WebAssembly makes it easier to preserve a service boundary across environments because the same core behavior can be compiled
+              into a portable executable form. That lowers the cost of running the same logic in multiple places, but it does not by itself
+              answer the harder questions about orchestration, trust, capability access, or long-term change.
+            </p>
+            <p>
+              This is why UMA treats WebAssembly as an execution fit rather than the whole architectural answer. WebAssembly gives the
+              service a stable binary boundary. The rest of the model still has to explain contracts, policy, runtime governance, trust, and
+              system evolution.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why WebAssembly fits this model</h2>
+            <p>
+              WebAssembly is useful here because it creates a repeatable execution boundary. That boundary makes it easier to preserve the
+              identity of a service as it moves between hosts. Instead of re-implementing the same behavior in multiple runtime-specific
+              forms, a team can preserve one portable expression of the service and then surround it with runtime governance.
+            </p>
+            <p>
+              That does not make WebAssembly the architecture by itself. It makes WebAssembly a strong implementation fit for an
+              architecture that already cares about portable behavior, explicit contracts, and governed execution.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Execution portability</h3>
+              <p>One service can move across client, edge, and cloud contexts without being reauthored for each one.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime boundaries</h3>
+              <p>The host still matters, which is why UMA keeps runtime responsibilities explicit rather than pretending they disappear.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Capability control</h3>
+              <p>Portable execution only stays useful when permissions, adapters, and host bindings are declared and enforced clearly.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Architectural consistency</h3>
+              <p>WebAssembly is most powerful when it supports a durable service model instead of becoming another packaging layer.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why this is bigger than packaging</h2>
+            <p>
+              Many discussions about WebAssembly focus on where binaries can run. UMA is more interested in what the system becomes when the
+              same business behavior can move safely across runtimes. That is an architectural question, not a distribution feature.
+            </p>
+            <p>
+              In other words, a WebAssembly artifact is only part of the story. The harder problem is deciding how the runtime knows what
+              the service is allowed to do, how it should be composed, how it is versioned, and how trust should be enforced. UMA exists to
+              answer those questions at the architectural level.
+            </p>
+          </section>
+
+          <section>
+            <h2>What WebAssembly does not solve by itself</h2>
+            <p>
+              WebAssembly does not automatically define the service boundary, the contract, the trust model, or the operational policy. It
+              does not decide where a service should execute, how compatibility should be described, or how the system should evolve when
+              more capabilities are added. Those are architectural responsibilities that still need a clear model around the portable unit.
+            </p>
+            <p>
+              This is where UMA adds value. It gives WebAssembly a larger architectural context so the binary target contributes to a durable
+              system model rather than becoming one more technical layer that teams still have to interpret differently.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why architects care</h2>
+            <p>
+              Architects care about WebAssembly in this context because it changes the cost of preserving service behavior. Once the same
+              behavior can move across controlled runtimes with stronger isolation, the architecture can stop centering everything on stack
+              ownership. The conversation becomes less about where code happens to live today and more about how to preserve meaning over
+              time.
+            </p>
+            <p>
+              That makes WebAssembly relevant not just for performance or sandboxing, but for system design. It supports a more durable
+              answer to the question of how one service model can survive across many runtime surfaces.
+            </p>
+          </section>
+
+          <section>
+            <h2>What architects should pay attention to</h2>
+            <ul>
+              <li>Whether the portable unit has a clear service boundary.</li>
+              <li>Whether host capabilities are explicit instead of implied.</li>
+              <li>Whether runtime policies stay visible as part of the system model.</li>
+              <li>Whether portability reduces duplication instead of creating new blind spots.</li>
+              <li>Whether the service can be validated consistently across multiple runtime targets.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Where teams go wrong</h2>
+            <p>
+              A common failure mode is to treat WebAssembly as if it alone guarantees a portable architecture. In practice, teams can still
+              build brittle systems if contracts stay vague, host bindings are hidden, or runtime policy lives only in undocumented code.
+            </p>
+            <p>
+              Another failure mode is treating WebAssembly as only a packaging choice. That misses the bigger opportunity. Its real value in
+              UMA is that it gives portable service behavior a stable execution target that the surrounding runtime can govern explicitly.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Does WebAssembly automatically make a system portable?</h3>
+            <p>
+              No. It makes portable execution more practical, but the system still needs contracts, trust, policy, and a coherent service
+              model. Without those, WebAssembly becomes another delivery mechanism rather than a durable architectural boundary.
+            </p>
+            <h3>Does UMA require WebAssembly everywhere?</h3>
+            <p>
+              No. UMA benefits from WebAssembly as a strong portable execution target, but the architectural point is larger than one
+              technology choice. The key question is whether service behavior stays durable while runtime responsibilities remain explicit.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Related pages</strong>
+            <p>
+              If you want to connect WebAssembly to the rest of the UMA model, continue to portable business logic and runtime-agnostic
+              architecture next.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../portable-business-logic/">Portable business logic</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../what-is-wasm-mcp/">What is WASM MCP?</a>
+              <a href="../examples/">Examples</a>
+              <a href="../diagrams/">Diagrams</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/learn-uma/book.md
+++ b/content/pages/learn-uma/book.md
@@ -1,0 +1,171 @@
+---
+ref: book
+title: "Universal Microservices Architecture Book"
+subtitle: "The Universal Microservices Architecture book This book is for architects and senior engineers who can already ship distributed systems, but are no longer satisfied with how quickly those systems fragment across browser, edge, backend, workflow, and AI-assisted execution paths. It uses WebAssembly as an enabling boundary, but the deeper subject is architectural coherence under runtime diversity."
+macro_area: learn-uma
+content_type: onboarding
+slug: book
+canonical_url: "https://www.universalmicroservices.com/book/"
+left_nav_group: learn-uma
+chapter_ref: null
+seo_description: "A practical overview of the Universal Microservices Architecture book, including what it teaches, who it helps, and how it connects to the runnable examples."
+breadcrumbs:
+  - "Home"
+  - "Learn Uma"
+  - "Universal Microservices Architecture Book"
+related_refs:
+  - end-to-end-feature-flag-example
+  - learning-path
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>The Universal Microservices Architecture book</h1>
+          <p>
+            This book is for architects and senior engineers who can already ship distributed systems, but are no longer satisfied with how
+            quickly those systems fragment across browser, edge, backend, workflow, and AI-assisted execution paths. It uses WebAssembly as
+            an enabling boundary, but the deeper subject is architectural coherence under runtime diversity.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>What readers should expect</h2>
+            <p>
+              The book is not a vague argument that portability is good. It works from the smallest portable service boundary outward into
+              runtime design, contracts, orchestration, service graph evolution, trust boundaries, discoverable decisions, and long-term
+              system change. The goal is to give experienced builders a model they can both reason about and challenge with runnable proof.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>What problem it tackles</h3>
+              <p>Why systems keep duplicating business behavior across runtimes even when the team already has good deployment tooling.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>What the reader gets</h3>
+              <p>A structured architectural model for portable services, governed runtime decisions, and explainable workflow execution.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>What keeps it honest</h3>
+              <p>A companion repository and live reference app that let readers inspect the model instead of taking the claims on faith.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Who it is for</h3>
+              <p>Architects, senior engineers, and platform teams trying to keep behavior coherent across client, edge, cloud, and AI surfaces.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>How the book is organized</h2>
+            <p>
+              The book is structured as a progression rather than as an encyclopedia. It begins with one portable service boundary and then
+              deliberately adds the runtime concerns that real systems accumulate: contracts, orchestration, metadata, compatibility,
+              trust, and evolution. This order matters because the later topics only become valuable when the earlier service model is
+              already clear.
+            </p>
+            <p>
+              That structure also helps the reader connect concept to execution. Every major idea has a place in the learning path and in
+              the accompanying examples, so the architecture is explained, then exercised, instead of being left as a purely conceptual
+              framework.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Portable service design</h3>
+              <p>Learn how to preserve business behavior without letting any one framework or host environment own the logic.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime architecture</h3>
+              <p>See how validation, transport, adapters, policy, and trust become explicit parts of the system model.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>System composition</h3>
+              <p>Follow the path from a single service to event-driven orchestration, service graphs, and runtime-governed systems.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Evolution over time</h3>
+              <p>Understand how portability, governance, and compatibility interact as a system grows more complex.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why the book matters now</h2>
+            <p>
+              Modern delivery models already assume software will move between many execution contexts. The real architectural challenge is
+              not simply shipping code to multiple runtimes. It is keeping the meaning of the system stable while those runtimes continue to
+              multiply. That is the problem this book is written to address.
+            </p>
+            <p>
+              That challenge matters more now because runtime diversity is normal. Systems increasingly depend on browser logic, edge
+              functions, background jobs, service platforms, and AI-assisted flows. A useful architectural model can no longer assume that
+              “backend” is the only durable home of business behavior.
+            </p>
+          </section>
+
+          <section>
+            <h2>Who should read it</h2>
+            <p>
+              This book is written for people who are responsible for architectural clarity over time. That includes software architects,
+              senior engineers, platform teams, and technical leads who need a better way to think about service behavior, runtime
+              governance, and long-term system coherence.
+            </p>
+          </section>
+
+          <section>
+            <h2>What makes it different</h2>
+            <p>
+              Many architecture books stay abstract. Many implementation books stay tied to one stack. This book sits between those two
+              worlds. It introduces a concrete architectural model, but keeps the discussion close to runtime behavior, operational
+              pressure, and practical examples. It is also deliberately opinionated about something many books only imply: deployment
+              tooling alone does not solve behavior fragmentation.
+            </p>
+          </section>
+
+          <section>
+            <h2>How it connects to the site and examples</h2>
+            <p>
+              The site acts as the authority hub for the book, while the repository acts as the practical companion. Together they turn the
+              material into a connected experience: understand the idea, follow the learning path, inspect the code, and validate the
+              architecture through runnable examples.
+            </p>
+            <p>
+              If you want to evaluate the model before buying, the best sequence is: read
+              <a href="../what-problem-does-uma-solve/">what problem UMA solves</a>, try the
+              <a href="https://www.universalmicroservices.com/reference-application/">live reference app</a>, and then inspect the
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">examples repository</a>. The book goes further by connecting
+              those pieces into one coherent design argument instead of leaving them as isolated artifacts.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked question</h2>
+            <h3>Do I need to adopt UMA all at once?</h3>
+            <p>
+              No. One of the practical strengths of the model is that it can begin with a single portable service and then expand as runtime
+              and governance complexity increase. The book is sequenced that way intentionally.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Choose your next proof point</strong>
+            <p>
+              If the framing here matches the kind of system pain you are dealing with, the next move depends on how you like to evaluate
+              ideas: concept first, runnable proof first, or the full book path.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-problem-does-uma-solve/">What problem does UMA solve?</a>
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+              <a href="../learning-path/">Learning Path</a>
+              <a href="../examples/">Examples</a>
+              <a href="../what-is-uma/">What is UMA?</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/learn-uma/end-to-end-feature-flag-example.md
+++ b/content/pages/learn-uma/end-to-end-feature-flag-example.md
@@ -1,0 +1,85 @@
+---
+ref: end-to-end-feature-flag-example
+title: "End-to-End UMA Example: Feature Flag Service"
+subtitle: "End-to-end UMA example: feature flag service A feature flag service is a useful end-to-end UMA example because the business behavior is small, testable, and easy to duplicate badly. The same decision often appears in frontend checks, backend authority, edge routing, and workflow logic. UMA turns that repeated rule into one governed capability."
+macro_area: learn-uma
+content_type: onboarding
+slug: end-to-end-feature-flag-example
+canonical_url: "https://www.universalmicroservices.com/end-to-end-feature-flag-example/"
+left_nav_group: learn-uma
+chapter_ref: null
+seo_description: "Follow an end-to-end UMA feature flag service from requirement to capability, contract, build, browser execution, cloud execution, and AI-assisted execution."
+breadcrumbs:
+  - "Home"
+  - "Learn Uma"
+  - "End-to-End UMA Example: Feature Flag Service"
+related_refs:
+  - book
+  - learning-path
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>End-to-end UMA example: feature flag service</h1>
+          <p>A feature flag service is a useful end-to-end UMA example because the business behavior is small, testable, and easy to duplicate badly. The same decision often appears in frontend checks, backend authority, edge routing, and workflow logic. UMA turns that repeated rule into one governed capability.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>1. Requirement</h2>
+            <p>The product needs to decide whether a feature is enabled for a user. The decision may depend on country, account, rollout percentage, or a fallback rule. The important part is that every runtime should agree on the same outcome.</p>
+          </section>
+
+          <section>
+            <h2>2. Capability</h2>
+            <p>The capability is feature flag evaluation. It is narrow enough to test and important enough to keep coherent. That makes it a good first Universal Microservice candidate.</p>
+          </section>
+
+          <section>
+            <h2>3. Contract</h2>
+            <p>The contract defines the input context, flag rules, and decision output. A reader should be able to inspect the contract without needing to understand a specific UI framework or cloud provider.</p>
+            <p>The contract is where the service becomes understandable before it becomes deployable.</p>
+          </section>
+
+          <section>
+            <h2>4. Build</h2>
+            <p>The portable core implements deterministic evaluation. In the repository, the Rust-first path is the authoritative implementation, with TypeScript parity where present to make comparison visible.</p>
+          </section>
+
+          <section>
+            <h2>5. Browser execution</h2>
+            <p>A browser can use the capability when low-latency local decisions are appropriate. The runtime still has to decide which data is safe and which decisions require backend authority.</p>
+          </section>
+
+          <section>
+            <h2>6. Cloud execution</h2>
+            <p>Cloud execution can provide authority, auditability, and integration with backend systems. UMA does not force the choice. It makes the runtime decision explicit.</p>
+          </section>
+
+          <section>
+            <h2>7. AI-assisted execution</h2>
+            <p>An AI-assisted flow may propose a flag change, request an evaluation, or summarize rollout behavior. The runtime remains authoritative over validation and execution. The agent participates, but it does not become the system of record.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Website</h3><p>Conceptual walkthrough of the end-to-end model.</p></article>
+            <article class="subpage-card"><h3>GitHub</h3><p>Runnable examples and validation scripts.</p></article>
+            <article class="subpage-card"><h3>Book</h3><p>Methodology, tradeoffs, governance, and production guidance.</p></article>
+            <article class="subpage-card"><h3>Runtime</h3><p>The authority that decides where execution belongs.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This walkthrough tells the complete story at a high level. The Chapter 4 example lets you run the evaluator, and the book connects the same pattern to contracts, runtime governance, and later production concerns.</p>
+            <div class="subpage-inline-links">
+              <a href="../examples/chapter-04-feature-flag-evaluator/">Feature flag tutorial</a>
+              <a href="../what-is-a-universal-microservice/">What is a Universal Microservice?</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/learn-uma/learning-path.md
+++ b/content/pages/learn-uma/learning-path.md
@@ -1,0 +1,163 @@
+---
+ref: learning-path
+title: "UMA Learning Path"
+subtitle: "The UMA learning path The Universal Microservices Architecture learning path is designed to make a demanding architectural model teachable. It begins with the smallest useful service boundary, then adds the runtime, orchestration, graph, trust, and evolution concerns that eventually define the real behavior of a distributed system."
+macro_area: learn-uma
+content_type: onboarding
+slug: learning-path
+canonical_url: "https://www.universalmicroservices.com/learning-path/"
+left_nav_group: learn-uma
+chapter_ref: null
+seo_description: "Follow a chapter-by-chapter Universal Microservices Architecture learning path, from portable services to trust boundaries, graph evolution, discoverable decisions, and portable MCP runtime composition."
+breadcrumbs:
+  - "Home"
+  - "Learn Uma"
+  - "UMA Learning Path"
+related_refs:
+  - book
+  - end-to-end-feature-flag-example
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>The UMA learning path</h1>
+          <p>
+            The Universal Microservices Architecture learning path is designed to make a demanding architectural model teachable. It begins
+            with the smallest useful service boundary, then adds the runtime, orchestration, graph, trust, and evolution concerns that
+            eventually define the real behavior of a distributed system.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>Why the path is sequenced</h2>
+            <p>
+              UMA only makes sense when the reader can see how each new concern changes the meaning of the architecture. That is why the
+              material is sequenced instead of presented as a loose catalog. The early chapters establish what is portable. The later
+              chapters show what happens when that portable behavior meets runtime complexity.
+            </p>
+          </section>
+
+          <section>
+            <h2>The logic behind the sequence</h2>
+            <p>
+              The early part of the path establishes the core service model. Without that, portability is just an aspiration. The middle
+              part shows how a runtime layer forms around the service and what that layer must own. The later part shows how orchestration,
+              graphs, trust, and governance emerge once there is more than one service and more than one runtime choice in play.
+            </p>
+            <p>
+              This is also the order in which real architectural complexity appears. Systems do not begin as large graphs with governed
+              trust boundaries. They begin with useful behavior and then accumulate responsibilities around it. The learning path mirrors
+              that reality so the model stays intuitive.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Start with one portable service</h3>
+              <p>Understand the smallest durable boundary before introducing transport, hosting, or orchestration concerns.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Add the runtime layer</h3>
+              <p>Make validation, adapter binding, transport, and lifecycle evidence visible around the service behavior.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Watch systems emerge</h3>
+              <p>See how metadata, event compatibility, and runtime decisions cause a graph and orchestration model to appear.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Follow governance and evolution</h3>
+              <p>Understand how trust, compatibility, and system change determine whether portability remains a strength or becomes risk.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>How to use it well</h2>
+            <p>
+              Treat the learning path as a progression, not a menu. Each chapter answers one architectural question and gives the next one
+              context. If you skip directly to the later topics, you can still learn from them, but the bigger picture will be harder to
+              retain.
+            </p>
+            <p>
+              The best way to use the path is to pair each conceptual step with the corresponding runnable material. That keeps the
+              architecture grounded and makes the later chapters much easier to evaluate, because the earlier vocabulary and assumptions are
+              already in place.
+            </p>
+          </section>
+
+          <section>
+            <h2>What the path teaches by the end</h2>
+            <p>
+              By the end of the sequence, the reader should be able to explain more than what UMA is. They should be able to explain why a
+              portable service needs contracts, why runtime behavior must remain visible, why trust belongs inside the architectural model,
+              how a system can evolve without turning into a collection of hidden rewrites, and how governed decisions become queryable artifacts instead of hidden execution side effects.
+            </p>
+            <p>
+              The later chapters also teach readers to recognize an evolution pattern instead of only isolated failures: drift, duplication,
+              version sprawl, and governed recovery are connected stages, not separate random incidents.
+            </p>
+          </section>
+
+          <section>
+            <h2>Where Chapters 12 and 13 change the learning path</h2>
+            <p>
+              Chapter 12 extends the path beyond governed evolution into discoverable decisions. The reader is no longer only asking whether
+              the system behaved correctly. They are asking whether projections, proposals, validation feedback, revision, approved execution,
+              and trace artifacts can be inspected directly by a person or tool without reading hidden runtime code.
+            </p>
+            <p>
+              That changes the standard again. A governed system should not only make valid decisions. It should make the decision lifecycle
+              visible enough that another tool, team, or runtime can inspect what happened without guesswork.
+            </p>
+            <p>
+              That makes the final step important. It turns UMA from a runtime model that can stay coherent into a system model that can also
+              explain itself under change.
+            </p>
+            <p>
+              Chapter 13 then turns that discoverable model into a portable runtime experience. Distributed sources, MCP-style capability
+              descriptors, deterministic agent proposals, event-driven execution, and authoritative runtime validation all participate in the
+              same structured-report flow. That final step matters because it shows how UMA can stay queryable and governed even when the
+              system is acting like a small multi-capability environment instead of a single bounded runtime example.
+            </p>
+          </section>
+
+          <section>
+            <h2>Best path for different readers</h2>
+            <ul>
+              <li>If you are new to UMA, start at the beginning and move chapter by chapter.</li>
+              <li>If you already think in platform terms, pair the learning path with the examples and trust pages.</li>
+              <li>If you mainly want proof, keep the repository open while reading so the architecture remains concrete.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Frequently asked question</h2>
+            <h3>Can I skip ahead to later chapters?</h3>
+            <p>
+              You can, but the later material is much more useful when the early service and runtime model is already clear. The sequence is
+              part of the teaching strategy, not just the table of contents.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Use the runnable path too</strong>
+            <p>
+              The strongest way to follow the learning path is to pair it with the repository. The examples make the same sequence visible
+              through code, tests, and runtime output.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../examples/">Examples</a>
+              <a href="../book/">Book overview</a>
+              <a href="../uma-vs-traditional-microservices/">UMA vs traditional microservices</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../how-systems-evolve-without-fragmentation/">How systems evolve without fragmentation</a>
+              <a href="../what-makes-a-decision-discoverable/">What makes a decision discoverable?</a>
+              <a href="../service-graph-evolution/">Service graph evolution</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/proof/benchmark-and-footprint.md
+++ b/content/pages/proof/benchmark-and-footprint.md
@@ -1,0 +1,351 @@
+---
+ref: benchmark-and-footprint
+title: "UMA Benchmark And Footprint Notes"
+subtitle: "UMA benchmark and footprint notes These numbers are intended as honest proof points, not universal claims. They show that the UMA examples can publish measurable artifact sizes and repeated execution timings while keeping the architectural claim grounded: write once, run where it makes sense."
+macro_area: proof
+content_type: proof
+slug: benchmark-and-footprint
+canonical_url: "https://www.universalmicroservices.com/benchmark-and-footprint/"
+left_nav_group: proof
+chapter_ref: null
+seo_description: "Initial UMA benchmark and footprint notes: reproducible local measurements for portable services, WASI runners, and runtime tradeoffs."
+breadcrumbs:
+  - "Home"
+  - "Proof"
+  - "UMA Benchmark And Footprint Notes"
+related_refs:
+  - how-to-prove-portability
+  - what-makes-a-service-portable
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>UMA benchmark and footprint notes</h1>
+          <p>
+            These numbers are intended as honest proof points, not universal claims. They show that the UMA examples can publish measurable
+            artifact sizes and repeated execution timings while keeping the architectural claim grounded: write once, run where it makes
+            sense.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>How to read this page</h2>
+            <p>
+              The measurements here come from reproducible local runs against fixed inputs. They are useful because they expose tradeoffs
+              clearly. They are not meant to imply that one runtime always wins in every deployment environment.
+            </p>
+            <p>
+              The stronger claim UMA makes is not raw speed alone. It is that portable behavior remains measurable, comparable, and
+              explicit across runtime choices.
+            </p>
+            <p>
+              The startup and memory numbers are especially sensitive to local machine state, filesystem caches, and host runtime behavior.
+              That is why the page shows both repeated timings and one first measured run, rather than pretending there is only one number
+              worth publishing.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Environment</h3>
+              <p>macOS 26.3 on arm64, Rust 1.94.0, Node v23.11.0, local pinned Wasmtime v39.0.0.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Method</h3>
+              <p>Release builds, fixed inputs, warmup runs, then repeated local measurements with mean, median, min, and max timing.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Scope</h3>
+              <p>Chapter 4 for a minimal portable evaluator, and Chapter 6 for native-versus-WASI portability under one contract.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>What not to infer</h3>
+              <p>These are not cloud benchmarks, distributed throughput tests, or cost comparisons across production-scale environments.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>At a glance</h2>
+            <p>
+              These comparisons are normalized inside each row so the slower or larger path sets the full scale. They are not trying to
+              imply global winners across workloads. They are here to make the local tradeoff legible quickly.
+            </p>
+            <div class="benchmark-compare">
+              <article class="benchmark-panel">
+                <h3>Chapter 4 repeated execution</h3>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Rust WASI via Wasmtime</strong><span>33.42 ms mean</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 12.32%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>TypeScript via Node</strong><span>271.17 ms mean</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+              </article>
+              <article class="benchmark-panel">
+                <h3>Chapter 4 first run and memory</h3>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Rust WASI cold start</strong><span>51.63 ms</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 53.53%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>TypeScript cold start</strong><span>96.45 ms</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Rust WASI peak RSS</strong><span>17.09 MiB</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 45.03%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>TypeScript peak RSS</strong><span>37.95 MiB</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+              </article>
+              <article class="benchmark-panel">
+                <h3>Chapter 6 artifact footprint</h3>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Native runner</strong><span>5.31 MiB</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>WASI runner</strong><span>352.33 KiB</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 6.48%"></span></div>
+                </div>
+              </article>
+              <article class="benchmark-panel">
+                <h3>Chapter 6 repeated execution</h3>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Native runner</strong><span>56.73 ms mean</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 14.94%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>WASI runner via Wasmtime</strong><span>379.63 ms mean</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+              </article>
+              <article class="benchmark-panel">
+                <h3>Chapter 6 first run and memory</h3>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Native cold start</strong><span>336.64 ms</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>WASI cold start</strong><span>212.73 ms</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 63.19%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Native peak RSS</strong><span>7.80 MiB</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 17.00%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>WASI peak RSS</strong><span>45.88 MiB</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+              </article>
+              <article class="benchmark-panel">
+                <h3>Chapter 13 reference runtime</h3>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Release CLI binary</strong><span>947.95 KiB</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 100%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Render JSON path</strong><span>512.36 ms mean</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>First measured run</strong><span>964.64 ms</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-warm" style="width: 100%"></span></div>
+                </div>
+                <div class="benchmark-row">
+                  <div class="benchmark-label"><strong>Peak RSS</strong><span>2.19 MiB</span></div>
+                  <div class="benchmark-bar"><span class="benchmark-bar-fill benchmark-bar-fill-accent" style="width: 100%"></span></div>
+                </div>
+              </article>
+            </div>
+          </section>
+
+          <section>
+            <h2>Chapter 4: minimal portable evaluator</h2>
+            <p>
+              Chapter 4 is the right first footprint proof because it shows the smallest portable unit in the repo: one contract, one
+              deterministic evaluator, and one WASI boundary.
+            </p>
+            <ul>
+              <li>WASI module size: <code>198.00 KiB</code></li>
+              <li>Input: <code>lab2-rollout-match.json</code></li>
+              <li>First measured run: <code>51.63 ms</code> (Rust/WASI), <code>96.45 ms</code> (TypeScript/Node)</li>
+              <li>Peak RSS: <code>17.09 MiB</code> (Rust/WASI), <code>37.95 MiB</code> (TypeScript/Node)</li>
+            </ul>
+            <table>
+              <thead>
+                <tr>
+                  <th>Path</th>
+                  <th>Mean (ms)</th>
+                  <th>Median (ms)</th>
+                  <th>Min (ms)</th>
+                  <th>Max (ms)</th>
+                  <th>Runs</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Rust WASI via Wasmtime</td>
+                  <td>33.42</td>
+                  <td>31.93</td>
+                  <td>22.7</td>
+                  <td>57.89</td>
+                  <td>20</td>
+                </tr>
+                <tr>
+                  <td>TypeScript via Node</td>
+                  <td>271.17</td>
+                  <td>125.61</td>
+                  <td>82.44</td>
+                  <td>1662.06</td>
+                  <td>20</td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              On this fixed input, the WASI evaluator stayed dramatically smaller and lighter in memory than the TypeScript path under the
+              same local measurement method. The timing spread is visibly noisy on the Node side, which is exactly why this page now shows
+              repeated timings together with one first measured run. The architectural point is not that Rust or WASI always wins. It is
+              that one portable evaluator can stay compact and measurable without being rewritten into a second implementation just to
+              change the runtime surface.
+            </p>
+          </section>
+
+          <section>
+            <h2>Chapter 6: portability proof under two runtime targets</h2>
+            <p>
+              Chapter 6 is the more interesting benchmark because it keeps one contract and one shared service behavior while running it
+              through both a native path and a WASI path.
+            </p>
+            <ul>
+              <li>Native runner size: <code>5.31 MiB</code></li>
+              <li>WASI runner size: <code>352.33 KiB</code></li>
+              <li>Input: <code>sample-data/sample.pgm</code></li>
+              <li>First measured run: <code>336.64 ms</code> (native), <code>212.73 ms</code> (WASI via Wasmtime)</li>
+              <li>Peak RSS: <code>7.80 MiB</code> (native), <code>45.88 MiB</code> (WASI via Wasmtime)</li>
+            </ul>
+            <table>
+              <thead>
+                <tr>
+                  <th>Path</th>
+                  <th>Mean (ms)</th>
+                  <th>Median (ms)</th>
+                  <th>Min (ms)</th>
+                  <th>Max (ms)</th>
+                  <th>Runs</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Native runner</td>
+                  <td>56.73</td>
+                  <td>45.79</td>
+                  <td>25.79</td>
+                  <td>157.13</td>
+                  <td>20</td>
+                </tr>
+                <tr>
+                  <td>WASI runner via Wasmtime</td>
+                  <td>379.63</td>
+                  <td>290.29</td>
+                  <td>152.34</td>
+                  <td>1616.95</td>
+                  <td>20</td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              This is the tradeoff the page should make explicit. The native runner stays lighter in memory and faster on repeated runs on
+              this machine, while the WASI runner stays much smaller as an artifact and preserves the same behavior under a portable
+              execution target. That is exactly the kind of evidence UMA should publish instead of hiding behind vague portability
+              language.
+            </p>
+          </section>
+
+          <section>
+            <h2>Chapter 13: reference runtime CLI</h2>
+            <p>
+              The earlier chapters prove compact portability. Chapter 13 adds a different kind of evidence: the reference runtime can
+              still expose a deterministic local path without dragging the benchmark through the model-backed AI setup. The measured slice
+              here is the release CLI rendering <code>use-case-1-basic-report</code> as JSON.
+            </p>
+            <ul>
+              <li>CLI binary size: <code>947.95 KiB</code></li>
+              <li>Input: <code>use-case-1-basic-report</code></li>
+              <li>First measured run: <code>964.64 ms</code></li>
+              <li>Peak RSS: <code>2.19 MiB</code></li>
+            </ul>
+            <table>
+              <thead>
+                <tr>
+                  <th>Path</th>
+                  <th>Mean (ms)</th>
+                  <th>Median (ms)</th>
+                  <th>Min (ms)</th>
+                  <th>Max (ms)</th>
+                  <th>Runs</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Render JSON via CLI</td>
+                  <td>512.36</td>
+                  <td>312.45</td>
+                  <td>48.06</td>
+                  <td>2228.3</td>
+                  <td>20</td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              That does not measure the full AI-assisted workflow. It measures the deterministic runtime/report path that should stay
+              fast enough and legible enough to act as a real operational surface, not just a demo shell. It also makes one useful point
+              visible: the Chapter 13 CLI is still a small binary with a modest memory footprint even though the repeated local timing of
+              the full JSON render path is not as tight as the earlier chapter slices.
+            </p>
+          </section>
+
+          <section>
+            <h2>What these numbers actually prove</h2>
+            <p>
+              The important result is not that every portable path is the fastest. The important result is that the portable path remains
+              compact, measurable, and behaviorally comparable. That gives teams a much cleaner basis for deciding where logic should run
+              instead of duplicating the behavior by default.
+            </p>
+            <p>
+              In the book, I use the architectural model behind these examples more broadly than this page can. Here, the goal is narrower:
+              give you honest proof data you can inspect instead of asking you to trust portability claims at face value.
+            </p>
+            <p>
+              If you want to reproduce these numbers locally, the repository includes the reporting script and the generated benchmark
+              artifacts so you can inspect both the method and the result rather than treating this page as a static marketing claim.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Continue from numbers into the model</strong>
+            <p>
+              If the benchmark notes make the tradeoff feel more concrete, the next useful move is to connect them back to portability,
+              runtime authority, and the reference app.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/blob/main/benchmarks/benchmark-proof.md">Benchmark report</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples/blob/main/scripts/report_benchmark_proof.py">Benchmark script</a>
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../how-to-prove-portability/">How to prove portability</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../examples/">Examples</a>
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/proof/how-to-prove-portability.md
+++ b/content/pages/proof/how-to-prove-portability.md
@@ -1,0 +1,176 @@
+---
+ref: how-to-prove-portability
+title: "How to Prove Portability"
+subtitle: "How to prove portability Portability is easy to claim and harder to prove. In UMA, portability becomes credible only when the same service behavior can be observed across more than one runtime target without quietly changing its meaning."
+macro_area: proof
+content_type: proof
+slug: how-to-prove-portability
+canonical_url: "https://www.universalmicroservices.com/how-to-prove-portability/"
+left_nav_group: proof
+chapter_ref: null
+seo_description: "Learn how to prove portability in UMA by comparing observable behavior across runtimes instead of assuming that shared code is enough."
+breadcrumbs:
+  - "Home"
+  - "Proof"
+  - "How to Prove Portability"
+related_refs:
+  - benchmark-and-footprint
+  - what-makes-a-service-portable
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>How to prove portability</h1>
+          <p>
+            Portability is easy to claim and harder to prove. In UMA, portability becomes credible only when the same service behavior can
+            be observed across more than one runtime target without quietly changing its meaning.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              You prove portability by comparing observable behavior, not by trusting shared source code or similar intent. If two runtime
+              targets emit the same governed result from the same contract and input, portability is becoming evidence instead of a slogan.
+            </p>
+            <p>
+              That comparison matters because many systems look portable in code review while still drifting in execution. The only honest
+              test is what the system actually does.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why shared code is not enough</h2>
+            <p>
+              Shared code can be a useful starting point, but it does not prove the behavior is stable once the code is compiled, hosted,
+              and run under different runtime constraints. Subtle host assumptions, missing capabilities, data-shape drift, and adapter
+              shortcuts can all change the outcome while leaving the codebase looking deceptively aligned.
+            </p>
+            <p>
+              That is why UMA treats portability as something to validate from outputs, events, and contract-governed results instead of
+              something to assume from a familiar repository structure.
+            </p>
+          </section>
+
+          <section>
+            <h2>What to compare instead</h2>
+            <p>
+              The most useful comparison point is observable behavior. That can mean a shared result payload, an emitted event, a stable
+              output shape, or another contract-visible artifact that shows the service behaved the same way under two runtimes.
+            </p>
+            <p>
+              Once the comparison becomes observable, portability stops being an abstract architectural virtue. It becomes something a
+              reader, a reviewer, and a runtime test can all evaluate directly.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Compare results</h3>
+              <p>Use the same contract and input, then compare the resulting behavior across runtimes.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Keep differences visible</h3>
+              <p>Target-specific capabilities should stay explicit instead of leaking into the portable path unnoticed.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Trust emitted evidence</h3>
+              <p>Event streams, payloads, and digests make parity easier to inspect than implementation claims alone.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Let the contract lead</h3>
+              <p>Portability is more credible when the same contract governs both targets without hidden forks.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why observable parity matters</h2>
+            <p>
+              Observable parity is stronger than “both implementations look similar.” If two runtimes converge on the same contract-shaped
+              result, the architecture can point to something concrete. If they do not, the system has already learned something valuable:
+              where portability breaks and which boundary is not as durable as it seemed.
+            </p>
+            <p>
+              That is one reason Chapter 6 matters so much in the learning path. It turns portability from a design preference into a test
+              that can pass or fail in public.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why target-specific behavior should stay explicit</h2>
+            <p>
+              Proving portability does not mean pretending every runtime should behave identically in every respect. Some capabilities are
+              inherently target-specific. The important point is that those differences stay visible and do not contaminate the portable
+              behavior being compared.
+            </p>
+            <p>
+              A good portability test therefore has two layers: the shared behavior that should stay aligned, and the runtime-specific
+              behavior that should remain explicit as a governed difference rather than a hidden divergence.
+            </p>
+          </section>
+
+          <section>
+            <h2>How portability usually gets overstated</h2>
+            <p>
+              Teams often overstate portability when they stop at “the same logic compiles” or “the implementations are based on the same
+              design.” Those are encouraging signs, but they are not enough. Portability becomes trustworthy only when the system can show
+              that the actual behavior stayed aligned under real execution.
+            </p>
+            <p>
+              Another common mistake is to ignore the runtime-specific paths that do differ. That weakens the claim because it blurs the
+              line between portable behavior and host-only extensions. UMA is clearer when both are visible.
+            </p>
+          </section>
+
+          <section>
+            <h2>A practical portability proof checklist</h2>
+            <ul>
+              <li>Use one explicit contract across the runtime targets you are comparing.</li>
+              <li>Run the same service behavior with the same relevant input.</li>
+              <li>Compare observable outputs or events rather than source structure.</li>
+              <li>Make target-specific capabilities visible instead of hiding them.</li>
+              <li>Record enough evidence to explain why parity passed or failed.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Does portability require byte-for-byte identical execution?</h3>
+            <p>
+              No. What matters is that the portable behavior stays semantically aligned. Some runtime-specific details may differ, but the
+              business result being protected should remain stable.
+            </p>
+            <h3>Why compare events or payloads instead of internal code paths?</h3>
+            <p>
+              Because emitted results are what the architecture can actually prove. Internal similarity is informative, but it does not
+              settle whether the system behaved the same way in practice.
+            </p>
+            <h3>Can a portability check fail and still be useful?</h3>
+            <p>
+              Yes. A failed portability check is still valuable because it shows exactly where the architecture is not yet as runtime-agnostic
+              or contract-disciplined as it claimed to be.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Turn portability into evidence</strong>
+            <p>
+              This page gives the test, not the whole runtime story around it. In the book, I go further into how portability checks
+              change the way teams reason about service boundaries, execution targets, and confidence. On the site, the best next step is
+              to connect this idea to portable services, the runtime layer, and the runnable examples.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../what-belongs-in-the-runtime-layer/">What belongs in the runtime layer?</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../examples/">Examples</a>
+              <a href="../diagrams/">Diagrams</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/proof/what-makes-a-service-portable.md
+++ b/content/pages/proof/what-makes-a-service-portable.md
@@ -1,0 +1,186 @@
+---
+ref: what-makes-a-service-portable
+title: "What Makes a Service Portable?"
+subtitle: "What makes a service portable? A portable service is not just code that happens to compile in more than one place. In UMA, a service becomes portable when its business behavior stays stable while the runtime around it is allowed to vary openly."
+macro_area: proof
+content_type: proof
+slug: what-makes-a-service-portable
+canonical_url: "https://www.universalmicroservices.com/what-makes-a-service-portable/"
+left_nav_group: proof
+chapter_ref: null
+seo_description: "Learn what makes a service portable in UMA: deterministic behavior, explicit contracts, visible runtime boundaries, and stable output semantics."
+breadcrumbs:
+  - "Home"
+  - "Proof"
+  - "What Makes a Service Portable?"
+related_refs:
+  - benchmark-and-footprint
+  - how-to-prove-portability
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What makes a service portable?</h1>
+          <p>
+            A portable service is not just code that happens to compile in more than one place. In UMA, a service becomes portable when
+            its business behavior stays stable while the runtime around it is allowed to vary openly.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              A service is portable when four things stay true at the same time: its behavior remains semantically stable, its contract is
+              explicit, its output stays comparable across runtimes, and the runtime-specific concerns remain outside the portable core.
+            </p>
+            <p>
+              That is stricter than “shared logic.” Portability becomes real only when a team can preserve meaning, not just move code.
+              In UMA terms, the goal is not “write once, run everywhere.” It is “write once, run where it makes sense.”
+            </p>
+          </section>
+
+          <section>
+            <h2>Portability starts with deterministic behavior</h2>
+            <p>
+              The first thing a portable service needs is stable behavior. If the same input produces different decisions depending on the
+              host, the integration layer, or the deployment surface, the service is not really portable. It is only being re-expressed in
+              several places.
+            </p>
+            <p>
+              This is why deterministic behavior matters so much in early UMA examples. A small, portable service should be boring in the
+              best possible way: the same contract, the same rules, the same output shape, and the same result wherever the service is
+              validated correctly.
+            </p>
+          </section>
+
+          <section>
+            <h2>Contracts make portability governable</h2>
+            <p>
+              Portability becomes much easier to reason about when inputs and outputs are explicit. Without that, teams often mistake
+              “shared intention” for portable behavior. One implementation seems close enough to another, but the architecture still lacks
+              a stable reference point.
+            </p>
+            <p>
+              A contract gives the service a visible boundary. It tells the runtime, the tests, and the reader what the service expects and
+              what it is supposed to produce. That is what turns portability from a hope into something a system can validate.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Stable behavior</h3>
+              <p>The same input should lead to the same business decision across the runtimes you claim to support.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Visible contract</h3>
+              <p>Inputs, outputs, and expectations should be explicit enough to test, compare, and govern.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Runtime separation</h3>
+              <p>Transport, hosting, trust, and adapters should surround the service instead of quietly redefining it.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Comparable output</h3>
+              <p>Portability is easier to prove when different implementations converge on the same observable result.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>What the runtime should not own</h2>
+            <p>
+              The runtime should own validation, policy, placement, capabilities, trust, and integration concerns around the service. It
+              should not own the business rule that gives the service its meaning. When the runtime starts smuggling business behavior into
+              adapters or environment-specific helpers, portability has already begun to erode.
+            </p>
+            <p>
+              That is why a portable service boundary is so useful early in the UMA learning path. It makes the split visible: the service
+              owns the rule; the runtime owns the conditions around execution.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why small services matter first</h2>
+            <p>
+              The easiest place to understand portability is a small service with clear rules and low ambiguity. If a team cannot keep one
+              small service deterministic and contract-shaped, it will struggle even more when orchestration, trust, workflow selection,
+              and dynamic capability discovery enter the picture.
+            </p>
+            <p>
+              That is why the UMA learning path starts small. Portability is easier to believe once it is observable in one compact service
+              boundary before it becomes part of a larger governed system.
+            </p>
+          </section>
+
+          <section>
+            <h2>How portability is usually lost</h2>
+            <p>
+              A service often stops being portable gradually. One runtime adds a convenience branch. Another adds a host-specific shortcut.
+              A third enriches the output shape because a local consumer needs more context. None of those changes looks dramatic by
+              itself, but together they move the real behavior out of the portable center and back into stack-owned code.
+            </p>
+            <p>
+              Once that happens, the architecture still looks portable from far away, but the durable behavior no longer lives in one
+              place. The service is shared in name more than in fact.
+            </p>
+          </section>
+
+          <section>
+            <h2>A practical portability test</h2>
+            <p>
+              Ask three questions. First: can the service be described through one explicit contract? Second: do the same inputs produce
+              the same business result across the runtimes you claim to support? Third: can runtime-specific code change without rewriting
+              the rule itself?
+            </p>
+            <p>
+              If those answers are yes, you probably have a portable service. If not, you may still have useful shared code, but you do
+              not yet have a service boundary the architecture can trust for long-term portability.
+            </p>
+            <p>
+              If you want the next step beyond this test, the practical follow-up is
+              <a href="../how-to-prove-portability/">how to prove portability</a> from observable outputs and events rather than relying on
+              shared implementation structure alone.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Is portability the same as code sharing?</h3>
+            <p>
+              No. Code can be shared while behavior still drifts. Portability is stronger: it means the behavior itself remains stable and
+              the runtime differences stay explicit around it.
+            </p>
+            <h3>Does a portable service have to run everywhere?</h3>
+            <p>
+              No. A service can be portable without being deployed in every environment. Portability is about preserving one durable
+              behavior, not forcing universal placement.
+            </p>
+            <h3>Why does deterministic behavior matter so much?</h3>
+            <p>
+              Because deterministic behavior makes portability testable. If the same service produces different decisions across runtimes,
+              the architecture no longer has one stable expression of the rule.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Follow the portable boundary into the system</strong>
+            <p>
+              This page explains the qualities of a portable service, not the whole system that grows around it. In the book, I take that
+              small boundary deeper into runtime design, orchestration, and trust so the broader consequences become concrete. On the site,
+              the next useful step is to connect portability to capability, runtime, and portable business logic.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../how-to-prove-portability/">How to prove portability</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../portable-business-logic/">Portable business logic</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../examples/">Examples</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/why-uma/from-stack-ownership-to-behavior-ownership.md
+++ b/content/pages/why-uma/from-stack-ownership-to-behavior-ownership.md
@@ -1,0 +1,211 @@
+---
+ref: from-stack-ownership-to-behavior-ownership
+title: "From Stack Ownership to Behavior Ownership"
+subtitle: "From stack ownership to behavior ownership One of the biggest hidden shifts in modern architecture is this: the durable unit of value is no longer the stack that runs the code. It is the business behavior that must survive as code moves across browser, edge, backend, workflow, and AI-assisted contexts."
+macro_area: why-uma
+content_type: overview
+slug: from-stack-ownership-to-behavior-ownership
+canonical_url: "https://www.universalmicroservices.com/from-stack-ownership-to-behavior-ownership/"
+left_nav_group: why-uma
+chapter_ref: null
+seo_description: "Learn why modern software architecture needs to move from stack ownership to behavior ownership, and how UMA reframes systems around durable business meaning."
+breadcrumbs:
+  - "Home"
+  - "Why Uma"
+  - "From Stack Ownership to Behavior Ownership"
+related_refs:
+  - what-is-a-universal-microservice
+  - what-is-uma
+  - what-problem-does-uma-solve
+  - why-universal-microservices-exist
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>From stack ownership to behavior ownership</h1>
+          <p>
+            One of the biggest hidden shifts in modern architecture is this: the durable unit of value is no longer the stack that runs the
+            code. It is the business behavior that must survive as code moves across browser, edge, backend, workflow, and AI-assisted
+            contexts.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              Stack ownership organizes software around where code lives. Behavior ownership organizes software around what the system must
+              keep meaningfully correct. UMA matters because modern products often lose that second perspective. Teams know who owns the
+              frontend, backend, or edge runtime, but they no longer know who owns the durable expression of one business rule.
+            </p>
+            <p>
+              That is where drift starts. The stack remains clear. The behavior does not.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why stack ownership was not irrational</h2>
+            <p>
+              Organizing work around stacks was a practical response to real engineering constraints. Teams needed clear boundaries. They
+              needed ownership models that matched tools, deployment pipelines, and operational accountability. That approach still solves
+              important problems.
+            </p>
+            <p>
+              The trouble begins when stack ownership is treated as the primary architectural truth. Once that happens, the business
+              behavior itself becomes secondary. It gets split across the stacks that happen to deliver it, rather than preserved as one
+              durable concern.
+            </p>
+          </section>
+
+          <section>
+            <h2>What behavior ownership changes</h2>
+            <p>
+              Behavior ownership asks a different question: what part of the system must remain semantically stable even when execution
+              moves? Instead of starting from frontend, backend, or edge as the default unit, it starts from the rule, decision, or domain
+              meaning that the organization needs to preserve.
+            </p>
+            <p>
+              This is not a denial of runtime differences. It is a refusal to let those differences quietly redefine the business meaning of
+              the system every time behavior crosses a boundary.
+            </p>
+            <p>
+              That distinction becomes especially useful once one product behavior starts touching UI validation, service enforcement,
+              background automation, and AI-assisted composition at the same time. At that point, stack ownership still explains who
+              shipped each layer, but it no longer explains who preserved the meaning of the behavior.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Stack ownership</h3>
+              <p>Clear for team boundaries, deployment pipelines, and local responsibility.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Behavior ownership</h3>
+              <p>Clear for preserving one durable business meaning across many execution contexts.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Stack ownership risk</h3>
+              <p>The same rule gets reauthored wherever delivery pressure is highest.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Behavior ownership gain</h3>
+              <p>The architecture keeps one reference point for what the service actually means.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why this matters more now than before</h2>
+            <p>
+              Older systems could sometimes get away with stack-centered ownership because execution surfaces were fewer and more stable.
+              Modern systems rarely have that luxury. A product may need the same behavior in web UX, backend enforcement, edge response,
+              event workflows, and AI-assisted decisions. That makes behavior ownership much more important than it used to be.
+            </p>
+            <p>
+              If the architecture keeps centering only on stacks, the behavior becomes fragmented almost by default. Each stack starts
+              carrying its own version of the truth.
+            </p>
+          </section>
+
+          <section>
+            <h2>How UMA reframes the problem</h2>
+            <p>
+              UMA does not erase stacks. It changes what the architecture treats as durable. The durable unit becomes the portable service
+              behavior, expressed through contracts and surrounded by runtime governance. The stacks still exist. They simply stop owning
+              the meaning of the service by default.
+            </p>
+            <p>
+              That is why the model fits naturally with portable execution and governed runtimes. Once behavior ownership becomes primary,
+              the runtime can adapt execution without forcing a rewrite of the rule itself.
+            </p>
+          </section>
+
+          <section>
+            <h2>What this looks like in practice</h2>
+            <p>
+              In a stack-owned design, the frontend owns part of a rule for responsiveness, the backend owns a second version for
+              authority, and a workflow or report layer owns a third copy for automation. In a behavior-owned design, the rule has a more
+              durable center, while the surrounding runtimes handle validation, presentation, placement, and integration concerns.
+            </p>
+            <p>
+              That does not eliminate runtime-specific code. It makes that code more honest about what it is doing. The runtime adapts. The
+              behavior stays recognizable.
+            </p>
+          </section>
+
+          <section>
+            <h2>How to tell when the architecture is still stack-owned</h2>
+            <p>
+              Look for moments where the same business rule is described differently depending on which team you ask. If the browser team
+              describes one version, the backend team describes a second version, and the workflow or reporting layer carries a third,
+              the architecture is already signaling that the stack owns the behavior more than the system does.
+            </p>
+            <p>
+              Another sign is when a change request has to be translated into several implementation stories before anyone can say whether
+              the behavior itself is complete. That usually means the organization has runtime clarity but weak behavioral ownership.
+            </p>
+          </section>
+
+          <section>
+            <h2>What this idea is not</h2>
+            <ul>
+              <li>It is not an argument that teams should stop owning systems.</li>
+              <li>It is not a claim that runtimes no longer matter.</li>
+              <li>It is not a shortcut around policy, trust, or operational design.</li>
+              <li>It is not the same as “share more code.”</li>
+              <li>It is a shift in what the architecture treats as the durable center.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>A practical design test</h2>
+            <p>
+              Ask this question: if one important behavior changes, who owns the update? If the answer is “several stacks, in different
+              ways,” the system is still stack-owned at the behavioral level. If the answer is “one durable service meaning, with runtime
+              adaptation around it,” the architecture is moving closer to behavior ownership.
+            </p>
+            <p>
+              That test is useful because it turns a philosophical distinction into something teams can actually inspect.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked questions</h2>
+            <h3>Does behavior ownership replace team ownership?</h3>
+            <p>
+              No. Teams still need clear ownership. The shift is architectural: team boundaries should not silently become the only place
+              where business meaning is defined.
+            </p>
+            <h3>Is behavior ownership just another name for reusable business logic?</h3>
+            <p>
+              Not quite. Reuse is part of it, but behavior ownership is really about preserving one durable source of semantic truth across
+              multiple runtime surfaces.
+            </p>
+            <h3>Why is this idea useful before the rest of UMA?</h3>
+            <p>
+              Because it explains why the later concepts matter. Capabilities, workflows, runtimes, and discovery all make more sense once
+              the architecture stops centering only on stacks.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Follow the shift into the rest of the model</strong>
+            <p>
+              This page gives the architectural lens, not the full argument. In the book, I take this shift further into service design,
+              organizational pressure, and runtime responsibility so the tradeoffs become much more concrete. On the site, the best next
+              move is to connect behavior ownership to the portable service model around it.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../portable-business-logic/">Portable business logic</a>
+              <a href="../what-is-uma/">What is UMA?</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/why-uma/what-is-a-universal-microservice.md
+++ b/content/pages/why-uma/what-is-a-universal-microservice.md
@@ -1,0 +1,80 @@
+---
+ref: what-is-a-universal-microservice
+title: "What Is a Universal Microservice?"
+subtitle: "What is a Universal Microservice? A Universal Microservice is a small unit of business behavior that can remain recognizable across runtime contexts. It is not just a service that has been packaged differently. It is a capability with an explicit contract, portable core logic, and a runtime boundary that makes validation, placement, trust, and execution visible."
+macro_area: why-uma
+content_type: overview
+slug: what-is-a-universal-microservice
+canonical_url: "https://www.universalmicroservices.com/what-is-a-universal-microservice/"
+left_nav_group: why-uma
+chapter_ref: null
+seo_description: "Define a Universal Microservice, what makes it portable, how its lifecycle works, and how it differs from a traditional service."
+breadcrumbs:
+  - "Home"
+  - "Why Uma"
+  - "What Is a Universal Microservice?"
+related_refs:
+  - from-stack-ownership-to-behavior-ownership
+  - what-is-uma
+  - what-problem-does-uma-solve
+  - why-universal-microservices-exist
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What is a Universal Microservice?</h1>
+          <p>A Universal Microservice is a small unit of business behavior that can remain recognizable across runtime contexts. It is not just a service that has been packaged differently. It is a capability with an explicit contract, portable core logic, and a runtime boundary that makes validation, placement, trust, and execution visible.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short definition</h2>
+            <p>A Universal Microservice is the primary object in UMA. It owns a specific behavior, exposes a clear contract, and can be executed through more than one runtime path without changing what the behavior means.</p>
+            <p>The portable summary is write once, run where it makes sense. That matters because the runtime may change while the service meaning should not.</p>
+          </section>
+
+          <section>
+            <h2>Properties that define it</h2>
+            <p>A Universal Microservice has a narrow responsibility, deterministic inputs and outputs where possible, explicit capability expectations, and a boundary that does not depend on one host framework. It can be wrapped by different adapters, but the adapters do not become the service.</p>
+            <p>The core question is simple: can the behavior be understood, tested, and governed without assuming one permanent deployment surface?</p>
+          </section>
+
+          <section>
+            <h2>How it differs from a traditional service</h2>
+            <p>A traditional microservice is usually defined by deployment, ownership, and network boundaries. A Universal Microservice is defined first by portable behavior and then by the runtime decisions that surround it.</p>
+            <p>This does not make conventional services obsolete. It makes the durable behavioral unit more explicit when the same capability needs to appear in browser, edge, cloud, workflow, or AI-assisted execution paths.</p>
+          </section>
+
+          <section>
+            <h2>What makes it portable</h2>
+            <p>Portability comes from separating core behavior from host concerns. Contracts describe what the service accepts and returns. The runtime handles validation, transport, policy, and placement. That separation lets the same behavior move without dragging a whole application stack behind it.</p>
+            <p>WebAssembly can provide a strong execution boundary, but UMA is the architectural model that keeps the boundary meaningful.</p>
+          </section>
+
+          <section>
+            <h2>Lifecycle of a Universal Microservice</h2>
+            <p>The lifecycle begins with a capability, then a contract, then a portable implementation, then runtime exposure, validation, observation, and versioned evolution. The service is not complete just because it compiles. It is complete when the runtime can govern how and where it is used.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Capability</h3><p>The service exists because the system needs one specific behavior to remain coherent.</p></article>
+            <article class="subpage-card"><h3>Contract</h3><p>Inputs, outputs, events, and expectations are explicit enough for humans and tools to inspect.</p></article>
+            <article class="subpage-card"><h3>Portable core</h3><p>The behavior is not hidden inside framework glue or a single host process.</p></article>
+            <article class="subpage-card"><h3>Runtime governance</h3><p>Placement, policy, trust, and validation stay visible as the service moves.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This page defines the object at a conceptual level. Chapters 2 through 4 of the book build the complete design model, and the first runnable proof lives in the feature flag evaluator example.</p>
+            <div class="subpage-inline-links">
+              <a href="../what-is-uma/">What is UMA?</a>
+              <a href="../what-makes-a-service-portable/">What makes a service portable?</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../examples/chapter-04-feature-flag-evaluator/">Feature flag example</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/why-uma/what-is-uma.md
+++ b/content/pages/why-uma/what-is-uma.md
@@ -1,0 +1,172 @@
+---
+ref: what-is-uma
+title: "What Is UMA?"
+subtitle: "What is Universal Microservices Architecture? Universal Microservices Architecture, or UMA, is an execution model for distributed systems where compute can happen in many places and the system decides where logic runs. It keeps business behavior portable while still treating runtime policy, transport, trust, and execution boundaries as first-class architectural concerns."
+macro_area: why-uma
+content_type: overview
+slug: what-is-uma
+canonical_url: "https://www.universalmicroservices.com/what-is-uma/"
+left_nav_group: why-uma
+chapter_ref: null
+seo_description: "Learn what Universal Microservices Architecture is, why it matters, and how it keeps business behavior portable across client, edge, and cloud runtimes."
+breadcrumbs:
+  - "Home"
+  - "Why Uma"
+  - "What Is UMA?"
+related_refs:
+  - from-stack-ownership-to-behavior-ownership
+  - what-is-a-universal-microservice
+  - what-problem-does-uma-solve
+  - why-universal-microservices-exist
+---
+
+## intro
+
+<section class="subpage-hero">
+            <h1>What is Universal Microservices Architecture?</h1>
+            <p>
+              Universal Microservices Architecture, or UMA, is an execution model for distributed systems where compute can happen in many
+              places and the system decides where logic runs. It keeps business behavior portable while still treating runtime policy,
+              transport, trust, and execution boundaries as first-class architectural concerns.
+            </p>
+          </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The problem UMA is trying to solve</h2>
+            <p>
+              Most software teams do not struggle because they cannot build services. They struggle because the same behavior keeps being
+              reimplemented in different places. A decision appears once in the browser, once in the backend, once in an edge worker, and
+              again inside an internal workflow. Over time the architecture drifts, the product experience diverges, and the system becomes
+              harder to reason about.
+            </p>
+            <p>
+              UMA starts from the idea that architecture should preserve behavior before it preserves deployment shape. Instead of using
+              “frontend,” “backend,” or “microservice” as the primary organizing principle, it treats the portable service boundary as the
+              durable unit and then makes runtime-specific responsibilities explicit around it.
+            </p>
+            <p>
+              That is why one of the most useful early distinctions in UMA is the move from
+              <a href="../from-stack-ownership-to-behavior-ownership/">stack ownership to behavior ownership</a>. Without that shift, the
+              rest of the model can sound like a runtime technique instead of an architectural correction.
+            </p>
+            <p>
+              If you want the direct cold-reader version of that gap before going deeper into the model, start with
+              <a href="../what-problem-does-uma-solve/">what problem UMA solves</a>.
+            </p>
+          </section>
+
+          <section>
+            <h2>A practical definition of UMA</h2>
+            <p>
+              UMA is a design model for software that must survive across many execution environments without losing its architectural
+              clarity. It treats the portable service boundary as the durable unit of the system, while treating validation, transport,
+              policy, permissions, and runtime placement as explicit surrounding concerns. That distinction is what keeps portability from
+              collapsing into duplication.
+            </p>
+            <p>
+              Another way to say it is this: UMA is not “write once, run everywhere.” It is “write once, run where it makes sense.” The
+              service remains recognizable, the runtime stays governed, and the system stays explainable for longer.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Portable service behavior</h3>
+              <p>Rules, decisions, and business intent should survive across runtimes without being rewritten every time execution moves.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Explicit contracts</h3>
+              <p>Inputs, outputs, events, and capability expectations should be machine-readable instead of hidden in framework glue code.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Governed runtime decisions</h3>
+              <p>Placement, policy, trust, and orchestration are still important, but they become visible parts of the model.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Long-term coherence</h3>
+              <p>Versioning, change, compatibility, and system growth remain architectural topics instead of operational cleanup work.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>How UMA differs from conventional boundaries</h2>
+            <p>
+              Traditional architectural labels mostly describe where code runs or which team owns it. UMA is more interested in whether the
+              behavior itself can remain stable while the runtime context changes. That is why the model aligns naturally with WebAssembly:
+              WebAssembly provides a portable execution boundary, while UMA provides the architectural discipline required to keep that
+              boundary meaningful at system scale.
+            </p>
+            <p>
+              In that sense, UMA is not trying to replace every existing architectural style with a new label. It is trying to answer a
+              modern problem that older labels do not explain well enough: how to keep one business capability coherent when it must execute
+              across client, edge, server, background, and agent-like contexts.
+            </p>
+          </section>
+
+          <section>
+            <h2>Why this matters in real systems</h2>
+            <p>
+              Organizations rarely plan to duplicate important business behavior. It happens because teams are rewarded for shipping inside
+              local boundaries. The browser team adds a rule for responsiveness. The backend team repeats it for safety. The edge layer
+              reintroduces it for latency reasons. A workflow adds it again because the event model does not expose the same logic. Each
+              step feels reasonable, but the result is drift.
+            </p>
+            <p>
+              UMA matters because it gives that organization a different architectural center of gravity. Instead of treating local runtime
+              ownership as the default, it starts from a portable behavior model and forces the runtime-specific decisions to stay visible.
+            </p>
+          </section>
+
+          <section>
+            <h2>What UMA is not</h2>
+            <ul>
+              <li>It is not a promise that every service should run everywhere.</li>
+              <li>It is not a claim that runtimes stop mattering once logic is portable.</li>
+              <li>It is not a framework feature or a deployment trick.</li>
+              <li>It is not an excuse to ignore trust, policy, or operational design.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Who should care about this model</h2>
+            <p>
+              UMA is useful for architects, platform engineers, senior developers, and technical leads who need a more stable way to think
+              about software that crosses runtime boundaries. It is especially useful when systems must preserve behavior across product
+              surfaces and when architectural drift is starting to show up as duplicated rules, inconsistent outcomes, or governance gaps.
+            </p>
+          </section>
+
+          <section>
+            <h2>Frequently asked question</h2>
+            <h3>Is UMA only relevant if I use WebAssembly?</h3>
+            <p>
+              No. WebAssembly is a strong fit because it provides a practical execution boundary for portable behavior, but the architectural
+              model is larger than the compilation target. UMA is fundamentally about keeping service meaning stable and runtime decisions
+              explicit.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Continue the path</strong>
+            <p>
+              If you want the practical version of this idea, use the learning path and examples next. That is where UMA stops being a
+              definition and becomes something you can inspect, run, and evaluate.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../learning-path/">Learning Path</a>
+              <a href="../examples/">Examples</a>
+              <a href="../what-problem-does-uma-solve/">What problem does UMA solve?</a>
+              <a href="../uma-vs-traditional-microservices/">UMA vs traditional microservices</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="../what-is-a-workflow/">What is a workflow?</a>
+              <a href="../what-is-a-uma-runtime/">What is a UMA runtime?</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/why-uma/what-problem-does-uma-solve.md
+++ b/content/pages/why-uma/what-problem-does-uma-solve.md
@@ -1,0 +1,166 @@
+---
+ref: what-problem-does-uma-solve
+title: "What Problem Does UMA Solve?"
+subtitle: "What problem does UMA solve? UMA exists because modern systems keep preserving deployment freedom while losing behavioral coherence. The same business rule gets reintroduced in the browser, edge layer, backend, workflow engine, and now inside AI-assisted paths. Each move feels locally justified. The system as a whole becomes harder to explain, govern, and change."
+macro_area: why-uma
+content_type: overview
+slug: what-problem-does-uma-solve
+canonical_url: "https://www.universalmicroservices.com/what-problem-does-uma-solve/"
+left_nav_group: why-uma
+chapter_ref: null
+seo_description: "Understand the core problem Universal Microservices Architecture solves: keeping one business behavior coherent across browser, edge, cloud, workflows, and AI-assisted execution."
+breadcrumbs:
+  - "Home"
+  - "Why Uma"
+  - "What Problem Does UMA Solve?"
+related_refs:
+  - from-stack-ownership-to-behavior-ownership
+  - what-is-a-universal-microservice
+  - what-is-uma
+  - why-universal-microservices-exist
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>What problem does UMA solve?</h1>
+          <p>
+            UMA exists because modern systems keep preserving deployment freedom while losing behavioral coherence. The same business rule
+            gets reintroduced in the browser, edge layer, backend, workflow engine, and now inside AI-assisted paths. Each move feels
+            locally justified. The system as a whole becomes harder to explain, govern, and change.
+          </p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The short answer</h2>
+            <p>
+              UMA solves the problem of behavior fragmentation across runtimes. It gives teams an execution model for distributed systems
+              where compute can happen in many places and the system decides where logic runs, while still keeping one business behavior
+              portable and runtime choices explicit.
+            </p>
+            <p>
+              It is not mainly a deployment optimization. It is an architectural response to a system that keeps multiplying its execution
+              surfaces faster than its architectural model evolves.
+            </p>
+            <p>
+              The useful portability slogan here is not “write once, run everywhere.” It is “write once, run where it makes sense.”
+            </p>
+          </section>
+
+          <section>
+            <h2>What the pain looks like in real teams</h2>
+            <p>
+              A product rule starts in one place and then spreads. The frontend adds a local check for responsiveness. The backend repeats
+              it for authority. An edge adapter copies part of it for latency. A workflow or agent path recreates it because the original
+              service boundary is no longer visible enough to reuse directly. No single duplication looks outrageous. The total effect is
+              drift.
+            </p>
+            <p>
+              When that happens, the architecture is no longer governed by one stable model of behavior. It is governed by whichever
+              runtime happened to become responsible for the latest copy.
+            </p>
+          </section>
+
+          <section class="subpage-grid">
+            <article class="subpage-card">
+              <h3>Repeated business rules</h3>
+              <p>The same logic is expressed several times because each runtime surface wants a local version of the rule.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Hidden runtime authority</h3>
+              <p>Placement, adapters, policy, trust, and orchestration start deciding outcomes without staying legible in the architecture.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Expensive change</h3>
+              <p>Simple rule updates require touching multiple stacks, increasing the chance of inconsistency and regression.</p>
+            </article>
+            <article class="subpage-card">
+              <h3>Weaker explanation</h3>
+              <p>The system can still work while becoming harder to audit, reason about, and evolve safely.</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>Why common platform tooling does not fully solve it</h2>
+            <p>
+              Good platform tooling can deploy services, route traffic, scale workloads, and wrap them with observability or policy. Those
+              are necessary capabilities. They still do not guarantee that one business behavior remains coherent as execution spreads
+              across browser, edge, backend, background jobs, and AI-assisted workflows.
+            </p>
+            <p>
+              That is why UMA is not mainly competing with deployment platforms. It is trying to solve a different architectural gap: the
+              absence of a durable model for one behavior that can survive across many runtime surfaces without being silently reauthored by
+              each one.
+            </p>
+          </section>
+
+          <section>
+            <h2>What UMA changes</h2>
+            <p>
+              UMA changes the center of gravity. Instead of treating the deployable unit as the main architectural anchor, it treats
+              portable behavior as the durable unit and makes the runtime around it explicit. That runtime can then discover capabilities,
+              validate constraints, approve workflows, enforce trust, and preserve enough trace for the system to explain what happened.
+            </p>
+            <p>
+              In practical terms, UMA tries to keep three things true at once:
+            </p>
+            <ul>
+              <li>the service behavior stays recognizable across runtimes</li>
+              <li>runtime decisions stay governed instead of becoming hidden architecture</li>
+              <li>system evolution stays visible instead of collapsing into duplication and drift</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>Why this matters more now</h2>
+            <p>
+              The problem is sharper today because more systems now include workflow engines, edge execution, local client logic, and
+              agent-assisted planning. If the architecture only models backend service ownership, it leaves too much of the real system
+              outside the durable design vocabulary.
+            </p>
+            <p>
+              UMA becomes relevant when a team realizes its hardest architectural problem is no longer just how to split services. It is
+              how to keep one business behavior coherent while several runtimes, policies, and decision surfaces participate in producing
+              the result.
+            </p>
+          </section>
+
+          <section>
+            <h2>A fast test for whether this is your problem</h2>
+            <p>
+              Ask one blunt question: if a core product rule changes tomorrow, how many runtime surfaces need to be inspected, rewritten,
+              or revalidated before you trust the result? If the answer is browser, backend, workflow, edge, and maybe an AI-generated
+              path, then your architecture is already paying the tax UMA is trying to reduce.
+            </p>
+          </section>
+
+          <section>
+            <h2>Where to go next</h2>
+            <p>
+              This page is the short version of the problem statement. The site covers the vocabulary needed to evaluate the model in more
+              concrete terms, and the examples repository shows how that model behaves when it is pushed into runnable systems. In the
+              book, I take this problem further and connect it to the full design sequence from one portable service to a governed runtime
+              reference application.
+            </p>
+          </section>
+
+          <section class="subpage-callout">
+            <strong>Continue from the problem into the model</strong>
+            <p>
+              Once the problem is clear, the next useful question is not “what tool should I use?” but “what durable unit should the
+              architecture preserve?” That is where the rest of the UMA concept cluster becomes useful.
+            </p>
+            <div class="subpage-inline-links">
+              <a href="../what-is-uma/">What is UMA?</a>
+              <a href="../uma-vs-traditional-microservices/">UMA vs traditional microservices</a>
+              <a href="../from-stack-ownership-to-behavior-ownership/">From stack ownership to behavior ownership</a>
+              <a href="../what-is-a-capability/">What is a capability?</a>
+              <a href="https://www.universalmicroservices.com/reference-application/">Live reference app</a>
+            </div>
+          </section>
+        </div>
+
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/pages/why-uma/why-universal-microservices-exist.md
+++ b/content/pages/why-uma/why-universal-microservices-exist.md
@@ -1,0 +1,80 @@
+---
+ref: why-universal-microservices-exist
+title: "Why Universal Microservices Exist"
+subtitle: "Why Universal Microservices exist Universal Microservices exist because modern systems no longer execute in one stable place. Business behavior now crosses browsers, edge runtimes, cloud services, workflows, and AI-assisted paths. Without an architectural model for that movement, systems duplicate behavior and lose coherence."
+macro_area: why-uma
+content_type: overview
+slug: why-universal-microservices-exist
+canonical_url: "https://www.universalmicroservices.com/why-universal-microservices-exist/"
+left_nav_group: why-uma
+chapter_ref: null
+seo_description: "Learn why Universal Microservices exist, including infrastructure coupling, runtime dependence, portability pressure, and AI-driven architecture change."
+breadcrumbs:
+  - "Home"
+  - "Why Uma"
+  - "Why Universal Microservices Exist"
+related_refs:
+  - from-stack-ownership-to-behavior-ownership
+  - what-is-a-universal-microservice
+  - what-is-uma
+  - what-problem-does-uma-solve
+---
+
+## intro
+
+<section class="subpage-hero">
+          <h1>Why Universal Microservices exist</h1>
+          <p>Universal Microservices exist because modern systems no longer execute in one stable place. Business behavior now crosses browsers, edge runtimes, cloud services, workflows, and AI-assisted paths. Without an architectural model for that movement, systems duplicate behavior and lose coherence.</p>
+        </section>
+
+## main
+
+<div class="subpage-body">
+          <section>
+            <h2>The pressure underneath the model</h2>
+            <p>Teams already know how to deploy services. The harder problem is preserving service meaning when execution spreads across many runtimes. UMA starts from that pressure rather than from a new packaging technique.</p>
+            <p>The model exists to make runtime diversity manageable without pretending every runtime is equivalent.</p>
+          </section>
+
+          <section>
+            <h2>Infrastructure coupling</h2>
+            <p>Many systems look modular from the outside but keep business behavior bound to a specific framework, queue, database adapter, or hosting assumption. That coupling limits where the behavior can run and makes change expensive.</p>
+            <p>UMA separates the portable service boundary from the infrastructure concerns that surround it.</p>
+          </section>
+
+          <section>
+            <h2>Runtime dependence</h2>
+            <p>Runtime dependence becomes a problem when local choices quietly redefine the service. A browser rule, an edge optimization, and a backend authority check may all claim to implement the same behavior while drifting apart over time.</p>
+            <p>Universal Microservices make the runtime layer explicit so placement, validation, and policy are governed decisions.</p>
+          </section>
+
+          <section>
+            <h2>AI-driven architectural pressure</h2>
+            <p>AI-assisted flows increase the need for visible authority. Agents can propose paths, rank options, or assemble workflows, but the runtime still needs to validate what is allowed and what actually executes.</p>
+            <p>That is why UMA draws a firm distinction between proposal and authority.</p>
+          </section>
+
+          <section>
+            <h2>Why this matters now</h2>
+            <p>Portable architecture is no longer a niche concern. It is a response to systems that must keep one behavior consistent across many execution surfaces while still respecting trust, latency, cost, and operational context.</p>
+          </section>
+          <section class="subpage-grid">
+            <article class="subpage-card"><h3>Less duplication</h3><p>One behavior can remain the durable center instead of being reimplemented surface by surface.</p></article>
+            <article class="subpage-card"><h3>Clearer authority</h3><p>The runtime becomes responsible for validation and policy rather than leaving those decisions implicit.</p></article>
+            <article class="subpage-card"><h3>Better evolution</h3><p>Versioning and compatibility become visible system concerns.</p></article>
+            <article class="subpage-card"><h3>More credible AI use</h3><p>Agents can participate without becoming the source of operational authority.</p></article>
+          </section>
+          <section class="subpage-callout">
+            <strong>Want to go deeper?</strong>
+            <p>This topic maps to the strategic argument in Chapter 1. The website explains why UMA exists, the repository shows runnable proof, and the book develops the methodology for applying it responsibly.</p>
+            <div class="subpage-inline-links">
+              <a href="../what-problem-does-uma-solve/">What problem does UMA solve?</a>
+              <a href="../runtime-agnostic-architecture/">Runtime-agnostic architecture</a>
+              <a href="../agent-vs-runtime/">Agent vs runtime</a>
+              <a href="../examples/">Examples</a>
+              <a href="https://github.com/enricopiovesan/UMA-code-examples">Official GitHub examples repository</a>
+              <a href="../book/">Book page</a>
+            </div>
+          </section>
+        </div>
+        <section id="contacts" class="section contacts-band" data-shared-footer></section>

--- a/content/site-map.md
+++ b/content/site-map.md
@@ -1,0 +1,93 @@
+# UMA Site Map
+
+This file is the canonical ordering and grouping source for the UMA website.
+It defines semantic page groups, not HTML output.
+
+## Rules
+
+- Home is managed separately.
+- Every other page belongs to one macro area.
+- Chapter pages live under `Examples`.
+- Stable URLs take precedence over title changes.
+- The generator should read this file to build navigation and page order.
+
+## Macro Areas
+
+### Why UMA
+- `what-problem-does-uma-solve`
+- `what-is-uma`
+- `why-universal-microservices-exist`
+- `what-is-a-universal-microservice`
+- `from-stack-ownership-to-behavior-ownership`
+
+### Core Model
+- `what-is-a-capability`
+- `what-is-a-workflow`
+- `what-is-a-uma-runtime`
+- `what-belongs-in-the-runtime-layer`
+- `active-descriptors`
+- `late-bound-policy-enforcement`
+- `what-makes-a-decision-discoverable`
+- `what-is-wasm-mcp`
+- `agent-vs-runtime`
+
+### How UMA Works
+- `runtime-agnostic-architecture`
+- `portable-business-logic`
+- `architecture-drift-and-portable-business-logic`
+- `webassembly-architecture`
+- `migrating-to-uma-incrementally`
+- `incremental-uma-adoption`
+- `uma-production-readiness`
+
+### Proof
+- `what-makes-a-service-portable`
+- `how-to-prove-portability`
+- `benchmark-and-footprint`
+
+### Learning Path
+- `learning-path`
+- `book`
+- `end-to-end-feature-flag-example`
+
+### Hands-On Examples
+- `chapter-04-feature-flag-evaluator`
+- `chapter-05-post-fetcher-runtime`
+- `chapter-06-portability-lab`
+- `chapter-07-metadata-orchestration`
+- `chapter-08-service-graph`
+- `chapter-09-trust-boundaries`
+- `chapter-10-architectural-tradeoffs`
+- `chapter-11-evolution-without-fragmentation`
+- `chapter-12-discoverable-decisions`
+- `chapter-13-portable-mcp-runtime`
+
+### System Evolution
+- `contract-driven-orchestration`
+- `service-graph-evolution`
+- `how-systems-evolve-without-fragmentation`
+- `what-makes-a-system-coherent`
+- `trust-boundaries`
+- `runtime-provenance-and-trust`
+- `ai-native-runtime-governance`
+
+### Discovery and References
+- `faq`
+- `diagrams`
+- `about-enrico`
+- `blog`
+- `reference-application`
+- `white-paper`
+
+### Comparisons and Tradeoffs
+- `uma-vs-serverless`
+- `uma-vs-modular-monolith`
+- `uma-vs-traditional-microservices`
+- `common-criticisms-and-tradeoffs-of-uma`
+- `why-software-architecture-keeps-fragmenting`
+
+## Ordering Notes
+
+- Primary ordering should follow the learning journey from `Why UMA` to `Hands-On Examples` and then outward to evolution and references.
+- The `Examples` area should be subdivided by chapter sequence when rendered in navigation.
+- The footer should draw from the macro areas, not from ad hoc page lists.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,9 @@ Enrico Piovesan is the creator of Universal Microservices Architecture (UMA), a 
 
 ## SEO Operations
 
+- [Content Source of Truth Spec](site/content-source-of-truth-spec.md)
+- [Subpage Template Spec](site/subpage-template-spec.md)
+- [Semantic Content Taxonomy](seo/semantic-content-taxonomy.md)
 - [Structured Data Opportunities](seo/structured-data-opportunities.md)
 - [Backlink Acquisition Plan](seo/backlink-acquisition-plan.md)
 - [Repository Metadata Recommendations](seo/repository-metadata.md)

--- a/docs/seo/semantic-content-taxonomy.md
+++ b/docs/seo/semantic-content-taxonomy.md
@@ -1,0 +1,68 @@
+# UMA Semantic Content Taxonomy
+
+This file defines the durable SEO and information-architecture structure for the UMA website.
+Page titles, slugs, and subpage names are intentionally left open. The purpose of this file is to
+keep the semantic role of each page stable over time so the site can grow without losing structure.
+
+## Rules
+
+- Each page should map to one primary `ref`.
+- A page may have one secondary `ref` only when it genuinely supports discovery or learning.
+- A `ref` may expand into sub content and sub sub content, but the semantic role should stay the same.
+- Page names can change. The category and content type should remain stable.
+- SEO should follow the taxonomy, not the other way around.
+
+## Content Map
+
+| Ref | Main category | Content type | Sub content | Sub sub content |
+|---|---|---|---|---|
+| `why-uma` | Positioning | overview | problem statement | comparison, differentiation, motivation |
+| `core-model` | Core Model | explainer | capability, workflow, runtime, decision, trust | glossary, term relationships, model boundaries |
+| `how-uma-works` | How It Works | walkthrough | contracts, events, policies, placement, runtime selection | execution flow, validation flow, approval flow |
+| `proof` | Proof | evidence | portability, parity, benchmarks, footprint | measurements, smoke gates, reproducibility |
+| `learn-uma` | Learning Path | onboarding | book flow, guided path, progression | chapter sequence, prerequisite order, next-step guidance |
+| `examples` | Hands-On Examples | tutorial hub | chapter labs, runnable demos, reference paths | chapter sections, validation commands, subpage routes |
+| `evolve-uma` | System Evolution | architecture progression | orchestration, service graphs, trust boundaries, compatibility | incremental adoption, fragmentation avoidance, governed change |
+| `discoverability` | Discovery and References | resource hub | FAQ, diagrams, blog, book, about | canonical links, supporting references, external proof |
+
+## Suggested Page Roles
+
+### Positioning
+- The user should understand what UMA is, why it exists, and what problem it solves.
+- Content should answer the “why this model?” question before introducing implementation detail.
+
+### Core Model
+- The user should learn the vocabulary of UMA.
+- Pages here should define the main semantic building blocks and their relationships.
+
+### How It Works
+- The user should see how the model becomes executable.
+- Pages here should explain contracts, runtime decisions, and the mechanics of placement.
+
+### Proof
+- The user should be able to validate UMA with observable behavior.
+- Pages here should prioritize benchmarks, parity, smoke gates, and repeatable output.
+
+### Learning Path
+- The user should be guided from concept to runnable examples in a predictable order.
+- Pages here should reduce friction for first-time readers.
+
+### Hands-On Examples
+- The user should find the chapter-aligned labs and tutorial entry points.
+- Pages here should make the repository feel navigable by chapter, not just by topic.
+
+### System Evolution
+- The user should see how UMA handles growth, compatibility, and change.
+- Pages here should cover orchestration, versioning, trust, and long-term architecture.
+
+### Discovery and References
+- The user should find supporting pages and canonical references quickly.
+- Pages here should act as the support layer for the rest of the site.
+
+## SEO Notes
+
+- Use the main category as the primary search-intent cluster.
+- Use content type to describe the intent of the page, not the title.
+- Use sub content and sub sub content to extend topical depth without fragmenting the category.
+- Keep future pages inside the existing refs unless a genuinely new semantic area appears.
+- Prefer one strong page per ref, then add subpages only when the content needs a deeper sequence.

--- a/docs/site/content-source-of-truth-spec.md
+++ b/docs/site/content-source-of-truth-spec.md
@@ -1,0 +1,80 @@
+# UMA Content Source of Truth Spec
+
+This spec defines how UMA website content should move from HTML-first authoring to Markdown-first
+authoring without changing the homepage.
+
+## Source of Truth
+
+- `content/site-map.md` is the authoritative map for page order and macro areas.
+- `content/pages/**.md` is the authoritative page content.
+- The generated HTML is build output, not the source of truth.
+
+## Recommended Folder Model
+
+```text
+content/
+|- site-map.md
+|- pages/
+|  |- why-uma/
+|  |- core-model/
+|  |- how-uma-works/
+|  |- examples/
+|  |- evolve-uma/
+|  |- discoverability/
+|  |- _shared/
+```
+
+Recommended placement:
+- page files are grouped by macro area
+- each page file owns one page
+- shared fragments live under `_shared/` if they are truly reusable
+
+## Portable Fields
+
+Each page Markdown file should carry frontmatter for:
+
+- `ref`
+- `title`
+- `subtitle`
+- `macro_area`
+- `content_type`
+- `slug`
+- `canonical_url`
+- `breadcrumbs`
+- `left_nav_group`
+- `chapter_ref`
+- `seo_description`
+- `related_refs`
+
+## Portable Body Sections
+
+Use a predictable section model so HTML generation stays efficient:
+
+- `intro`
+- `main`
+- `book_ref`
+- `related`
+- `faq`
+
+The generator should map these sections into the reusable page template spec.
+
+## Reusable Components
+
+These should be generated from shared data or shared templates, not duplicated per page:
+
+- footer link groups
+- breadcrumb generation
+- left navigation / rail
+- chapter previous / next navigation
+- metadata schema
+- global reference links
+- book CTA references
+
+## Maintenance Rules
+
+- Update the site map once when page order changes.
+- Update the shared footer once when a global link changes.
+- Do not copy navigation blocks into page content.
+- Keep page-specific content in the page file.
+- Keep the homepage out of this workflow unless explicitly requested.
+

--- a/docs/site/subpage-template-spec.md
+++ b/docs/site/subpage-template-spec.md
@@ -1,0 +1,218 @@
+# UMA Subpage Template Spec
+
+This document defines the reusable structure for all non-home pages on the UMA website.
+It is intentionally homepage-agnostic. The homepage has its own composition rules and should not
+be modified from this spec unless explicitly requested.
+
+The goal is to keep subpages semantically consistent, SEO-friendly, and easy to maintain as the
+site grows. Page titles, slugs, and exact copy can change. The template contract should not.
+
+## Core Principle
+
+Each subpage should be assembled from the same portable building blocks:
+
+- shared metadata
+- shared breadcrumbs
+- shared left navigation
+- page-specific hero and intro
+- page-specific body content
+- optional book or chapter reference block
+- shared footer
+
+The reusable parts should live in one shared source of truth so navigation or footer updates do not
+require editing every page by hand.
+
+## Template Contract
+
+### 1. Metadata
+
+Purpose:
+- define search intent and canonical identity
+- help search engines classify the page
+
+Reusable components:
+- canonical URL pattern
+- Open Graph title and description pattern
+- Twitter card pattern
+- JSON-LD schema shape
+
+Page-specific fields:
+- `title`
+- `description`
+- canonical path
+- social image selection, if needed
+- schema type and page name
+
+### 2. Breadcrumbs
+
+Purpose:
+- show the current page location in the site hierarchy
+- reinforce topical relationships for readers and search engines
+
+Reusable components:
+- `Home`
+- main content area label
+- current section label
+- optional chapter or subpage label
+
+Page-specific fields:
+- the current page label
+- any parent section labels needed for that route
+
+### 3. Left-Side Menu / Rail
+
+Purpose:
+- keep navigation close to the content
+- expose sibling and related pages without pushing readers to the footer
+
+Reusable components:
+- `On this page`
+- `Explore UMA`
+- `In the examples path` when the page belongs to a chapter example
+
+Page-specific fields:
+- the page outline
+- chapter previous / next links when relevant
+- source folder link when relevant
+
+### 4. Hero / Intro
+
+Purpose:
+- explain the page in one glance
+- capture search intent and reader intent quickly
+
+Reusable components:
+- hero layout
+- heading hierarchy
+- intro paragraph rhythm
+- optional kicker or label
+
+Page-specific fields:
+- the page title
+- the page subtitle or intro copy
+- any chapter or series label
+
+### 5. Main Content Body
+
+Purpose:
+- deliver the substance of the page
+- support SEO depth without flattening the page into a single generic block
+
+Reusable components:
+- section heading pattern
+- body text rhythm
+- callout block pattern
+- inline link pattern
+- list and grid patterns
+
+Page-specific fields:
+- the section order
+- the content blocks
+- the examples, proof points, or explanations
+
+### 6. Book / Chapter Reference Block
+
+Purpose:
+- connect the page to the book and to the implementation path
+- give readers a clear next step
+
+Reusable components:
+- book CTA language
+- chapter source link pattern
+- previous / next chapter pattern
+- examples hub link pattern
+
+Page-specific fields:
+- chapter number
+- chapter title
+- source repository path
+- recommended next step
+
+### 7. Footer
+
+Purpose:
+- provide durable site-wide navigation
+- support discovery, conversion, and topic clustering
+
+Reusable components:
+- footer group headings
+- link clusters
+- book CTA card
+- external links to GitHub, blog, white paper, and reference application
+
+Page-specific fields:
+- none, ideally
+- the footer should be shared across all non-home pages
+
+## Portable Component Registry
+
+These are the shared components that should be treated as reusable modules rather than page-local copy.
+
+| Component | What it does | What changes often | What should stay stable |
+|---|---|---|---|
+| Metadata schema | Defines page identity for SEO and social sharing | title, description, canonical path | field structure and semantic purpose |
+| Breadcrumb builder | Shows page position in the site tree | current page label, parent labels | breadcrumb pattern and ordering |
+| Left rail navigation | Exposes page outline and sibling paths | page outline, chapter links | rail layout and section headings |
+| Hero block | Introduces the page | intro copy, kicker, page title | structure and hierarchy |
+| Body section blocks | Organizes the main content | section content and order | section styling and spacing rules |
+| Book/chapter reference | Connects content to the book and examples | chapter-specific links | CTA structure and placement |
+| Footer cluster set | Provides global navigation and resource links | link lists and labels | grouping model and update mechanism |
+
+## Recommended Data Ownership
+
+To avoid editing every page when a site-wide link changes, the following should be centralized:
+
+- footer link groups
+- global resource links
+- chapter list and chapter ordering
+- source repository path generation
+- external reference links
+- blog and white paper links
+
+To keep SEO consistent, the following should be page-owned:
+
+- title
+- description
+- canonical path
+- hero intro
+- body content
+- section-level headings
+- any page-specific CTA text
+
+## SEO Structure
+
+The site should be organized around semantic content areas rather than arbitrary page names.
+
+Each subpage should answer one primary intent:
+
+- what UMA is
+- why UMA exists
+- how UMA works
+- how to prove UMA
+- how to learn UMA
+- how UMA evolves
+- where to find supporting references
+- where to run the examples
+
+For SEO, each page should keep:
+
+- one main category
+- one primary content type
+- one clear intro
+- one clear body topic
+- one clear next step
+
+That gives search engines a stable signal while leaving room for the page name and slug to evolve.
+
+## Maintenance Rules
+
+- Update the shared footer once, not page by page.
+- Update the breadcrumb/rail logic once, not page by page.
+- Keep page-specific content in the page document, not in shared navigation data.
+- Add new subpages by fitting them into an existing category first.
+- Create a new category only when a genuinely new semantic area appears.
+
+## Explicit Exclusion
+
+Do not use this spec to redesign the homepage.
+The homepage has its own narrative role and should be handled separately.

--- a/scripts/export-content-md.mjs
+++ b/scripts/export-content-md.mjs
@@ -1,0 +1,288 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const BOOK_SITE = path.join(ROOT, "book-site");
+const CONTENT_ROOT = path.join(ROOT, "content", "pages");
+
+const WHY_UMA = new Set([
+  "what-problem-does-uma-solve",
+  "what-is-uma",
+  "why-universal-microservices-exist",
+  "what-is-a-universal-microservice",
+  "from-stack-ownership-to-behavior-ownership",
+  "why-software-architecture-keeps-fragmenting",
+]);
+
+const CORE_MODEL = new Set([
+  "what-is-a-capability",
+  "what-is-a-workflow",
+  "what-is-a-uma-runtime",
+  "what-belongs-in-the-runtime-layer",
+  "active-descriptors",
+  "late-bound-policy-enforcement",
+  "what-makes-a-decision-discoverable",
+  "what-is-wasm-mcp",
+  "agent-vs-runtime",
+]);
+
+const PROOF = new Set([
+  "what-makes-a-service-portable",
+  "how-to-prove-portability",
+  "benchmark-and-footprint",
+]);
+
+const LEARN = new Set([
+  "learning-path",
+  "book",
+  "end-to-end-feature-flag-example",
+]);
+
+const EVOLVE = new Set([
+  "contract-driven-orchestration",
+  "service-graph-evolution",
+  "how-systems-evolve-without-fragmentation",
+  "what-makes-a-system-coherent",
+  "trust-boundaries",
+  "runtime-provenance-and-trust",
+  "ai-native-runtime-governance",
+]);
+
+const DISCOVER = new Set([
+  "faq",
+  "diagrams",
+  "about-enrico",
+]);
+
+const HOW_UMA_WORKS = new Set([
+  "runtime-agnostic-architecture",
+  "portable-business-logic",
+  "architecture-drift-and-portable-business-logic",
+  "webassembly-architecture",
+  "migrating-to-uma-incrementally",
+  "incremental-uma-adoption",
+  "uma-production-readiness",
+]);
+
+const COMPARISONS = new Set([
+  "common-criticisms-and-tradeoffs-of-uma",
+  "uma-vs-serverless",
+  "uma-vs-modular-monolith",
+  "uma-vs-traditional-microservices",
+  "why-software-architecture-keeps-fragmenting",
+]);
+
+const CHAPTERS = new Map([
+  ["chapter-04-feature-flag-evaluator", ["Chapter 4", "Feature Flag Evaluator"]],
+  ["chapter-05-post-fetcher-runtime", ["Chapter 5", "Post Fetcher Runtime"]],
+  ["chapter-06-portability-lab", ["Chapter 6", "Portability Lab"]],
+  ["chapter-07-metadata-orchestration", ["Chapter 7", "Metadata Orchestration"]],
+  ["chapter-08-service-graph", ["Chapter 8", "Service Graph Evolution"]],
+  ["chapter-09-trust-boundaries", ["Chapter 9", "Trust Boundaries"]],
+  ["chapter-10-architectural-tradeoffs", ["Chapter 10", "Architectural Tradeoffs"]],
+  ["chapter-11-evolution-without-fragmentation", ["Chapter 11", "Evolution Without Fragmentation"]],
+  ["chapter-12-discoverable-decisions", ["Chapter 12", "Discoverable Decisions"]],
+  ["chapter-13-portable-mcp-runtime", ["Chapter 13", "Portable MCP Runtime"]],
+]);
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function escapeYaml(text) {
+  return String(text ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r?\n/g, " ");
+}
+
+function stripTags(html) {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractMatch(html, regex) {
+  const match = html.match(regex);
+  return match ? match[1] : "";
+}
+
+function extractMainSections(html) {
+  const start = html.indexOf("<main");
+  if (start < 0) return { main: "", hero: "", body: "" };
+  const openEnd = html.indexOf(">", start);
+  const end = html.lastIndexOf("</main>");
+  const main = html.slice(openEnd + 1, end >= 0 ? end : html.length);
+  const heroStart = main.indexOf('<section class="subpage-hero');
+  if (heroStart < 0) {
+    return { main, hero: "", body: main.trim() };
+  }
+  const heroEnd = main.indexOf("</section>", heroStart);
+  if (heroEnd < 0) {
+    return { main, hero: main.slice(heroStart).trim(), body: "" };
+  }
+  const hero = main.slice(heroStart, heroEnd + "</section>".length).trim();
+  const body = main.slice(heroEnd + "</section>".length).trim();
+  return { main, hero, body };
+}
+
+function buildFrontmatter(meta) {
+  const lines = [];
+  lines.push("---");
+  lines.push(`ref: ${meta.ref}`);
+  lines.push(`title: "${escapeYaml(meta.title)}"`);
+  if (meta.subtitle) lines.push(`subtitle: "${escapeYaml(meta.subtitle)}"`);
+  lines.push(`macro_area: ${meta.macro_area}`);
+  lines.push(`content_type: ${meta.content_type}`);
+  lines.push(`slug: ${meta.slug}`);
+  if (meta.canonical_url) lines.push(`canonical_url: "${escapeYaml(meta.canonical_url)}"`);
+  lines.push(`left_nav_group: ${meta.left_nav_group}`);
+  lines.push(`chapter_ref: ${meta.chapter_ref ? `"${escapeYaml(meta.chapter_ref)}"` : "null"}`);
+  if (meta.seo_description) lines.push(`seo_description: "${escapeYaml(meta.seo_description)}"`);
+  lines.push("breadcrumbs:");
+  for (const crumb of meta.breadcrumbs) {
+    lines.push(`  - "${escapeYaml(crumb)}"`);
+  }
+  lines.push("related_refs:");
+  for (const related of meta.related_refs) {
+    lines.push(`  - ${related}`);
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+function classify(slug) {
+  if (slug === "examples") {
+    return { macro_area: "examples", content_type: "hub", chapter_ref: null };
+  }
+  if (CHAPTERS.has(slug)) {
+    return { macro_area: "examples", content_type: "tutorial", chapter_ref: CHAPTERS.get(slug)[0] };
+  }
+  if (slug === "book" || slug === "learning-path" || slug === "end-to-end-feature-flag-example") {
+    return { macro_area: "learn-uma", content_type: "onboarding", chapter_ref: null };
+  }
+  if (WHY_UMA.has(slug)) return { macro_area: "why-uma", content_type: "overview", chapter_ref: null };
+  if (CORE_MODEL.has(slug)) return { macro_area: "core-model", content_type: "explainer", chapter_ref: null };
+  if (PROOF.has(slug)) return { macro_area: "proof", content_type: "proof", chapter_ref: null };
+  if (LEARN.has(slug)) return { macro_area: "learn-uma", content_type: "onboarding", chapter_ref: null };
+  if (EVOLVE.has(slug)) return { macro_area: "evolve-uma", content_type: "walkthrough", chapter_ref: null };
+  if (DISCOVER.has(slug)) return { macro_area: "discoverability", content_type: "resource", chapter_ref: null };
+  if (HOW_UMA_WORKS.has(slug)) return { macro_area: "how-uma-works", content_type: "walkthrough", chapter_ref: null };
+  if (COMPARISONS.has(slug)) return { macro_area: "comparisons", content_type: "comparison", chapter_ref: null };
+  return { macro_area: "discoverability", content_type: "resource", chapter_ref: null };
+}
+
+async function listSourcePages() {
+  const sources = [];
+
+  async function walk(dir, prefix = "") {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (["assets", "data", "node_modules", "scripts", "target"].includes(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      const index = path.join(full, "index.html");
+      const subentries = await fs.readdir(full, { withFileTypes: true }).catch(() => []);
+      const hasIndex = subentries.some((e) => e.isFile() && e.name === "index.html");
+      if (hasIndex) {
+        sources.push({ slug: prefix ? `${prefix}/${entry.name}` : entry.name, file: index });
+      }
+      if (entry.name === "examples") {
+        await walk(full, "examples");
+      }
+    }
+  }
+
+  await walk(BOOK_SITE);
+  return sources.filter((item) => item.slug !== "index");
+}
+
+function macroAreaLabel(area) {
+  return area
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase());
+}
+
+function relatedRefsFor(slug, area, allByArea) {
+  const siblings = allByArea.get(area) || [];
+  return siblings.filter((entry) => entry.slug !== slug).slice(0, 4).map((entry) => entry.slug);
+}
+
+async function main() {
+  const pages = await listSourcePages();
+  const grouped = new Map();
+  for (const page of pages) {
+    const sourceHtml = await fs.readFile(page.file, "utf8");
+    const { hero, body } = extractMainSections(sourceHtml);
+    const title = extractMatch(sourceHtml, /<title>(.*?)<\/title>/i).split("|")[0].trim();
+    const seoDescription = extractMatch(sourceHtml, /<meta\s+name="description"\s+content="([^"]+)"/i);
+    const canonical = extractMatch(sourceHtml, /<link\s+rel="canonical"\s+href="([^"]+)"/i);
+    const heroText = stripTags(hero);
+    const slug = page.slug.replace(/^examples\//, "");
+    const { macro_area, content_type, chapter_ref } = classify(slug);
+    const groupedLabel = macroAreaLabel(macro_area);
+    if (!grouped.has(macro_area)) grouped.set(macro_area, []);
+    grouped.get(macro_area).push({ slug, title });
+    const related_refs = []; // filled later
+    const meta = {
+      ref: slug,
+      title,
+      subtitle: heroText,
+      macro_area,
+      content_type,
+      slug,
+      canonical_url: canonical,
+      left_nav_group: macro_area,
+      chapter_ref,
+      seo_description: seoDescription,
+      breadcrumbs: page.slug.startsWith("examples/")
+        ? ["Home", "Examples", chapter_ref ? `${chapter_ref}: ${title}` : title]
+        : ["Home", groupedLabel, title],
+      related_refs,
+    };
+    page.meta = meta;
+    page.hero = hero;
+    page.body = body;
+  }
+
+  for (const page of pages) {
+    const siblings = relatedRefsFor(page.meta.slug, page.meta.macro_area, grouped);
+    page.meta.related_refs = siblings;
+  }
+
+  await fs.mkdir(CONTENT_ROOT, { recursive: true });
+  for (const page of pages) {
+    const outDir = path.join(CONTENT_ROOT, page.meta.macro_area);
+    await fs.mkdir(outDir, { recursive: true });
+    const outPath = path.join(outDir, `${page.meta.slug}.md`);
+    const md = [
+      buildFrontmatter(page.meta),
+      "",
+      "## intro",
+      "",
+      page.hero || "",
+      "",
+      "## main",
+      "",
+      page.body || "",
+      "",
+    ].join("\n");
+    await fs.writeFile(outPath, md);
+  }
+
+  console.log(`Generated ${pages.length} content markdown files.`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Restructures the non-home pages with semantic breadcrumbs and a left-side navigation rail, and reorganizes the footer into durable link clusters that can grow over time.

## Why

The non-home pages needed a clearer information architecture for SEO, discoverability, and long-term maintainability. This change makes the chapter/tutorial pages easier to navigate while keeping the homepage untouched.

## Verification

- `node --check book-site/app.js`
- `git diff --check`
- `./scripts/smoke_reader_paths.sh`

## Notes

- No source logic was changed.
- The work stays off `main`; it is staged on a feature branch and opened as a PR for review.